### PR TITLE
Create baseline Facet component with types

### DIFF
--- a/components/Facet/Facet.tsx
+++ b/components/Facet/Facet.tsx
@@ -7,13 +7,10 @@ interface FacetBuckets {
 export interface FacetProps {
   label: string;
   buckets: FacetBuckets[];
+  handleFacetChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
-const Facet: React.FC<FacetProps> = ({ label, buckets }) => {
-  const handleFacetChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
-    console.log(e);
-  };
-
+const Facet: React.FC<FacetProps> = ({ label, buckets, handleFacetChange }) => {
   return (
     <div key={label}>
       <h3>{label}</h3>

--- a/components/Facet/Facet.tsx
+++ b/components/Facet/Facet.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+
+interface FacetBuckets {
+  key: string;
+  doc_count: string;
+}
+
+interface FacetData {
+  label: string;
+  buckets: FacetBuckets[];
+}
+
+interface FacetProps {
+  data: FacetData;
+}
+
+const Facet: React.FC<FacetProps> = ({ data }) => {
+  const handleFacetChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
+    console.log(e);
+  };
+
+  return (
+    <div key={data.label}>
+      <h3>{data.label}</h3>
+      <input name={`${data.label}-filter`} />
+      <ul>
+        {data.buckets &&
+          data.buckets.map((bucket, index) => (
+            <li key={index}>
+              <input
+                id={`${data.label}-${index}`}
+                name={`${data.label}`}
+                onChange={handleFacetChange}
+                type="checkbox"
+                value={bucket.key}
+              />
+              <label htmlFor={`${data.label}-${index}`}>
+                {bucket.key} ({bucket.doc_count})
+              </label>
+            </li>
+          ))}
+      </ul>
+    </div>
+  );
+};
+
+export default Facet;

--- a/components/Facet/Facet.tsx
+++ b/components/Facet/Facet.tsx
@@ -4,37 +4,32 @@ interface FacetBuckets {
   key: string;
   doc_count: string;
 }
-
-interface FacetData {
+interface FacetProps {
   label: string;
   buckets: FacetBuckets[];
 }
 
-interface FacetProps {
-  data: FacetData;
-}
-
-const Facet: React.FC<FacetProps> = ({ data }) => {
+const Facet: React.FC<FacetProps> = ({ label, buckets }) => {
   const handleFacetChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
     console.log(e);
   };
 
   return (
-    <div key={data.label}>
-      <h3>{data.label}</h3>
-      <input name={`${data.label}-filter`} />
+    <div key={label}>
+      <h3>{label}</h3>
+      <input name={`${label}-filter`} />
       <ul>
-        {data.buckets &&
-          data.buckets.map((bucket, index) => (
+        {buckets &&
+          buckets.map((bucket, index) => (
             <li key={index}>
               <input
-                id={`${data.label}-${index}`}
-                name={`${data.label}`}
+                id={`${label}-${index}`}
+                name={`${label}`}
                 onChange={handleFacetChange}
                 type="checkbox"
                 value={bucket.key}
               />
-              <label htmlFor={`${data.label}-${index}`}>
+              <label htmlFor={`${label}-${index}`}>
                 {bucket.key} ({bucket.doc_count})
               </label>
             </li>

--- a/components/Facet/Facet.tsx
+++ b/components/Facet/Facet.tsx
@@ -4,7 +4,7 @@ interface FacetBuckets {
   key: string;
   doc_count: string;
 }
-interface FacetProps {
+export interface FacetProps {
   label: string;
   buckets: FacetBuckets[];
 }

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -86,7 +86,7 @@ const SearchPage: NextPage = () => {
         <h2>Facets</h2>
         <div>
           {aggregatedFacets &&
-            aggregatedFacets.map((facet) => <Facet data={facet} />)}
+            aggregatedFacets.map((facet) => <Facet {...facet} />)}
         </div>
 
         <h2>Search Results</h2>

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -51,11 +51,11 @@ const SearchPage: NextPage = () => {
   }, [esData]);
 
   // TODO: Put a debounce on this
-  const handleSearchChange = (e) => {
+  const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setSearchTerm(e.target.value);
   };
 
-  const handleFacetChange = (e) => {
+  const handleFacetChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     console.log("e", e.target.checked);
     const newObj = { ...userFacets };
     const { checked, name, value } = e.target;

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -3,6 +3,7 @@ import { NextPage } from "next";
 import Layout from "components/layout";
 import Container from "components/Container";
 import useApiSearch from "hooks/useApiSearch";
+import Facet from "components/Facet/Facet";
 
 const ALL_FACETS = ["subject", "genre"];
 const url = `https://dcapi.stack.rdc-staging.library.northwestern.edu/search/meadow/_search`;
@@ -44,7 +45,7 @@ const SearchPage: NextPage = () => {
     if (!esData?.aggregations) return;
     setAggregatedFacets(
       Object.entries(esData.aggregations).map((facet) => {
-        return { facetLabel: facet[0], ...facet[1] };
+        return { label: facet[0], ...facet[1] };
       })
     );
   }, [esData]);
@@ -83,35 +84,10 @@ const SearchPage: NextPage = () => {
         <button>Submit</button>
 
         <h2>Facets</h2>
-
-        <ul>
+        <div>
           {aggregatedFacets &&
-            aggregatedFacets.map((facet) => (
-              <li key={facet.label}>
-                {facet.facetLabel}
-                <input name={`${facet.facetLabel}-filter`} />
-                <ul>
-                  {facet.buckets &&
-                    facet.buckets.map((bucket, index) => (
-                      <li key={index}>
-                        <input
-                          type="checkbox"
-                          id={`${facet.facetLabel}-${index}`}
-                          name={`${facet.facetLabel}`}
-                          data-label={bucket.key}
-                          data-facet={facet.facetLabel}
-                          onChange={handleFacetChange}
-                          value={bucket.key}
-                        />
-                        <label htmlFor={`${facet.facetLabel}-${index}`}>
-                          {bucket.key} ({bucket.doc_count})
-                        </label>
-                      </li>
-                    ))}
-                </ul>
-              </li>
-            ))}
-        </ul>
+            aggregatedFacets.map((facet) => <Facet data={facet} />)}
+        </div>
 
         <h2>Search Results</h2>
         <ul>

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -3,7 +3,7 @@ import { NextPage } from "next";
 import Layout from "components/layout";
 import Container from "components/Container";
 import useApiSearch from "hooks/useApiSearch";
-import Facet from "components/Facet/Facet";
+import Facet, { FacetProps } from "components/Facet/Facet";
 
 const ALL_FACETS = ["subject", "genre"];
 const url = `https://dcapi.stack.rdc-staging.library.northwestern.edu/search/meadow/_search`;
@@ -86,7 +86,9 @@ const SearchPage: NextPage = () => {
         <h2>Facets</h2>
         <div>
           {aggregatedFacets &&
-            aggregatedFacets.map((facet) => <Facet {...facet} />)}
+            aggregatedFacets.map((facet: FacetProps) => (
+              <Facet {...facet} key={facet.label} />
+            ))}
         </div>
 
         <h2>Search Results</h2>

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -87,7 +87,11 @@ const SearchPage: NextPage = () => {
         <div>
           {aggregatedFacets &&
             aggregatedFacets.map((facet: FacetProps) => (
-              <Facet {...facet} key={facet.label} />
+              <Facet
+                {...facet}
+                key={facet.label}
+                handleFacetChange={handleFacetChange}
+              />
             ))}
         </div>
 


### PR DESCRIPTION
# What does this do?

This PR just organizes things a bit more and breaks some our logic into a Facet component. I think it might be best to complete quite a few micro PRs rather than trying to merge everything after all of our individual exploration. 

# How do I review this?

Things should functionally with the same as they did in [2710-api-connect-testing](https://github.com/nulib/dc-nextjs/tree/2710-api-connect-testing). Running `npm run dev` should spins things up and checking any facet options should `console.log()` each individual event.