### PR TITLE
Refactor Search Context Provider

### DIFF
--- a/components/Search/Search.tsx
+++ b/components/Search/Search.tsx
@@ -8,18 +8,16 @@ import {
 } from "react";
 import Router, { useRouter } from "next/router";
 import { Button, Clear, Input, SearchStyled } from "./Search.styled";
-import { useSearchDispatch } from "@/context/search-context";
+import { useSearchState } from "@/context/search-context";
 
 interface SearchProps {
   isSearchActive: (value: boolean) => void;
 }
 
 const Search: React.FC<SearchProps> = ({ isSearchActive }) => {
-  const dispatch: any = useSearchDispatch();
   const router = useRouter();
-
+  const { searchDispatch } = useSearchState();
   const search = useRef<HTMLInputElement>(null);
-
   const [searchValue, setSearchValue] = useState<string>("");
   const [searchFocus, setSearchFocus] = useState<boolean>(false);
 
@@ -28,7 +26,7 @@ const Search: React.FC<SearchProps> = ({ isSearchActive }) => {
     let query = "";
     if (searchValue) query = `?q=${encodeURI(searchValue.replace(/ /g, "+"))}`;
     Router.push(`/search${query}`);
-    dispatch({
+    searchDispatch({
       q: searchValue,
       type: "updateSearch",
     });

--- a/pages/search-old.tsx
+++ b/pages/search-old.tsx
@@ -9,6 +9,7 @@ import { NextPage } from "next";
 import React from "react";
 import { facetFilterQuery } from "lib/queries/facet-filter";
 import useApiSearch from "hooks/useApiSearch";
+import { useSearchState } from "@/context/search-context";
 
 interface FacetNoLabel {
   buckets: Array<any>;
@@ -24,11 +25,14 @@ const SearchPage: NextPage = () => {
   const [aggregatedFacets, setAggregatedFacets] = React.useState<
     Array<AggregatedFacets>
   >([]);
-  const [userFacets, setUserFacets] = React.useState<UserFacets>({});
   const [searchTerm, setSearchTerm] = React.useState("");
   const [facetFilterResults, setFacetFilterResults] =
     React.useState<FilteredFacets>({});
   const { updateQuery } = useApiSearch();
+
+  // New context pattern
+  const { searchDispatch, searchState } = useSearchState();
+  const { userFacets } = searchState;
 
   const getAPIData = React.useCallback(async () => {
     const response = await fetch(API_PRODUCTION_URL, {
@@ -80,7 +84,10 @@ const SearchPage: NextPage = () => {
       newObj[name] = [...newObj[name]].filter((arrValue) => arrValue !== value);
     }
 
-    setUserFacets(newObj);
+    searchDispatch({
+      type: "updateUserFacets",
+      userFacets: newObj,
+    });
   };
 
   const clearFacetFilters = () => {

--- a/types/search-context.ts
+++ b/types/search-context.ts
@@ -1,13 +1,8 @@
-export interface SearchAction {
-  q: string;
-  type: string;
-}
-
 export interface SearchContextStore {
   q: string;
+  userFacets: UserFacets;
 }
 
-export interface SearchReducer {
-  action: SearchAction;
-  state: SearchContextStore;
+export interface UserFacets {
+  [key: string]: string[];
 }


### PR DESCRIPTION
Cleans up the Search Provider component, which is keeping track of Search application state.  Simplifies it a bit. And adds individually selected facets to the state.