### PR TITLE
Add search constants to build aggs.

### DIFF
--- a/lib/facets.ts
+++ b/lib/facets.ts
@@ -1,103 +1,115 @@
-const FACETS_CREATOR = [
-  {
-    componentId: "contributor",
-    field: "descriptiveMetadata.contributor.displayFacet",
-    title: "Contributor",
-  },
-  {
-    componentId: "creator",
-    field: "descriptiveMetadata.creator.displayFacet",
-    title: "Creator",
-  },
-];
+const FACETS_CREATOR = {
+  label: "Creator and Contributor",
+  facets: [
+    {
+      id: "contributor",
+      field: "descriptiveMetadata.contributor.displayFacet",
+      label: "Contributor",
+    },
+    {
+      id: "creator",
+      field: "descriptiveMetadata.creator.displayFacet",
+      label: "Creator",
+    },
+  ],
+};
 
-const FACETS_RIGHTS_USAGE = [
-  {
-    componentId: "rightsStatement",
-    field: "descriptiveMetadata.rightsStatement.label.keyword",
-    title: "Rights Statement",
-  },
-];
+const FACETS_RIGHTS_USAGE = {
+  label: "Rights and Usage",
+  facets: [
+    {
+      id: "rightsStatement",
+      field: "descriptiveMetadata.rightsStatement.label.keyword",
+      label: "Rights Statement",
+    },
+  ],
+};
 
-const FACETS_DESCRIPTIVE = [
-  {
-    componentId: "genre",
-    field: "descriptiveMetadata.genre.displayFacet",
-    title: "Genre",
-  },
-  {
-    componentId: "language",
-    field: "descriptiveMetadata.language.displayFacet",
-    title: "Language",
-  },
-  {
-    componentId: "Location",
-    field: "descriptiveMetadata.location.displayFacet",
-    title: "Location",
-  },
-  {
-    componentId: "stylePeriod",
-    field: "descriptiveMetadata.stylePeriod.displayFacet",
-    title: "Style Period",
-  },
-  {
-    componentId: "subject",
-    field: "descriptiveMetadata.subject.term.label.keyword",
-    title: "Subject",
-  },
-  {
-    componentId: "technique",
-    field: "descriptiveMetadata.technique.displayFacet",
-    title: "Technique",
-  },
-  {
-    componentId: "workType",
-    field: "workType.label.keyword",
-    title: "Work Type",
-  },
-];
+const FACETS_DESCRIPTIVE = {
+  label: "Subjects and Descriptive",
+  facets: [
+    {
+      id: "genre",
+      field: "descriptiveMetadata.genre.displayFacet",
+      label: "Genre",
+    },
+    {
+      id: "language",
+      field: "descriptiveMetadata.language.displayFacet",
+      label: "Language",
+    },
+    {
+      id: "Location",
+      field: "descriptiveMetadata.location.displayFacet",
+      label: "Location",
+    },
+    {
+      id: "stylePeriod",
+      field: "descriptiveMetadata.stylePeriod.displayFacet",
+      label: "Style Period",
+    },
+    {
+      id: "subject",
+      field: "descriptiveMetadata.subject.term.label.keyword",
+      label: "Subject",
+    },
+    {
+      id: "technique",
+      field: "descriptiveMetadata.technique.displayFacet",
+      label: "Technique",
+    },
+    {
+      id: "workType",
+      field: "workType.label.keyword",
+      label: "Work Type",
+    },
+  ],
+};
 
