### PR TITLE
Style modal preview items.

### DIFF
--- a/components/Facets/Filter/Filter.styled.ts
+++ b/components/Facets/Filter/Filter.styled.ts
@@ -92,11 +92,11 @@ const FilterBodyInner = styled("div", {
   "> div": {
     "&:first-child": {
       flexGrow: "1",
-      padding: "1rem 0",
     },
+
     "&:last-child": {
-      width: "300px",
-      minWidth: "200px",
+      width: "360px",
+      minWidth: "240px",
 
       "@sm": { display: "none" },
     },

--- a/components/Facets/Filter/GroupList.tsx
+++ b/components/Facets/Filter/GroupList.tsx
@@ -9,7 +9,7 @@ import {
   ItemContent,
   ItemList,
   ItemToggle,
-} from "./GroupList.styled";
+} from "@/components/Facets/Filter/GroupList.styled";
 import Facet from "@/components/Facets/Facet/Facet";
 import { getFacetGroup } from "@/lib/utils/facet-helpers";
 import { useFilterState } from "@/context/filter-context";
@@ -31,7 +31,7 @@ const FacetsGroupList: React.FC = () => {
     <Tabs.Root
       defaultValue={defaultFacetId}
       orientation="vertical"
-      style={{ display: "flex" }}
+      style={{ display: "flex", padding: "1rem 0" }}
       data-testid="facets-group-list"
     >
       <Accordion.Root type="single" defaultValue={defaultGroup}>

--- a/components/Facets/Filter/Modal.tsx
+++ b/components/Facets/Filter/Modal.tsx
@@ -56,7 +56,7 @@ const FilterModal: React.FC<FilterModalProps> = ({ q, setIsModalOpen }) => {
         <FacetsCurrentUser screen="modal" />
         <FilterBodyInner>
           <FacetsGroupList />
-          {!loading && apiData && <Preview data={apiData?.data} />}
+          {!loading && apiData && <Preview items={apiData?.data} />}
         </FilterBodyInner>
       </FilterBody>
       <FilterFooter role="menubar">

--- a/components/Facets/Filter/Preview.styled.ts
+++ b/components/Facets/Filter/Preview.styled.ts
@@ -1,0 +1,42 @@
+import { Image } from "@/components/Figure/Figure.styled";
+import { StyledHeading } from "@/components/Heading/Heading.styled";
+import { styled } from "@/stitches.config";
+
+/* eslint sort-keys: 0 */
+
+const PreviewItem = styled("li", {
+  margin: "0",
+  padding: "0",
+  listStyle: "none",
+
+  [`& ${Image}`]: {
+    width: "81px",
+    height: "81px",
+    flexShrink: "0",
+    flexGrow: "0",
+    objectFit: "cover",
+  },
+
+  figcaption: {
+    marginLeft: "1rem",
+    overflowWrap: "anywhere",
+    whiteSpace: "break-spaces",
+  },
+});
+
+const PreviewList = styled("ul", {
+  display: "flex",
+  flexDirection: "column",
+  margin: "0",
+  padding: "0",
+});
+
+const StyledPreview = styled("div", {
+  padding: "1rem 2rem",
+
+  [`& ${StyledHeading}`]: {
+    margin: "0.5rem 0 1rem",
+  },
+});
+
+export { PreviewItem, PreviewList, StyledPreview };

--- a/components/Facets/Filter/Preview.test.tsx
+++ b/components/Facets/Filter/Preview.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@/test-utils";
+import Preview from "@/components/Facets/Filter//Preview";
+import { sampleSearchShape } from "@/mocks/sample-search-shape";
+
+describe("Submit component", () => {
+  function renderHelper() {
+    return render(<Preview items={sampleSearchShape} />);
+  }
+
+  it("renders the component with heading 3", () => {
+    renderHelper();
+    expect(screen.getByRole("heading", { level: 3 })).toHaveTextContent(
+      "Top Results"
+    );
+  });
+
+  it("renders 2 items from search response", () => {
+    renderHelper();
+    const items = screen.getAllByTestId("facets-filter-preview-item");
+    expect(items.length).toBe(2);
+    expect(items[0]).toHaveTextContent("Voyager:RL03108");
+    expect(items[0]).toHaveTextContent("Image");
+    expect(items[1]).toHaveTextContent("Cakrasamvara Mandala");
+    expect(items[1]).toHaveTextContent("Image");
+  });
+
+  it("renders figures in horizontal orientation", () => {
+    renderHelper();
+    const links = screen.getAllByRole("link");
+    expect(links.length).toBe(2);
+    links.forEach((link, index) => {
+      expect(link.getAttribute("href")).toBe(
+        `/works/${sampleSearchShape[index].id}`
+      );
+    });
+  });
+
+  it("renders figures in horizontal orientation", () => {
+    renderHelper();
+    const figures = screen.getAllByRole("figure");
+    expect(figures.length).toBe(2);
+    figures.forEach((figure) => {
+      expect(figure.getAttribute("data-orientation")).toBe("horizontal");
+    });
+  });
+});

--- a/components/Facets/Filter/Preview.tsx
+++ b/components/Facets/Filter/Preview.tsx
@@ -1,20 +1,39 @@
+import { PreviewItem, PreviewList, StyledPreview } from "./Preview.styled";
+import Figure from "@/components/Figure/Figure";
+import Heading from "@/components/Heading/Heading";
+import Link from "next/link";
 import React from "react";
 import { SearchShape } from "@/types/api/response";
 
 interface PreviewProps {
-  data: SearchShape[];
+  items: SearchShape[];
 }
 
-const Preview: React.FC<PreviewProps> = ({ data }) => {
+const Preview: React.FC<PreviewProps> = ({ items }) => {
   return (
-    <div>
-      <p>[Preview]</p>
-      <ul>
-        {data.map((item) => (
-          <li key={item.id}>{item.accession_number}</li>
-        ))}
-      </ul>
-    </div>
+    <StyledPreview>
+      <Heading as="h3">Top Results</Heading>
+      <PreviewList>
+        {items.map((item) => {
+          return (
+            <PreviewItem key={item.id} data-testid="facets-filter-preview-item">
+              <Link href={`/works/${item.id}`}>
+                <a>
+                  <Figure
+                    data={{
+                      src: item.thumbnail,
+                      supplementalInfo: item.work_type_labels,
+                      title: item.title ? item.title : item.accession_number,
+                    }}
+                    orientation="horizontal"
+                  />
+                </a>
+              </Link>
+            </PreviewItem>
+          );
+        })}
+      </PreviewList>
+    </StyledPreview>
   );
 };
 

--- a/components/Figure/Figure.styled.ts
+++ b/components/Figure/Figure.styled.ts
@@ -7,10 +7,18 @@ const FigureStyled = styled("figure", {
   flexDirection: "column",
   paddingBottom: "1rem",
   margin: "0",
+  color: "transparent",
+
+  figcaption: { display: "flex", flexDirection: "column" },
+
+  [`&[data-orientation=horizontal]`]: {
+    flexDirection: "row",
+  },
 });
 
 const Image = styled("img", {
   backgroundColor: "$slate11",
+  width: "100%",
 });
 
 const SupplementalInfo = styled("span", {

--- a/components/Figure/Figure.tsx
+++ b/components/Figure/Figure.tsx
@@ -5,19 +5,23 @@ interface Figure {
   src: string;
   supplementalInfo?: string;
 }
+
 interface FigureProps {
   data: Figure;
+  orientation?: "horizontal" | "vertical";
 }
 
-const Figure: React.FC<FigureProps> = ({ data }) => {
+const Figure: React.FC<FigureProps> = ({ data, orientation = "vertical" }) => {
   const { title, supplementalInfo, src } = data;
   return (
-    <FigureStyled>
-      <Image src={src} style={{ width: "100%" }} alt={title} />
-      <Title>{title}</Title>
-      {supplementalInfo && (
-        <SupplementalInfo>{supplementalInfo}</SupplementalInfo>
-      )}
+    <FigureStyled data-orientation={orientation}>
+      <Image src={src} alt={title} />
+      <figcaption>
+        <Title>{title}</Title>
+        {supplementalInfo && (
+          <SupplementalInfo>{supplementalInfo}</SupplementalInfo>
+        )}
+      </figcaption>
     </FigureStyled>
   );
 };

--- a/components/Grid/Grid.tsx
+++ b/components/Grid/Grid.tsx
@@ -25,7 +25,7 @@ const Grid: React.FC<GridProps> = ({ data = [] }) => {
                   data={{
                     src: item.thumbnail,
                     supplementalInfo: item.work_type_labels,
-                    title: item.title,
+                    title: item.title ? item.title : item.accession_number,
                   }}
                 />
               </a>

--- a/mocks/sample-search-shape.ts
+++ b/mocks/sample-search-shape.ts
@@ -1,0 +1,22 @@
+import { SearchShape } from "@/types/api/response";
+
+export const sampleSearchShape: SearchShape[] = [
+  {
+    accession_number: "Voyager:RL03108",
+    api_model: "Work",
+    id: "4b0632df-07e4-4699-9510-1d96b715276e",
+    thumbnail:
+      "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/245eabab-7839-4e13-ab5a-e9d3243250fe/full/!300,300/0/default.jpg",
+    title: "",
+    work_type_labels: "Image",
+  },
+  {
+    accession_number: "Voyager:RL03538",
+    api_model: "Work",
+    id: "f292521f-4114-4d89-b477-403a697df2f8",
+    thumbnail:
+      "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/4c1c9ab6-72ed-42fa-b273-6acd0cf946dc/full/!300,300/0/default.jpg",
+    title: "Cakrasamvara Mandala",
+    work_type_labels: "Image",
+  },
+];


### PR DESCRIPTION
## What does this do?

This adds some basic styling to the Preview component on the search filter modal screen. 

- Some slight reworking of the Figure was completed to allow for horizontal orientation. This is completed by passing an optional `orientation` prop to figure and rendering that to the DOM as a data attribute on the `figure`.
- Items in the preview are also now clickable

![image](https://user-images.githubusercontent.com/7376450/170562513-47c2446a-8014-442c-9cc1-813640b2489b.png)

- Add baseline Preview styling.
- Add figcaption, orientation data attr.
- Style figures within preview.
- Add accession if title is missing.
- Add tests and mock search shape.
