### PR TITLE
Add React context and define state types.

### DIFF
--- a/components/Grid/Grid.tsx
+++ b/components/Grid/Grid.tsx
@@ -1,11 +1,12 @@
+import { ApiResponseDataShape } from "@/types/api/response";
 import { GridItem, GridStyled } from "@/components/Grid/Grid.styled";
 import Figure from "@/components/Figure/Figure";
 
 interface GridProps {
-  data: any[];
+  data: ApiResponseDataShape[];
   info: { total?: number };
 }
-const Grid: React.FC<GridProps> = ({ data = [], info }) => {
+const Grid: React.FC<GridProps> = ({ data = [] }) => {
   if (!data) return <span>Loading...</span>;
 
   return (
@@ -14,13 +15,13 @@ const Grid: React.FC<GridProps> = ({ data = [], info }) => {
       className="dc-grid"
       columnClassName="dc-grid-column"
     >
-      {data.map((item: any) => (
+      {data.map((item: ApiResponseDataShape) => (
         <GridItem key={item.accession_number}>
           <Figure
             data={{
+              src: item.thumbnail,
               title: item.title,
               type: item.accession_number,
-              src: item.thumbnail,
             }}
           />
         </GridItem>

--- a/components/Grid/Grid.tsx
+++ b/components/Grid/Grid.tsx
@@ -1,9 +1,9 @@
-import { ApiResponseDataShape } from "@/types/api/response";
+import { SearchShape } from "@/types/api/response";
 import { GridItem, GridStyled } from "@/components/Grid/Grid.styled";
 import Figure from "@/components/Figure/Figure";
 
 interface GridProps {
-  data: ApiResponseDataShape[];
+  data: SearchShape[];
   info: { total?: number };
 }
 const Grid: React.FC<GridProps> = ({ data = [] }) => {
@@ -15,13 +15,13 @@ const Grid: React.FC<GridProps> = ({ data = [] }) => {
       className="dc-grid"
       columnClassName="dc-grid-column"
     >
-      {data.map((item: ApiResponseDataShape) => (
+      {data.map((item: SearchShape) => (
         <GridItem key={item.accession_number}>
           <Figure
             data={{
               src: item.thumbnail,
               title: item.title,
-              type: item.accession_number,
+              type: item.work_type_labels,
             }}
           />
         </GridItem>

--- a/components/Grid/Grid.tsx
+++ b/components/Grid/Grid.tsx
@@ -1,12 +1,12 @@
 import { GridItem, GridStyled } from "@/components/Grid/Grid.styled";
 import Figure from "@/components/Figure/Figure";
-import { HitsResponse, Hit } from "@/types/elasticsearch";
 
 interface GridProps {
-  hits: HitsResponse;
+  data: any[];
+  info: { total?: number };
 }
-const Grid: React.FC<GridProps> = ({ hits }) => {
-  if (!hits) return <span>Loading...</span>;
+const Grid: React.FC<GridProps> = ({ data = [], info }) => {
+  if (!data) return <span>Loading...</span>;
 
   return (
     <GridStyled
@@ -14,13 +14,13 @@ const Grid: React.FC<GridProps> = ({ hits }) => {
       className="dc-grid"
       columnClassName="dc-grid-column"
     >
-      {hits.hits.map((hit: Hit) => (
-        <GridItem key={hit._source.accessionNumber}>
+      {data.map((item: any) => (
+        <GridItem key={item.accession_number}>
           <Figure
             data={{
-              title: hit._source.title,
-              type: hit._source.accessionNumber,
-              src: hit._source.thumbnail,
+              title: item.title,
+              type: item.accession_number,
+              src: item.thumbnail,
             }}
           />
         </GridItem>

--- a/components/Search/Search.tsx
+++ b/components/Search/Search.tsx
@@ -8,12 +8,14 @@ import {
 } from "react";
 import Router, { useRouter } from "next/router";
 import { Button, Clear, Input, SearchStyled } from "./Search.styled";
+import { useSearchDispatch } from "@/context/search-context";
 
 interface SearchProps {
   isSearchActive: (value: boolean) => void;
 }
 
 const Search: React.FC<SearchProps> = ({ isSearchActive }) => {
+  const dispatch: any = useSearchDispatch();
   const router = useRouter();
 
   const search = useRef<HTMLInputElement>(null);
@@ -26,6 +28,10 @@ const Search: React.FC<SearchProps> = ({ isSearchActive }) => {
     let query = "";
     if (searchValue) query = `?q=${encodeURI(searchValue.replace(/ /g, "+"))}`;
     Router.push(`/search${query}`);
+    dispatch({
+      q: searchValue,
+      type: "updateSearch",
+    });
   };
 
   const handleSearchFocus = (e: FocusEvent) =>

--- a/context/search-context.tsx
+++ b/context/search-context.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+import { SearchAction, SearchContextStore } from "@/types/search-context";
+
+const defaultState: SearchContextStore = {
+  q: "",
+};
+
+const SearchStateContext =
+  React.createContext<SearchContextStore>(defaultState);
+const SearchDispatchContext =
+  React.createContext<SearchContextStore>(defaultState);
+
+function searchReducer(state: SearchContextStore, action: SearchAction) {
+  switch (action.type) {
+    case "updateSearch": {
+      return {
+        ...state,
+        q: action.q,
+      };
+    }
+    default: {
+      throw new Error(`Unhandled action type: ${action.type}`);
+    }
+  }
+}
+
+interface SearchProviderProps {
+  initialState?: SearchContextStore;
+  children: React.ReactNode;
+}
+
+const SearchProvider: React.FC<SearchProviderProps> = ({
+  initialState = defaultState,
+  children,
+}) => {
+  const [state, dispatch] = React.useReducer<
+    React.Reducer<SearchContextStore, SearchAction>
+  >(searchReducer, initialState);
+
+  return (
+    <SearchStateContext.Provider value={state}>
+      <SearchDispatchContext.Provider
+        value={dispatch as unknown as SearchContextStore}
+      >
+        {children}
+      </SearchDispatchContext.Provider>
+    </SearchStateContext.Provider>
+  );
+};
+
+function useSearchState() {
+  const context = React.useContext(SearchStateContext);
+  if (context === undefined) {
+    throw new Error("useSearchState must be used within a SearchProvider");
+  }
+  return context;
+}
+
+function useSearchDispatch() {
+  const context = React.useContext(SearchDispatchContext);
+  if (context === undefined) {
+    throw new Error("useSearchDispatch must be used within a SearchProvider");
+  }
+  return context;
+}
+
+export { SearchProvider, useSearchState, useSearchDispatch };

--- a/hooks/useApiSearch.ts
+++ b/hooks/useApiSearch.ts
@@ -2,10 +2,13 @@ import { defaultQuery } from "@/mocks/defaultQuery";
 import { buildSearchQuery, querySearchTemplate } from "@/lib/queries/search";
 import { buildFacetPart } from "@/lib/queries/facet";
 import { UserFacets } from "types";
+import { DefaultSearchRequest } from "@/types/search";
 
 const useApiSearch = () => {
   function updateQuery(term: string, userFacets: UserFacets) {
-    const newQuery = JSON.parse(JSON.stringify(querySearchTemplate));
+    const newQuery: DefaultSearchRequest = JSON.parse(
+      JSON.stringify(querySearchTemplate)
+    );
 
     /**
      * Add search term to the API query
@@ -17,11 +20,13 @@ const useApiSearch = () => {
     /**
      * Add facets to the API query
      */
-    for (const [key, value] of Object.entries(userFacets)) {
-      if (value?.length > 0) {
-        newQuery.query.bool.must.push(buildFacetPart(key, value));
-      }
-    }
+    // for (const [key, value] of Object.entries(userFacets)) {
+    //   if (value?.length > 0) {
+    //     newQuery.query.bool.must.push(buildFacetPart(key, value));
+    //   }
+    // }
+
+    console.log(`newQuery`, newQuery);
 
     return newQuery;
   }

--- a/hooks/useApiSearch.ts
+++ b/hooks/useApiSearch.ts
@@ -2,11 +2,11 @@ import { defaultQuery } from "@/mocks/defaultQuery";
 import { buildSearchQuery, querySearchTemplate } from "@/lib/queries/search";
 import { buildFacetPart } from "@/lib/queries/facet";
 import { UserFacets } from "types";
-import { DefaultSearchRequest } from "@/types/search";
+import { ApiSearchRequest } from "@/types/api/request";
 
 const useApiSearch = () => {
   function updateQuery(term: string, userFacets: UserFacets) {
-    const newQuery: DefaultSearchRequest = JSON.parse(
+    const newQuery: ApiSearchRequest = JSON.parse(
       JSON.stringify(querySearchTemplate)
     );
 

--- a/hooks/useApiSearch.ts
+++ b/hooks/useApiSearch.ts
@@ -26,8 +26,6 @@ const useApiSearch = () => {
     //   }
     // }
 
-    console.log(`newQuery`, newQuery);
-
     return newQuery;
   }
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,6 +10,7 @@ const customJestConfig = {
   moduleNameMapper: {
     // Handle module aliases
     "^@/components/(.*)$": "<rootDir>/components/$1",
+    "^@/context/(.*)$": "<rootDir>/context/$1",
     "^@/pages/(.*)$": "<rootDir>/pages/$1",
     "^@/mocks/(.*)$": "<rootDir>/mocks/$1",
     "^@/(.*)$": "<rootDir>/$1",

--- a/lib/dc-api.ts
+++ b/lib/dc-api.ts
@@ -1,0 +1,18 @@
+import { DC_API_SEARCH_URL } from "@/lib/queries/endpoints";
+
+/**
+ * Wrapper for Elasticsearch API /search network requests
+ */
+async function getAPIData(body) {
+  const response = await fetch(DC_API_SEARCH_URL, {
+    body: JSON.stringify(body),
+    headers: {
+      "Content-Type": "application/json",
+    },
+    method: "POST",
+  });
+  const data: any = await response.json();
+  return data;
+}
+
+export { getAPIData };

--- a/lib/dc-api.ts
+++ b/lib/dc-api.ts
@@ -1,9 +1,10 @@
 import { DC_API_SEARCH_URL } from "@/lib/queries/endpoints";
+import { ApiResponse, DefaultSearchRequest } from "@/types/search";
 
 /**
  * Wrapper for Elasticsearch API /search network requests
  */
-async function getAPIData(body) {
+async function getAPIData(body: DefaultSearchRequest): Promise<ApiResponse> {
   const response = await fetch(DC_API_SEARCH_URL, {
     body: JSON.stringify(body),
     headers: {
@@ -11,7 +12,7 @@ async function getAPIData(body) {
     },
     method: "POST",
   });
-  const data: any = await response.json();
+  const data: ApiResponse = await response.json();
   return data;
 }
 

--- a/lib/dc-api.ts
+++ b/lib/dc-api.ts
@@ -1,10 +1,11 @@
 import { DC_API_SEARCH_URL } from "@/lib/queries/endpoints";
-import { ApiResponse, DefaultSearchRequest } from "@/types/search";
+import { ApiSearchResponse } from "@/types/api/response";
+import { ApiSearchRequest } from "@/types/api/request";
 
 /**
  * Wrapper for Elasticsearch API /search network requests
  */
-async function getAPIData(body: DefaultSearchRequest): Promise<ApiResponse> {
+async function getAPIData(body: ApiSearchRequest): Promise<ApiSearchResponse> {
   const response = await fetch(DC_API_SEARCH_URL, {
     body: JSON.stringify(body),
     headers: {
@@ -12,7 +13,7 @@ async function getAPIData(body: DefaultSearchRequest): Promise<ApiResponse> {
     },
     method: "POST",
   });
-  const data: ApiResponse = await response.json();
+  const data: ApiSearchResponse = await response.json();
   return data;
 }
 

--- a/lib/queries/endpoints.ts
+++ b/lib/queries/endpoints.ts
@@ -1,4 +1,5 @@
+const DC_API_SEARCH_URL = `https://zqwev40ued.execute-api.us-east-1.amazonaws.com/test/search`;
 const API_PRODUCTION_URL = `https://dcapi.stack.rdc.library.northwestern.edu/search/meadow/_search`;
 const API_STAGING_URL = `https://dcapi.stack.rdc-staging.library.northwestern.edu/search/meadow/_search`;
 
-export { API_PRODUCTION_URL, API_STAGING_URL };
+export { API_PRODUCTION_URL, API_STAGING_URL, DC_API_SEARCH_URL };

--- a/lib/queries/search.ts
+++ b/lib/queries/search.ts
@@ -1,7 +1,7 @@
 import { aggs } from "@/lib/queries/aggs";
-import { DefaultSearchRequest, SearchSimpleQueryString } from "@/types/search";
+import { ApiSearchRequest, SearchSimpleQueryString } from "@/types/api/request";
 
-const querySearchTemplate: DefaultSearchRequest = {
+const querySearchTemplate: ApiSearchRequest = {
   _source: [
     "accessionNumber",
     "id",

--- a/lib/queries/search.ts
+++ b/lib/queries/search.ts
@@ -1,4 +1,4 @@
-// import { aggs } from "@/lib/queries/aggs";
+import { aggs } from "@/lib/queries/aggs";
 import { DefaultSearchRequest, SearchSimpleQueryString } from "@/types/search";
 
 const querySearchTemplate: DefaultSearchRequest = {
@@ -28,26 +28,24 @@ const querySearchTemplate: DefaultSearchRequest = {
     },
   },
   size: 20,
-  //...aggs,
+  ...aggs,
 };
 
-const buildSearchQuery = (term: string) => {
-  const simple_query_string: SearchSimpleQueryString = {
-    default_operator: "or",
-    fields: [
-      "all_titles^5",
-      "description^2",
-      "all_subjects^2",
-      "full_text",
-      "legacy_identifier",
-      "accession_number",
-      "id",
-    ],
-    query: term ? `${term}~1 | ${term}*` : "",
-  };
-
+const buildSearchQuery = (term: string): SearchSimpleQueryString => {
   return {
-    simple_query_string: simple_query_string,
+    simple_query_string: {
+      default_operator: "or",
+      fields: [
+        "all_titles^5",
+        "description^2",
+        "all_subjects^2",
+        "full_text",
+        "legacy_identifier",
+        "accession_number",
+        "id",
+      ],
+      query: term ? `${term}~1 | ${term}*` : "",
+    },
   };
 };
 

--- a/lib/queries/search.ts
+++ b/lib/queries/search.ts
@@ -27,7 +27,7 @@ const querySearchTemplate = {
       ],
     },
   },
-  ...aggs,
+  //...aggs,
 };
 
 const buildSearchQuery = (term: string) => {

--- a/lib/queries/search.ts
+++ b/lib/queries/search.ts
@@ -1,14 +1,14 @@
-import { aggs } from "@/lib/queries/aggs";
+// import { aggs } from "@/lib/queries/aggs";
+import { DefaultSearchRequest, SearchSimpleQueryString } from "@/types/search";
 
-const querySearchTemplate = {
-  size: 20,
+const querySearchTemplate: DefaultSearchRequest = {
   _source: [
-    "id",
     "accessionNumber",
+    "id",
     "iiifManifest",
     "title",
-    "workType.label",
     "thumbnail",
+    "workType.label",
   ],
   query: {
     bool: {
@@ -27,24 +27,27 @@ const querySearchTemplate = {
       ],
     },
   },
+  size: 20,
   //...aggs,
 };
 
 const buildSearchQuery = (term: string) => {
+  const simple_query_string: SearchSimpleQueryString = {
+    default_operator: "or",
+    fields: [
+      "all_titles^5",
+      "description^2",
+      "all_subjects^2",
+      "full_text",
+      "legacy_identifier",
+      "accession_number",
+      "id",
+    ],
+    query: term ? `${term}~1 | ${term}*` : "",
+  };
+
   return {
-    simple_query_string: {
-      query: term ? `${term}~1 | ${term}*` : "",
-      fields: [
-        "all_titles^5",
-        "description^2",
-        "all_subjects^2",
-        "full_text",
-        "legacy_identifier",
-        "accession_number",
-        "id",
-      ],
-      default_operator: "or",
-    },
+    simple_query_string: simple_query_string,
   };
 };
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,8 +1,13 @@
-import '../styles/globals.css'
-import type { AppProps } from 'next/app'
+import "../styles/globals.css";
+import type { AppProps } from "next/app";
+import { SearchProvider } from "@/context/search-context";
 
 function MyApp({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />
+  return (
+    <SearchProvider>
+      <Component {...pageProps} />
+    </SearchProvider>
+  );
 }
 
-export default MyApp
+export default MyApp;

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -7,7 +7,8 @@ import Grid from "@/components/Grid/Grid";
 import Heading from "@/components/Heading/Heading";
 import Layout from "@/components/layout";
 import { getAPIData } from "@/lib/dc-api";
-import { DefaultSearchRequest } from "@/types/search";
+import { ApiSearchRequest } from "@/types/api/request";
+import { ApiSearchResponse } from "@/types/api/response";
 
 const SearchPage: NextPage = () => {
   const router = useRouter();
@@ -19,7 +20,7 @@ const SearchPage: NextPage = () => {
 
   const [userFacets, setUserFacets] = useState({});
   const [searchTerm, setSearchTerm] = useState<string>(q as string);
-  const [searchResponse, setSearchResponse] = useState<any>();
+  const [searchResponse, setSearchResponse] = useState<ApiSearchResponse>();
 
   const { updateQuery } = useApiSearch();
 
@@ -33,8 +34,7 @@ const SearchPage: NextPage = () => {
   }, [q, searchTerm]);
 
   useEffect(() => {
-    const body: DefaultSearchRequest = buildBody();
-    //const body: DefaultSearchRequest = updateQuery(searchTerm, userFacets);
+    const body: ApiSearchRequest = buildBody();
     const getData = async () => await getAPIData(body);
     getData()
       .then((data) => setSearchResponse(data))
@@ -45,7 +45,9 @@ const SearchPage: NextPage = () => {
     <Layout data-testid="search-page-wrapper">
       <Heading as="h1" title="Search" isHidden />
       <Container containerType="wide">
-        {searchResponse && <Grid {...searchResponse} />}
+        {searchResponse && (
+          <Grid data={searchResponse.data} info={searchResponse.info} />
+        )}
       </Container>
     </Layout>
   );

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -7,6 +7,7 @@ import Grid from "@/components/Grid/Grid";
 import Heading from "@/components/Heading/Heading";
 import Layout from "@/components/layout";
 import { getAPIData } from "@/lib/dc-api";
+import { DefaultSearchRequest } from "@/types/search";
 
 const SearchPage: NextPage = () => {
   const router = useRouter();
@@ -16,14 +17,14 @@ const SearchPage: NextPage = () => {
    * @todo: make getUseFacets() a hook.
    */
 
-  const [userFacets, setUserFacets] = useState<[]>([]);
+  const [userFacets, setUserFacets] = useState({});
   const [searchTerm, setSearchTerm] = useState<string>(q as string);
   const [searchResponse, setSearchResponse] = useState<any>();
 
   const { updateQuery } = useApiSearch();
 
   const buildBody = useCallback(
-    (updateQuery) => updateQuery(searchTerm, userFacets),
+    () => updateQuery(searchTerm, userFacets),
     [searchTerm, userFacets]
   );
 
@@ -32,7 +33,8 @@ const SearchPage: NextPage = () => {
   }, [q, searchTerm]);
 
   useEffect(() => {
-    const body: any = buildBody(updateQuery);
+    const body: DefaultSearchRequest = buildBody();
+    //const body: DefaultSearchRequest = updateQuery(searchTerm, userFacets);
     const getData = async () => await getAPIData(body);
     getData()
       .then((data) => setSearchResponse(data))

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -18,7 +18,7 @@ const SearchPage: NextPage = () => {
    */
   const userFacets = {};
   const [searchTerm, setSearchTerm] = useState<string>(q as string);
-  const [esData, setEsData] = useState<SearchResponse<Source>>();
+  const [searchResponse, setSearchResponse] = useState<any>();
 
   const { updateQuery } = useApiSearch();
 
@@ -30,10 +30,9 @@ const SearchPage: NextPage = () => {
       },
       method: "POST",
     });
-    console.log("response", response);
     const data: any = await response.json();
     console.log("data", data);
-    if (esData !== data) return data;
+    if (searchResponse !== data) return data;
   }, [searchTerm]);
 
   useEffect(() => {
@@ -43,7 +42,7 @@ const SearchPage: NextPage = () => {
   useEffect(() => {
     const getData = async () => await getAPIData();
     getData()
-      .then((data) => setEsData(data))
+      .then((data) => setSearchResponse(data))
       .catch(console.error);
   }, [getAPIData]);
 
@@ -51,7 +50,7 @@ const SearchPage: NextPage = () => {
     <Layout data-testid="search-page-wrapper">
       <Heading as="h1" title="Search" isHidden />
       <Container containerType="wide">
-        {esData && <Grid hits={esData?.hits} />}
+        {searchResponse && <Grid {...searchResponse} />}
       </Container>
     </Layout>
   );

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -37,7 +37,7 @@ const SearchPage: NextPage = () => {
     getData()
       .then((data) => setSearchResponse(data))
       .catch(console.error);
-  }, [buildBody, updateQuery]);
+  }, [buildBody]);
 
   return (
     <Layout data-testid="search-page-wrapper">

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { NextPage } from "next";
-import { SearchResponse, Source } from "@/types/elasticsearch";
 import { DC_API_SEARCH_URL } from "@/lib/queries/endpoints";
 import useApiSearch from "@/hooks/useApiSearch";
 import Grid from "@/components/Grid/Grid";
@@ -12,6 +11,7 @@ import Container from "@/components/Container";
 const SearchPage: NextPage = () => {
   const router = useRouter();
   const { q } = router.query;
+  console.log("q", q);
 
   /**
    * @todo: make getUseFacets() a hook.
@@ -37,7 +37,7 @@ const SearchPage: NextPage = () => {
 
   useEffect(() => {
     if (searchTerm !== q) setSearchTerm(q as string);
-  }, [q, searchTerm]);
+  }, [q]);
 
   useEffect(() => {
     const getData = async () => await getAPIData();

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { NextPage } from "next";
 import { SearchResponse, Source } from "@/types/elasticsearch";
-import { API_PRODUCTION_URL } from "@/lib/queries/endpoints";
+import { DC_API_SEARCH_URL } from "@/lib/queries/endpoints";
 import useApiSearch from "@/hooks/useApiSearch";
 import Grid from "@/components/Grid/Grid";
 import Heading from "@/components/Heading/Heading";
@@ -23,20 +23,22 @@ const SearchPage: NextPage = () => {
   const { updateQuery } = useApiSearch();
 
   const getAPIData = useCallback(async () => {
-    const response = await fetch(API_PRODUCTION_URL, {
-      method: "POST",
+    const response = await fetch(DC_API_SEARCH_URL, {
+      body: JSON.stringify(updateQuery(searchTerm, userFacets)),
       headers: {
         "Content-Type": "application/json",
       },
-      body: JSON.stringify(updateQuery(searchTerm, userFacets)),
+      method: "POST",
     });
-    const data: SearchResponse<Source> = await response.json();
+    console.log("response", response);
+    const data: any = await response.json();
+    console.log("data", data);
     if (esData !== data) return data;
   }, [searchTerm]);
 
   useEffect(() => {
     if (searchTerm !== q) setSearchTerm(q as string);
-  }, [q]);
+  }, [q, searchTerm]);
 
   useEffect(() => {
     const getData = async () => await getAPIData();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
     "paths": {
       "@/*": ["*"],
       "@/components/*": ["components/*"],
+      "@/context/*": ["context/*"],
       "@/mocks/*": ["mocks/*"],
       "@/pages/*": ["pages/*"],
       "@/styles/*": ["styles/*"]

--- a/types/api/generic.ts
+++ b/types/api/generic.ts
@@ -1,0 +1,1 @@
+export type ModelName = "Collection" | "Work";

--- a/types/api/request.ts
+++ b/types/api/request.ts
@@ -1,4 +1,4 @@
-export type ModelName = "Collection" | "Work";
+import { ModelName } from "@/types/api/generic";
 
 export interface SearchModelName {
   bool: {

--- a/types/api/request.ts
+++ b/types/api/request.ts
@@ -12,6 +12,16 @@ export interface SearchModelName {
   };
 }
 
+export interface ApiSearchRequest {
+  _source: SearchSource;
+  query: {
+    bool: {
+      must: [SearchModelName, SearchSimpleQueryString?];
+    };
+  };
+  size: number;
+}
+
 export interface SearchSimpleQueryString {
   simple_query_string: {
     default_operator: string;
@@ -28,20 +38,3 @@ export type SearchSource = [
   "thumbnail",
   "workType.label"
 ];
-
-export interface DefaultSearchRequest {
-  _source: SearchSource;
-  query: {
-    bool: {
-      must: [SearchModelName, SearchSimpleQueryString?];
-    };
-  };
-  size: number;
-}
-
-export interface ApiResponse {
-  data: Array<any>;
-  info: {
-    total: number;
-  };
-}

--- a/types/api/response.ts
+++ b/types/api/response.ts
@@ -1,0 +1,37 @@
+export interface ApiResponse {
+  data: ApiResponseData;
+  info: {
+    total: number;
+  };
+}
+
+interface ApiResponseAggregation {
+  buckets: Bucket[];
+  id: string;
+}
+
+export type ApiResponseData = CollectionShape[] | WorkShape[];
+
+export interface ApiResponseDataShape {
+  accession_number: string;
+  id: string;
+  thumbnail: string;
+  title: string;
+}
+
+export interface ApiSearchResponse extends ApiResponse {
+  aggregations?: ApiResponseAggregation[];
+}
+
+type Bucket = {
+  doc_count: number;
+  key: string;
+};
+
+export interface CollectionShape extends ApiResponseDataShape {
+  foo?: string;
+}
+
+export interface WorkShape extends ApiResponseDataShape {
+  foo?: string;
+}

--- a/types/api/response.ts
+++ b/types/api/response.ts
@@ -1,3 +1,5 @@
+import { ModelName } from "@/types/api/generic";
+
 export interface ApiResponse {
   data: ApiResponseData;
   info: {
@@ -6,32 +8,45 @@ export interface ApiResponse {
 }
 
 interface ApiResponseAggregation {
-  buckets: Bucket[];
+  buckets: ApiResponseBucket[];
   id: string;
 }
 
-export type ApiResponseData = CollectionShape[] | WorkShape[];
-
-export interface ApiResponseDataShape {
-  accession_number: string;
-  id: string;
-  thumbnail: string;
-  title: string;
-}
-
-export interface ApiSearchResponse extends ApiResponse {
-  aggregations?: ApiResponseAggregation[];
-}
-
-type Bucket = {
+type ApiResponseBucket = {
   doc_count: number;
   key: string;
 };
 
+export type ApiResponseData = CollectionShape | SearchShape[] | WorkShape;
+
+export interface ApiSearchResponse extends ApiResponse {
+  aggregations?: ApiResponseAggregation[];
+  data: SearchShape[];
+}
+
+/**
+ * Default shape for API response data property
+ */
+export interface ApiResponseDataShape {
+  accession_number: string;
+  id: string;
+  iiif_manifest?: string;
+  title: string;
+  thumbnail: string;
+  api_model: ModelName;
+}
+
+/**
+ * Defined shapes for API response data property
+ */
 export interface CollectionShape extends ApiResponseDataShape {
-  foo?: string;
+  api_model: "Collection";
+}
+
+export interface SearchShape extends ApiResponseDataShape {
+  work_type_labels: string;
 }
 
 export interface WorkShape extends ApiResponseDataShape {
-  foo?: string;
+  api_model: "Work";
 }

--- a/types/search-context.ts
+++ b/types/search-context.ts
@@ -1,0 +1,13 @@
+export interface SearchAction {
+  q: string;
+  type: string;
+}
+
+export interface SearchContextStore {
+  q: string;
+}
+
+export interface SearchReducer {
+  action: SearchAction;
+  state: SearchContextStore;
+}

--- a/types/search.ts
+++ b/types/search.ts
@@ -1,4 +1,25 @@
 export type ModelName = "Collection" | "Work";
+
+export interface SearchModelName {
+  bool: {
+    must: [
+      {
+        match: {
+          "model.name": ModelName;
+        };
+      }
+    ];
+  };
+}
+
+export interface SearchSimpleQueryString {
+  simple_query_string: {
+    default_operator: string;
+    fields: string[];
+    query: string;
+  };
+}
+
 export type SearchSource = [
   "accessionNumber",
   "id",
@@ -8,33 +29,19 @@ export type SearchSource = [
   "workType.label"
 ];
 
-export interface SearchSimpleQueryString {
-  default_operator: string;
-  fields: string[];
-  query: string;
-}
-
 export interface DefaultSearchRequest {
   _source: SearchSource;
   query: {
     bool: {
-      must: [
-        {
-          bool: {
-            must: [
-              {
-                match: {
-                  "model.name": ModelName;
-                };
-              }
-            ];
-          };
-        },
-        {
-          simple_query_string?: SearchSimpleQueryString;
-        }
-      ];
+      must: [SearchModelName, SearchSimpleQueryString?];
     };
   };
   size: number;
+}
+
+export interface ApiResponse {
+  data: Array<any>;
+  info: {
+    total: number;
+  };
 }

--- a/types/search.ts
+++ b/types/search.ts
@@ -1,0 +1,40 @@
+export type ModelName = "Collection" | "Work";
+export type SearchSource = [
+  "accessionNumber",
+  "id",
+  "iiifManifest",
+  "title",
+  "thumbnail",
+  "workType.label"
+];
+
+export interface SearchSimpleQueryString {
+  default_operator: string;
+  fields: string[];
+  query: string;
+}
+
+export interface DefaultSearchRequest {
+  _source: SearchSource;
+  query: {
+    bool: {
+      must: [
+        {
+          bool: {
+            must: [
+              {
+                match: {
+                  "model.name": ModelName;
+                };
+              }
+            ];
+          };
+        },
+        {
+          simple_query_string?: SearchSimpleQueryString;
+        }
+      ];
+    };
+  };
+  size: number;
+}


### PR DESCRIPTION
- Use new DC API URL
- Pull in data from new API shape
- Wrap app with Search Context
- Break search api requests out to lib helper.
- Define search query types.
- Pull in aggs from API and create types for them
- Re-factor structure of api request and response types and apply the types to active Search
- Add SearchShape and define search response data explicitly.

This work adds React context for state management wrapping our Next App, and creates the context for `q` search variable. We also defined types around API search requests and and search responses using the new DC API.  