-const FACETS_LOCATION = [
-  {
-    componentId: "libraryDepartment",
-    field: "administrativeMetadata.libraryUnit.label.keyword",
-    title: "Library Department",
-  },
-  {
-    componentId: "collection",
-    field: "collection.title.keyword",
-    title: "Collection",
-  },
-  {
-    componentId: "boxName",
-    field: "descriptiveMetadata.boxName.keyword",
-    title: "Box Name",
-  },
-  {
-    componentId: "boxNumber",
-    field: "descriptiveMetadata.boxNumber.keyword",
-    title: "Box Number",
-  },
-  {
-    componentId: "folderName",
-    field: "descriptiveMetadata.folderName.keyword",
-    title: "Folder Name",
-  },
-  {
-    componentId: "folderNumber",
-    field: "descriptiveMetadata.folderNumber.keyword",
-    title: "Folder Number",
-  },
-  {
-    componentId: "series",
-    field: "descriptiveMetadata.series.keyword",
-    title: "Series",
-  },
-];
+const FACETS_LOCATION = {
+  label: "Location",
+  facets: [
+    {
+      id: "libraryDepartment",
+      field: "administrativeMetadata.libraryUnit.label.keyword",
+      label: "Library Department",
+    },
+    {
+      id: "collection",
+      field: "collection.title.keyword",
+      label: "Collection",
+    },
+    {
+      id: "boxName",
+      field: "descriptiveMetadata.boxName.keyword",
+      label: "Box Name",
+    },
+    {
+      id: "boxNumber",
+      field: "descriptiveMetadata.boxNumber.keyword",
+      label: "Box Number",
+    },
+    {
+      id: "folderName",
+      field: "descriptiveMetadata.folderName.keyword",
+      label: "Folder Name",
+    },
+    {
+      id: "folderNumber",
+      field: "descriptiveMetadata.folderNumber.keyword",
+      label: "Folder Number",
+    },
+    {
+      id: "series",
+      field: "descriptiveMetadata.series.keyword",
+      label: "Series",
+    },
+  ],
+};
 
 export const FACETS = [
-  ...FACETS_CREATOR,
-  ...FACETS_DESCRIPTIVE,
-  ...FACETS_LOCATION,
-  ...FACETS_RIGHTS_USAGE,
+  FACETS_CREATOR,
+  FACETS_DESCRIPTIVE,
+  FACETS_LOCATION,
+  FACETS_RIGHTS_USAGE,
 ];

