### PR TITLE
Style modal Group Lists.

### DIFF
--- a/components/Facets/Facet/GenericFacet.styled.ts
+++ b/components/Facets/Facet/GenericFacet.styled.ts
@@ -1,3 +1,4 @@
+import * as Checkbox from "@radix-ui/react-checkbox";
 import { StyledHeading } from "@/components/Heading/Heading.styled";
 import { styled } from "@/stitches.config";
 
@@ -7,7 +8,7 @@ const StyledGenericFacet = styled("div", {
   marginBottom: "2rem",
 
   [`${StyledHeading}`]: {
-    margin: "1rem 0",
+    margin: "0 0 1rem",
   },
 });
 
@@ -52,6 +53,15 @@ const Find = styled("div", {
   },
 });
 
+const Indicator = styled(Checkbox.Indicator, {
+  display: "flex",
+  width: "calc(0.9rem)",
+  height: "calc(0.9rem)",
+  backgroundColor: "$purple",
+  margin: "-1px 0 0 -1px",
+  borderRadius: "2px",
+});
+
 const Options = styled("ul", {
   margin: "0",
   padding: "0",
@@ -60,13 +70,55 @@ const Options = styled("ul", {
     margin: "0",
     padding: "0",
     listStyle: "none",
-    marginBottom: "0.25rem",
+    marginBottom: "0.35rem",
     display: "flex",
 
-    input: {
+    "> span": {
+      display: "block",
+      color: "$black50",
+      marginLeft: "0.25em",
+    },
+
+    label: {
+      cursor: "pointer",
+      color: "$black50",
+
+      "&:hover, &:focus": {
+        color: "$black",
+      },
+
+      [`&[data-selected=true]`]: {
+        color: "$black",
+        fontWeight: "700",
+      },
+    },
+
+    button: {
+      display: "flex",
       marginRight: "0.382rem",
+      width: "0.9rem",
+      height: "0.9rem",
+      flexGrow: "0",
+      flexShrink: "0",
+      backgroundColor: "$white",
+      border: "1px solid $black20",
+      marginTop: "3px",
+      padding: "0",
+      cursor: "pointer",
+      borderRadius: "2px",
+      color: "$purple30",
+
+      svg: {
+        padding: "1px",
+      },
+
+      "&:hover, &:focus": {
+        borderColor: "$black50",
+        boxShadow: "2px 2px 5px #0002",
+        color: "$white",
+      },
     },
   },
 });
 
-export { Find, FindInput, Options, StyledGenericFacet };
+export { Find, FindInput, Indicator, Options, StyledGenericFacet };

--- a/components/Facets/Facet/GenericFacet.test.tsx
+++ b/components/Facets/Facet/GenericFacet.test.tsx
@@ -17,7 +17,7 @@ describe("GenericFacet UI component", () => {
 
   it("Renders the facet heading.", () => {
     render(<GenericFacet {...filterProps} {...mockAggregation} />);
-    const heading = screen.getByRole("heading", { level: 4 });
+    const heading = screen.getByRole("heading", { level: 3 });
     expect(heading).toBeInTheDocument();
     expect(heading).toHaveTextContent("foo");
   });

--- a/components/Facets/Facet/GenericFacet.tsx
+++ b/components/Facets/Facet/GenericFacet.tsx
@@ -11,6 +11,7 @@ import { IconSearch } from "@/components/Shared/SVG/Icons";
 import Option from "./Option";
 import React from "react";
 import { debounce } from "@/lib/utils/debounce";
+import { getFacetById } from "@/lib/utils/facet-helpers";
 
 interface GenericFacetProps extends ApiResponseAggregation {
   filterValue: string;
@@ -23,6 +24,8 @@ const GenericFacet: React.FC<GenericFacetProps> = ({
   buckets,
   setAggsFilterValue,
 }) => {
+  const facet = getFacetById(id);
+
   const handleFindChange = async (e: ChangeEvent<HTMLInputElement>) => {
     setAggsFilterValue(e.target.value);
   };
@@ -36,7 +39,7 @@ const GenericFacet: React.FC<GenericFacetProps> = ({
 
   return (
     <StyledGenericFacet data-testid="facet-multi-component" id={`facet--${id}`}>
-      <Heading as="h4">{id}</Heading>
+      <Heading as="h3">{facet ? facet.label : id}</Heading>
       <Find className="facet-find" data-testid="facet-find">
         <IconSearch />
         <FindInput

--- a/components/Facets/Facet/Option.test.tsx
+++ b/components/Facets/Facet/Option.test.tsx
@@ -31,7 +31,7 @@ describe("Facet Option UI component", () => {
 
   it("Renders a facet option with document count.", () => {
     render(<Option {...mockOption} />);
-    const count = screen.getByText(`2`);
+    const count = screen.getByText(`(2)`);
     expect(count).toBeInTheDocument();
   });
 });

--- a/components/Facets/Facet/Option.tsx
+++ b/components/Facets/Facet/Option.tsx
@@ -1,5 +1,7 @@
 import * as Checkbox from "@radix-ui/react-checkbox";
 import { FacetOption } from "@/types/components/facets";
+import { IconCheck } from "@/components/Shared/SVG/Icons";
+import { Indicator } from "./GenericFacet.styled";
 import React from "react";
 import { UserFacets } from "@/types";
 import { getFacetById } from "@/lib/utils/facet-helpers";
@@ -58,10 +60,14 @@ const Option: React.FC<FacetOption> = ({ bucket, facet, index }) => {
         name={`facet--${facet}`}
         onCheckedChange={handleCheckedChange}
       >
-        <Checkbox.Indicator>x</Checkbox.Indicator>
+        <Indicator>
+          <IconCheck />
+        </Indicator>
       </Checkbox.Root>
-      <label htmlFor={id}>{key}</label>
-      <span>{doc_count}</span>
+      <label htmlFor={id} data-selected={isChecked}>
+        {key}
+      </label>
+      <span>({doc_count})</span>
     </li>
   );
 };

--- a/components/Facets/Filter/Filter.styled.ts
+++ b/components/Facets/Filter/Filter.styled.ts
@@ -1,6 +1,9 @@
 import * as Dialog from "@radix-ui/react-dialog";
+import {
+  PopoverToggle,
+  ValueWrapper,
+} from "@/components/Facets/UserFacets/UserFacets.styled";
 import { IconStyled } from "@/components/Shared/Icon";
-import { PopoverToggle } from "@/components/Facets/UserFacets/UserFacets.styled";
 import { styled } from "@/stitches.config";
 
 /* eslint sort-keys: 0 */
@@ -81,8 +84,24 @@ const FilterOverlay = styled(Dialog.Overlay, {
 
 const FilterBodyInner = styled("div", {
   display: "flex",
+  flexGrow: "1",
   justifyContent: "space-between",
   flexDirection: "row",
+  borderTop: "1px solid $black10",
+
+  "> div": {
+    "&:first-child": {
+      flexGrow: "1",
+      padding: "1rem 0",
+    },
+    "&:last-child": {
+      width: "300px",
+      minWidth: "200px",
+
+      "@sm": { display: "none" },
+    },
+    borderRight: "1px solid $black10",
+  },
 
   "@sm": {
     flexDirection: "column",
@@ -90,10 +109,16 @@ const FilterBodyInner = styled("div", {
 });
 
 const FilterBody = styled("div", {
-  padding: "1rem",
+  display: "flex",
+  flexDirection: "column",
   margin: "3.5rem 0 4.5rem",
   maxHeight: "calc(100% - 8rem)",
+  minHeight: "calc(100% - 8rem)",
   overflow: "scroll",
+
+  [`& ${ValueWrapper}`]: {
+    padding: "0 1rem",
+  },
 
   "&:before": {
     position: "absolute",
@@ -149,13 +174,13 @@ const FilterHeader = styled("header", {
   width: "100%",
   justifyContent: "space-between",
   backgroundColor: "$white",
-  boxShadow: "3px 3px 8px #0001",
 
   h2: {
-    fontSize: "1.5rem",
+    fontSize: "1rem",
     lineHeight: "1.5rem",
     padding: "0",
     margin: "0",
+    color: "$black50",
   },
 
   em: {

--- a/components/Facets/Filter/GroupList.styled.ts
+++ b/components/Facets/Filter/GroupList.styled.ts
@@ -1,0 +1,90 @@
+// import * as Dialog from "@radix-ui/react-dialog";
+// import { IconStyled } from "@/components/Shared/Icon";
+// import { PopoverToggle } from "@/components/Facets/UserFacets/UserFacets.styled";
+import * as Accordion from "@radix-ui/react-accordion";
+import * as Tabs from "@radix-ui/react-tabs";
+import { styled } from "@/stitches.config";
+
+/* eslint sort-keys: 0 */
+
+const GroupContent = styled(Accordion.Content, {});
+
+const GroupHeader = styled(Accordion.Header, {
+  margin: "0",
+  fontSize: "1rem",
+});
+
+const GroupToggle = styled(Accordion.Trigger, {
+  width: "100%",
+  fontSize: "0.8333rem",
+  border: "none",
+  textAlign: "left",
+  padding: "0.75rem 1rem",
+  background: "transparent",
+  color: "$black50",
+  cursor: "pointer",
+  transition: "background 100ms ease-in-out",
+  borderRadius: "3px",
+  borderTopLeftRadius: "0",
+  borderBottomLeftRadius: "0",
+  whiteSpace: "nowrap",
+
+  ["&[aria-expanded=true]"]: {
+    backgroundColor: "$purple120",
+    color: "$purple30",
+
+    "&:hover, &:focus": {
+      backgroundColor: "$purple120",
+      color: "$purple30",
+    },
+  },
+
+  "&:hover, &:focus": {
+    color: "$purple",
+    backgroundColor: "$purple10",
+  },
+});
+
+const ItemList = styled(Tabs.List, {
+  display: "flex",
+  flexDirection: "column",
+  margin: "0.5rem",
+});
+
+const ItemToggle = styled(Tabs.Trigger, {
+  width: "100%",
+  fontSize: "1rem",
+  border: "none",
+  textAlign: "left",
+  padding: "0.75rem 1rem",
+  background: "transparent",
+  color: "$black",
+  cursor: "pointer",
+  transition: "background 100ms ease-in-out",
+  borderRadius: "3px",
+  borderTopLeftRadius: "0",
+  borderBottomLeftRadius: "0",
+
+  ["&[aria-selected=true]"]: {
+    fontWeight: "700",
+  },
+  "&:hover, &:focus": {
+    color: "$purple",
+  },
+});
+
+const ItemContent = styled(Tabs.Content, {
+  padding: "0.5rem 2rem",
+});
+
+const Group = styled(Accordion.Item, {});
+
+export {
+  Group,
+  GroupContent,
+  GroupHeader,
+  GroupToggle,
+  ItemContent,
+  ItemList,
+  ItemToggle,
+};

--- a/components/Facets/Filter/GroupList.tsx
+++ b/components/Facets/Filter/GroupList.tsx
@@ -1,6 +1,15 @@
 import * as Accordion from "@radix-ui/react-accordion";
 import * as Tabs from "@radix-ui/react-tabs";
 import { ALL_FACETS, FACETS } from "@/lib/constants/facets-model";
+import {
+  Group,
+  GroupContent,
+  GroupHeader,
+  GroupToggle,
+  ItemContent,
+  ItemList,
+  ItemToggle,
+} from "./GroupList.styled";
 import Facet from "@/components/Facets/Facet/Facet";
 import { getFacetGroup } from "@/lib/utils/facet-helpers";
 import { useFilterState } from "@/context/filter-context";
@@ -19,44 +28,41 @@ const FacetsGroupList: React.FC = () => {
   }
 
   return (
-    <Tabs.Root defaultValue={defaultFacetId} orientation="vertical">
-      <div style={{ display: "flex" }} data-testid="facets-group-list">
-        <Accordion.Root type="single" defaultValue={defaultGroup}>
-          {FACETS.map((group) => {
-            return (
-              <Accordion.Item value={group.label} key={group.label}>
-                <Accordion.Header>
-                  <Accordion.Trigger>{group.label}</Accordion.Trigger>
-                </Accordion.Header>
-                <Accordion.Content>
-                  <Tabs.List
-                    style={{ display: "flex", flexDirection: "column" }}
-                  >
-                    {group.facets.map((facet) => {
-                      return (
-                        <Tabs.Trigger
-                          value={facet.id}
-                          key={facet.id}
-                          style={{ backgroundColor: "white" }}
-                        >
-                          {facet.label}
-                        </Tabs.Trigger>
-                      );
-                    })}
-                  </Tabs.List>
-                </Accordion.Content>
-              </Accordion.Item>
-            );
-          })}
-        </Accordion.Root>
-        {ALL_FACETS.facets.map((facet) => {
+    <Tabs.Root
+      defaultValue={defaultFacetId}
+      orientation="vertical"
+      style={{ display: "flex" }}
+      data-testid="facets-group-list"
+    >
+      <Accordion.Root type="single" defaultValue={defaultGroup}>
+        {FACETS.map((group) => {
           return (
-            <Tabs.Content value={facet.id} key={facet.id}>
-              <Facet facet={facet} />
-            </Tabs.Content>
+            <Group value={group.label} key={group.label}>
+              <GroupHeader>
+                <GroupToggle>{group.label}</GroupToggle>
+              </GroupHeader>
+              <GroupContent>
+                <ItemList>
+                  {group.facets.map((facet) => {
+                    return (
+                      <ItemToggle value={facet.id} key={facet.id}>
+                        {facet.label}
+                      </ItemToggle>
+                    );
+                  })}
+                </ItemList>
+              </GroupContent>
+            </Group>
           );
         })}
-      </div>
+      </Accordion.Root>
+      {ALL_FACETS.facets.map((facet) => {
+        return (
+          <ItemContent value={facet.id} key={facet.id}>
+            <Facet facet={facet} />
+          </ItemContent>
+        );
+      })}
     </Tabs.Root>
   );
 };

--- a/components/Shared/SVG/Icons.tsx
+++ b/components/Shared/SVG/Icons.tsx
@@ -1,3 +1,17 @@
+const IconCheck: React.FC = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+    <title>Checkmark</title>
+    <path
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="80"
+      d="M416 128L192 384l-96-96"
+    />
+  </svg>
+);
+
 const IconChevronDown: React.FC = () => (
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
     <title>Chevron Down</title>
@@ -11,6 +25,7 @@ const IconChevronDown: React.FC = () => (
     />
   </svg>
 );
+
 const IconClear: React.FC = () => (
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
     <title>Clear</title>
@@ -32,4 +47,4 @@ const IconSearch: React.FC = () => (
   </svg>
 );
 
-export { IconClear, IconChevronDown, IconFilter, IconSearch };
+export { IconCheck, IconChevronDown, IconClear, IconFilter, IconSearch };


### PR DESCRIPTION
## What does this do?

This PR styles the Radix UI Accordion and Tab functionality on an open modal following guidance from our wireframes. This styling wraps the Options and GenericFacet components and these are also giving a nice styling treatment.

## What's not included?

This is pretty much just an issue focused on CSS styling. At some point we may also want to consider count on number of options and adding a "Show More" button. We may also want to come back and refine the internal scrolling of the modal body.

![image](https://user-images.githubusercontent.com/7376450/170537207-1cb62697-f65b-4fc7-8090-22682896fac4.png)

![image](https://user-images.githubusercontent.com/7376450/170537283-bf0d66f2-1556-41c4-aa7d-e751ec4c99f8.png)


- Initiate group list styling.
- Style Tabs.
- Get facet label by id.
- Style options.
- Adjust doc count test.
