### PR TITLE
Add test-utils helper to fix failing Jest tests

### DIFF
--- a/components/Facet/Facet.tsx
+++ b/components/Facet/Facet.tsx
@@ -1,5 +1,5 @@
 import { FacetBucketAgg } from "types";
-import FacetFilter from "../FacetFilter/FacetFilter";
+import FacetFilter from "@/components/FacetFilter/FacetFilter";
 import React from "react";
 
 interface FacetBuckets {

--- a/components/Facets/Facets.styled.ts
+++ b/components/Facets/Facets.styled.ts
@@ -1,4 +1,4 @@
-import { styled } from "../../stitches.config";
+import { styled } from "@/stitches.config";
 
 const StyledFacets = styled("div", {
   display: "flex",

--- a/components/Facets/Filter.styled.ts
+++ b/components/Facets/Filter.styled.ts
@@ -1,5 +1,5 @@
 import * as Dialog from "@radix-ui/react-dialog";
-import { styled } from "../../stitches.config";
+import { styled } from "@/stitches.config";
 
 /* eslint sort-keys: 0 */
 

--- a/components/Facets/InlineFacet.styled.ts
+++ b/components/Facets/InlineFacet.styled.ts
@@ -1,4 +1,4 @@
-import { styled } from "../../stitches.config";
+import { styled } from "@/stitches.config";
 
 const StyledInlineFacet = styled("ul", {
   display: "flex",

--- a/components/Facets/MultiFacet.styled.ts
+++ b/components/Facets/MultiFacet.styled.ts
@@ -1,4 +1,4 @@
-import { styled } from "../../stitches.config";
+import { styled } from "@/stitches.config";
 import { StyledHeading } from "@/components/Heading/Heading.styled";
 
 /* eslint sort-keys: 0 */

--- a/components/Facets/MultiFacet.test.tsx
+++ b/components/Facets/MultiFacet.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from "@testing-library/react";
+import { render, screen, within } from "@/test-utils";
 import MultiFacet from "./MultiFacet";
 import React from "react";
 import { mockAggregation } from "@/mocks/aggregation";

--- a/components/Facets/Option.test.tsx
+++ b/components/Facets/Option.test.tsx
@@ -1,7 +1,7 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen } from "@/test-utils";
+import { FacetOption } from "@/types/components/facets";
 import Option from "./Option";
 import React from "react";
-import { FacetOption } from "@/types/components/facets";
 import { mockAggregation } from "@/mocks/aggregation";
 
 const mockOption: FacetOption = {

--- a/components/Header/Header.styled.ts
+++ b/components/Header/Header.styled.ts
@@ -1,7 +1,7 @@
 import { Button, Input, SearchStyled } from "../Search/Search.styled";
 import { NavStyled } from "../Nav/Nav.styled";
 import { ContainerStyled } from "@/components/Container";
-import { styled } from "../../stitches.config";
+import { styled } from "@/stitches.config";
 
 const Lockup = styled("div", {
   padding: "31px 0 50px",

--- a/components/Header/Primary.test.tsx
+++ b/components/Header/Primary.test.tsx
@@ -1,10 +1,10 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen } from "@/test-utils";
 import HeaderPrimary from "./Primary";
 
 describe("HeaderPrimary", () => {
   it("renders the header-primary ui component", () => {
-    // render(<HeaderPrimary />);
-    // const wrapper = screen.getByTestId("header-primary-ui-component");
-    // expect(wrapper).toBeInTheDocument();
+    render(<HeaderPrimary />);
+    const wrapper = screen.getByTestId("header-primary-ui-component");
+    expect(wrapper).toBeInTheDocument();
   });
 });

--- a/components/Header/Primary.tsx
+++ b/components/Header/Primary.tsx
@@ -1,5 +1,5 @@
 import { Primary, PrimaryInner } from "@/components/Header/Header.styled";
-import Container from "../Container";
+import Container from "@/components/Container";
 import Heading from "@/components/Heading/Heading";
 import Link from "next/link";
 import Nav from "@/components/Nav/Nav";

--- a/components/Heading/Heading.styled.ts
+++ b/components/Heading/Heading.styled.ts
@@ -1,4 +1,4 @@
-import { styled } from "../../stitches.config";
+import { styled } from "@/stitches.config";
 
 const StyledHeading = styled("h2", {
   variants: {

--- a/components/Nav/Nav.styled.ts
+++ b/components/Nav/Nav.styled.ts
@@ -1,4 +1,4 @@
-import { styled } from "../../stitches.config";
+import { styled } from "@/stitches.config";
 
 const NavStyled = styled("nav", {
   display: "flex",

--- a/components/Search/Search.styled.ts
+++ b/components/Search/Search.styled.ts
@@ -1,4 +1,4 @@
-import { styled } from "../../stitches.config";
+import { styled } from "@/stitches.config";
 
 const SearchStyled = styled("form", {
   position: "relative",

--- a/components/Search/Search.test.tsx
+++ b/components/Search/Search.test.tsx
@@ -1,10 +1,10 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen } from "@/test-utils";
 import Search from "./Search";
 
 describe("Search", () => {
   it("renders the search ui component", () => {
-    // render(<Search isSearchActive={() => ({})} />);
-    // const wrapper = screen.getByTestId("search-ui-component");
-    // expect(wrapper).toBeInTheDocument();
+    render(<Search isSearchActive={() => ({})} />);
+    const wrapper = screen.getByTestId("search-ui-component");
+    expect(wrapper).toBeInTheDocument();
   });
 });

--- a/test-utils.tsx
+++ b/test-utils.tsx
@@ -1,0 +1,15 @@
+import React, { FC, ReactElement } from "react";
+import { RenderOptions, render, screen } from "@testing-library/react";
+import { SearchProvider } from "@/context/search-context";
+
+const AllTheProviders: FC = ({ children }) => {
+  return <SearchProvider>{children}</SearchProvider>;
+};
+
+const customRender = (
+  ui: ReactElement,
+  options?: Omit<RenderOptions, "wrapper">
+) => render(ui, { wrapper: AllTheProviders, ...options });
+
+export * from "@testing-library/react";
+export { customRender as render, screen };


### PR DESCRIPTION
Add test-utils helper to optionally wrap components with our SearchProvider.

See any of the tests for an implementation.  If we want to provide a unique, custom `context` to any of our tests, we can manually import the `<SearchProvider />` component into our test, and feed it an initial state(ie. `<SearchProvider initialState={ { q: "foo", userFacets: { ... } } />`)