--- a/lib/facets.ts
+++ b/lib/facets.ts
@@ -1,4 +1,14 @@
-const FACETS_CREATOR = {
+interface FacetsInstance {
+  id: string;
+  field: string;
+  label: string;
+}
+interface FacetsGroup {
+  label: string;
+  facets: FacetsInstance[];
+}
+
+const FACETS_CREATOR: FacetsGroup = {
   label: "Creator and Contributor",
   facets: [
     {
@@ -14,7 +24,7 @@ const FACETS_CREATOR = {
   ],
 };
 
-const FACETS_RIGHTS_USAGE = {
+const FACETS_RIGHTS_USAGE: FacetsGroup = {
   label: "Rights and Usage",
   facets: [
     {
@@ -25,7 +35,7 @@ const FACETS_RIGHTS_USAGE = {
   ],
 };
 
-const FACETS_DESCRIPTIVE = {
+const FACETS_DESCRIPTIVE: FacetsGroup = {
   label: "Subjects and Descriptive",
   facets: [
     {
@@ -66,7 +76,7 @@ const FACETS_DESCRIPTIVE = {
   ],
 };
 
-const FACETS_LOCATION = {
+const FACETS_LOCATION: FacetsGroup = {
   label: "Location",
   facets: [
     {
@@ -107,7 +117,7 @@ const FACETS_LOCATION = {
   ],
 };
 
-export const FACETS = [
+export const FACETS: FacetsGroup[] = [
   FACETS_CREATOR,
   FACETS_DESCRIPTIVE,
   FACETS_LOCATION,

--- a/lib/facets.ts
+++ b/lib/facets.ts
@@ -3,7 +3,7 @@ interface FacetsInstance {
   field: string;
   label: string;
 }
-interface FacetsGroup {
+export interface FacetsGroup {
   label: string;
   facets: FacetsInstance[];
 }
@@ -49,7 +49,7 @@ const FACETS_DESCRIPTIVE: FacetsGroup = {
       label: "Language",
     },
     {
-      id: "Location",
+      id: "location",
       field: "descriptiveMetadata.location.displayFacet",
       label: "Location",
     },

--- a/lib/facets.ts
+++ b/lib/facets.ts
@@ -1,0 +1,103 @@
+const FACETS_CREATOR = [
+  {
+    componentId: "contributor",
+    field: "descriptiveMetadata.contributor.displayFacet",
+    title: "Contributor",
+  },
+  {
+    componentId: "creator",
+    field: "descriptiveMetadata.creator.displayFacet",
+    title: "Creator",
+  },
+];
+
+const FACETS_RIGHTS_USAGE = [
+  {
+    componentId: "rightsStatement",
+    field: "descriptiveMetadata.rightsStatement.label.keyword",
+    title: "Rights Statement",
+  },
+];
+
+const FACETS_DESCRIPTIVE = [
+  {
+    componentId: "genre",
+    field: "descriptiveMetadata.genre.displayFacet",
+    title: "Genre",
+  },
+  {
+    componentId: "language",
+    field: "descriptiveMetadata.language.displayFacet",
+    title: "Language",
+  },
+  {
+    componentId: "Location",
+    field: "descriptiveMetadata.location.displayFacet",
+    title: "Location",
+  },
+  {
+    componentId: "stylePeriod",
+    field: "descriptiveMetadata.stylePeriod.displayFacet",
+    title: "Style Period",
+  },
+  {
+    componentId: "subject",
+    field: "descriptiveMetadata.subject.term.label.keyword",
+    title: "Subject",
+  },
+  {
+    componentId: "technique",
+    field: "descriptiveMetadata.technique.displayFacet",
+    title: "Technique",
+  },
+  {
+    componentId: "workType",
+    field: "workType.label.keyword",
+    title: "Work Type",
+  },
+];
+
+const FACETS_LOCATION = [
+  {
+    componentId: "libraryDepartment",
+    field: "administrativeMetadata.libraryUnit.label.keyword",
+    title: "Library Department",
+  },
+  {
+    componentId: "collection",
+    field: "collection.title.keyword",
+    title: "Collection",
+  },
+  {
+    componentId: "boxName",
+    field: "descriptiveMetadata.boxName.keyword",
+    title: "Box Name",
+  },
+  {
+    componentId: "boxNumber",
+    field: "descriptiveMetadata.boxNumber.keyword",
+    title: "Box Number",
+  },
+  {
+    componentId: "folderName",
+    field: "descriptiveMetadata.folderName.keyword",
+    title: "Folder Name",
+  },
+  {
+    componentId: "folderNumber",
+    field: "descriptiveMetadata.folderNumber.keyword",
+    title: "Folder Number",
+  },
+  {
+    componentId: "series",
+    field: "descriptiveMetadata.series.keyword",
+    title: "Series",
+  },
+];
+
+export const FACETS = [
+  ...FACETS_CREATOR,
+  ...FACETS_DESCRIPTIVE,
+  ...FACETS_LOCATION,
+  ...FACETS_RIGHTS_USAGE,
+];

--- a/lib/queries/aggs.ts
+++ b/lib/queries/aggs.ts
@@ -1,31 +1,25 @@
+import { FACETS, FacetsGroup } from "lib/facets";
+
+export const buildAggs = (facets: FacetsGroup[]) => {
+  const aggs: any = {};
+
+  facets.forEach((groups) => {
+    groups.facets.forEach((facet) => {
+      let terms = Object.create({});
+      terms.field = facet.field;
+      terms.size = 10;
+      terms.order = {
+        _count: "desc",
+      };
+
+      aggs[facet.id] = Object.create({});
+      aggs[facet.id].terms = terms;
+    });
+  });
+
+  return aggs;
+};
+
 export const aggs = {
-  aggs: {
-    contributor: {
-      terms: {
-        field: "descriptiveMetadata.contributor.displayFacet",
-        size: 10,
-        order: {
-          _count: "desc",
-        },
-      },
-    },
-    genre: {
-      terms: {
-        field: "descriptiveMetadata.genre.displayFacet",
-        size: 10,
-        order: {
-          _count: "desc",
-        },
-      },
-    },
-    subject: {
-      terms: {
-        field: "descriptiveMetadata.subject.displayFacet",
-        size: 10,
-        order: {
-          _count: "desc",
-        },
-      },
-    },
-  },
+  aggs: buildAggs(FACETS),
 };


### PR DESCRIPTION
This just adds some data for facets that will help us programmatically build aggs on the elastic search requests. I don't have my heart set on anything here other than that we should somehow dynamically generate this in some way.

From this you should now see all the Facets populating on the search page.