### PR TITLE
Drive UI display by a IIIF manifest

### DIFF
--- a/components/Work/TopInfo.styled.ts
+++ b/components/Work/TopInfo.styled.ts
@@ -10,10 +10,16 @@ const ActionButtons = styled("div", {
 });
 
 const MetadataWrapper = styled("div", {
-  border: "3px dashed $black10",
-  height: "200px",
-  padding: "2rem",
-  width: "100%",
+  "& dt": {
+    fontSize: "0.75rem",
+    fontWeight: "bold",
+    paddingBottom: "0.5rem",
+    textTransform: "uppercase",
+  },
+  "& dd": {
+    marginInlineStart: "0",
+    paddingBottom: "1.25rem",
+  },
 });
 
 const TopInfoWrapper = styled("section", {

--- a/components/Work/TopInfo.test.tsx
+++ b/components/Work/TopInfo.test.tsx
@@ -1,32 +1,62 @@
-import { render, screen } from "@/test-utils";
+import { render, screen, within } from "@/test-utils";
 import WorkTopInfo from "@/components/Work/TopInfo";
+import { buildPres3Manifest } from "@/lib/iiif/manifest-helpers";
 import { sampleWork1 } from "@/mocks/sample-work1";
 
 describe("WorkTopInfo component", () => {
-  function renderHelper() {
-    return render(<WorkTopInfo work={sampleWork1} />);
+  async function renderHelper() {
+    const manifest = await buildPres3Manifest(sampleWork1);
+    return render(<WorkTopInfo manifest={manifest} work={sampleWork1} />);
   }
-  it("renders", () => {
-    renderHelper();
+
+  it("renders", async () => {
+    await renderHelper();
     expect(screen.getByTestId("work-top-info-wrapper"));
   });
 
-  it("renders title and description", () => {
-    renderHelper();
-    expect(screen.getByText(sampleWork1.title));
-    expect(screen.getByText(sampleWork1.descriptions[0]));
+  it("renders title and description", async () => {
+    await renderHelper();
+    expect(screen.getByTestId("title")).toHaveTextContent(sampleWork1.title);
+    expect(screen.getByTestId("summary")).toHaveTextContent(
+      sampleWork1.descriptions[0]
+    );
+    expect(screen.getByTestId("summary")).toHaveTextContent(
+      sampleWork1.descriptions[1]
+    );
   });
 
-  it("renders Action buttons", () => {
-    renderHelper();
+  it("renders Action buttons", async () => {
+    await renderHelper();
     expect(screen.getByText(/find this item/i));
     expect(screen.getByText(/cite this item/i));
     expect(screen.getByText(/download and share/i));
   });
 
-  // TODO: Flesh this out once we know if we're pulling from a IIIF Manifest
-  it("renders metadata", () => {
-    renderHelper();
-    expect(screen.getByTestId("metadata"));
+  it("renders metadata", async () => {
+    await renderHelper();
+    const metadataEl = screen.getByTestId("metadata");
+    expect(metadataEl);
+
+    /**
+     * Test Nectar is rendering out the right info
+     * We'll pick out a few to prove the point.  Once we know
+     * exactly what metadata we want displayed, we add
+     * that here to confirm
+     */
+    expect(
+      within(metadataEl).getByText("Date").nextElementSibling
+    ).toHaveTextContent("1971");
+
+    expect(
+      within(metadataEl).getByText(/Identifier/i).nextElementSibling
+    ).toHaveTextContent("MS 63");
+
+    expect(
+      within(metadataEl).getByText(/SUBJECTS/i).nextElementSibling
+    ).toHaveTextContent("Mexico--Cuernavaca, Mexicans");
+
+    expect(
+      within(metadataEl).getByText(/library unit/i).nextElementSibling
+    ).toHaveTextContent("University Archives");
   });
 });

--- a/components/Work/TopInfo.tsx
+++ b/components/Work/TopInfo.tsx
@@ -3,32 +3,38 @@ import {
   MetadataWrapper,
   TopInfoWrapper,
 } from "@/components//Work/TopInfo.styled";
+import {
+  Label,
+  Metadata,
+  RequiredStatement,
+  Summary,
+} from "@samvera/nectar-iiif";
 import { Button } from "@nulib/design-system";
 import Card from "@/components/Shared/Card";
+import { Manifest } from "@iiif/presentation-3";
 import { WorkShape } from "@/types/components/works";
 
 interface TopInfoProps {
+  manifest?: Manifest;
   work: WorkShape;
 }
-const WorkTopInfo: React.FC<TopInfoProps> = ({ work }) => {
+const WorkTopInfo: React.FC<TopInfoProps> = ({ manifest, work }) => {
   if (!work) return null;
+  if (!manifest) return <p>Error grabbing manifest</p>;
 
-  const { descriptions, title } = work;
   return (
     <TopInfoWrapper>
       <div data-testid="work-top-info-wrapper">
-        <h1>{title}</h1>
-        {descriptions.length === 0 && <p>No description exists</p>}
-        {descriptions.map((d) => (
-          <p key={d}>{d}</p>
-        ))}
+        <Label label={manifest.label} as="h1" data-testid="title" />
+        <Summary summary={manifest.summary} as="p" data-testid="summary" />
         <ActionButtons>
           <Button>Find this item</Button>
           <Button>Cite this item</Button>
           <Button>Download and share</Button>
         </ActionButtons>
         <MetadataWrapper>
-          <p data-testid="metadata">Metadata displays here</p>
+          <Metadata metadata={manifest.metadata} data-testid="metadata" />
+          <RequiredStatement requiredStatement={manifest.requiredStatement} />
         </MetadataWrapper>
       </div>
       <div>

--- a/lib/iiif/manifest-helpers.test.js
+++ b/lib/iiif/manifest-helpers.test.js
@@ -1,0 +1,23 @@
+import { buildPres3Manifest } from "@/lib/iiif/manifest-helpers";
+import { sampleWork1 } from "@/mocks/sample-work1";
+
+describe("Function to build Pres 3 manifests", () => {
+  it("successfully builds a manifest", async () => {
+    const { label, summary, metadata } = await buildPres3Manifest(sampleWork1);
+
+    expect(label).toEqual({
+      none: [sampleWork1.title],
+    });
+    expect(summary).toEqual({
+      none: sampleWork1.descriptions,
+    });
+    expect(metadata[0].label.none[0]).toEqual("Contributor");
+    expect(metadata[0].value.none[0]).toEqual("Roberts, James S.");
+
+    expect(metadata[1].label.none[0]).toEqual("Date");
+    expect(metadata[1].value.none[0]).toEqual("1971");
+
+    expect(metadata[2].label.none[0]).toEqual("Identifier");
+    expect(metadata[2].value.none[0]).toEqual("MS 63");
+  });
+});

--- a/lib/iiif/manifest-helpers.ts
+++ b/lib/iiif/manifest-helpers.ts
@@ -1,0 +1,71 @@
+import { Manifest } from "@iiif/presentation-3";
+import { WorkShape } from "@/types/components/works";
+import { getAPIData } from "@/lib/dc-api";
+import { manifestPres3Template } from "@/lib/iiif/manifest-pres3-template";
+
+interface MetadataInput {
+  label: string;
+  value: string[] | string;
+}
+export const buildMetadataValues = (metadata: MetadataInput[]) => {
+  return metadata.map(({ label, value }) => ({
+    label: {
+      none: [label],
+    },
+    value: {
+      none: Array.isArray(value) ? [...value] : [value],
+    },
+  }));
+};
+
+export const buildPres3Manifest = async (
+  work: WorkShape
+): Promise<Manifest | undefined> => {
+  const manifest = { ...manifestPres3Template };
+  try {
+    manifest.id = work.iiif_manifest;
+    manifest.label.none = [work.title];
+    manifest.summary &&
+      (manifest.summary.none = work.descriptions.map(
+        (description) => description
+      ));
+    manifest.metadata = buildMetadataValues([
+      {
+        label: "Contributor",
+        value: [...work.contributor_labels],
+      },
+      {
+        label: "Date",
+        value: [...work.dates_created],
+      },
+      {
+        label: "Identifier",
+        value: [...work.identifiers],
+      },
+      {
+        label: "Library Unit",
+        value: work.library_unit,
+      },
+      {
+        label: "Subjects",
+        value: [...work.subject_labels],
+      },
+      {
+        label: "Accession Number",
+        value: work.accession_number,
+      },
+      {
+        label: "Terms of Use",
+        value: work.terms_of_use,
+      },
+    ]);
+  } catch (err) {
+    throw new Error("Error building manifest locally");
+  }
+  return manifest;
+};
+
+export const getManifest = async (id: string) => {
+  const manifest = await getAPIData<Manifest>({ url: id });
+  return manifest;
+};

--- a/lib/iiif/manifest-pres3-template.ts
+++ b/lib/iiif/manifest-pres3-template.ts
@@ -1,0 +1,27 @@
+import { Manifest } from "@iiif/presentation-3";
+
+/* eslint sort-keys: 0 */
+
+export const manifestPres3Template: Manifest = {
+  "@context": "http://iiif.io/api/presentation/3/context.json",
+  id: "",
+  type: "Manifest",
+  label: {
+    none: [],
+  },
+  summary: {
+    none: [],
+  },
+  metadata: [],
+  requiredStatement: {
+    label: {
+      none: ["Attribution"],
+    },
+    value: {
+      none: ["Courtesy of Northwestern University Libraries"],
+    },
+  },
+  rights: "http://rightsstatements.org/vocab/NoC-NC/1.0/",
+  thumbnail: [],
+  items: [],
+};

--- a/mocks/sample-work1.ts
+++ b/mocks/sample-work1.ts
@@ -40,7 +40,7 @@ export const sampleWork1: WorkShape = {
   genre_labels: [],
   genre_variants: [],
   id: "c16029ff-d027-496a-98b7-6f259395a8f7",
-  identifiers: [],
+  identifiers: ["MS 63"],
   iiif_manifest:
     "https://iiif.stack.rdc-staging.library.northwestern.edu/public/c1/60/29/ff/-d/02/7-/49/6a/-9/8b/7-/6f/25/93/95/a8/f7-manifest.json",
   keywords: [],

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@radix-ui/react-radio-group": "^0.1.6-rc.20",
         "@radix-ui/react-tabs": "^0.1.6-rc.13",
         "@samvera/clover-iiif": "^1.10.1",
-        "@samvera/nectar-iiif": "^0.0.4-alpha.1",
+        "@samvera/nectar-iiif": "^0.0.12",
         "@stitches/react": "^1.2.6",
         "next": "^12.0.10",
         "react": "^18.0.0",
@@ -25,6 +25,7 @@
       },
       "devDependencies": {
         "@elastic/elasticsearch": "^7.17.0",
+        "@iiif/presentation-3": "^1.0.5",
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.0.0",
         "@testing-library/user-event": "^14.0.4",
@@ -721,9 +722,9 @@
       }
     },
     "node_modules/@iiif/presentation-3": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@iiif/presentation-3/-/presentation-3-1.0.4.tgz",
-      "integrity": "sha512-L5fPMyNAZ3UaDOR7D4mcv9Z1YJIqx9/nI9kaNcq3azLB4lp5w7cv7O1her3gjIPSH/mLCOuUG5KTBOfE/SgXUg==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@iiif/presentation-3/-/presentation-3-1.0.5.tgz",
+      "integrity": "sha512-hIfq8q0eC//l47TEniXxvb23+8zXZjNfhtbPgJHqTUgcvG9JsYnqjjzbhVMeLPSpzqjHNCImgcrLIGwLX5P0nA==",
       "dependencies": {
         "@types/geojson": "^7946.0.7"
       }
@@ -3335,50 +3336,15 @@
       }
     },
     "node_modules/@samvera/nectar-iiif": {
-      "version": "0.0.4-alpha.1",
-      "resolved": "https://registry.npmjs.org/@samvera/nectar-iiif/-/nectar-iiif-0.0.4-alpha.1.tgz",
-      "integrity": "sha512-qQzEHYtu7DrjM/FeOHDKWVJMKcac5M4AYxK9igeqznTIA87qy2lKDPpLIk0cHkfuhmkcuCDX1+YInt2+Lqv/Pw==",
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@samvera/nectar-iiif/-/nectar-iiif-0.0.12.tgz",
+      "integrity": "sha512-EtfBaZs/qjkUdfT2elSf4ZjZBjD47jdifyYzqnKvltRzPq+8yttgZRpre4e2bJGAv5z+2DQBf/Vmt1JRuAVcTg==",
       "dependencies": {
-        "@iiif/presentation-3": "^1.0.4",
         "@stitches/react": "^1.2.7",
-        "@types/react": "^17.0.0",
-        "@types/react-dom": "^17.0.0",
-        "react": "^17.0.2",
-        "react-dom": "^17.0.2"
-      }
-    },
-    "node_modules/@samvera/nectar-iiif/node_modules/react": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
-      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@samvera/nectar-iiif/node_modules/react-dom": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
-      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "scheduler": "^0.20.2"
-      },
-      "peerDependencies": {
-        "react": "17.0.2"
-      }
-    },
-    "node_modules/@samvera/nectar-iiif/node_modules/scheduler": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
-      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "dompurify": "^2.3.8",
+        "hls.js": "^1.1.5",
+        "react": "^16.8  || ^17.0 || ^18.0",
+        "react-dom": "^16.8  || ^17.0 || ^18.0"
       }
     },
     "node_modules/@sinonjs/commons": {
@@ -3641,12 +3607,14 @@
     "node_modules/@types/prop-types": {
       "version": "15.7.4",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
-      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
+      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==",
+      "devOptional": true
     },
     "node_modules/@types/react": {
       "version": "17.0.43",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.43.tgz",
       "integrity": "sha512-8Q+LNpdxf057brvPu1lMtC5Vn7J119xrP1aq4qiaefNioQUYANF/CYeK4NsKorSZyUGJ66g0IM+4bbjwx45o2A==",
+      "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -3657,6 +3625,7 @@
       "version": "17.0.14",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.14.tgz",
       "integrity": "sha512-H03xwEP1oXmSfl3iobtmQ/2dHF5aBHr8aUMwyGZya6OW45G+xtdzmq6HkncefiBt5JU8DVyaWl/nWZbjZCnzAQ==",
+      "dev": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -3673,7 +3642,8 @@
     "node_modules/@types/scheduler": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
+      "devOptional": true
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
@@ -4779,6 +4749,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dompurify": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.3.8.tgz",
+      "integrity": "sha512-eVhaWoVibIzqdGYjwsBWodIQIaXFSB+cKDf4cfxLMsK0xiud6SE+/WCVx/Xw/UwQsa4cS3T2eITcdtmTg2UKcw=="
     },
     "node_modules/electron-to-chromium": {
       "version": "1.4.106",
@@ -7581,6 +7556,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9774,9 +9750,9 @@
       "requires": {}
     },
     "@iiif/presentation-3": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@iiif/presentation-3/-/presentation-3-1.0.4.tgz",
-      "integrity": "sha512-L5fPMyNAZ3UaDOR7D4mcv9Z1YJIqx9/nI9kaNcq3azLB4lp5w7cv7O1her3gjIPSH/mLCOuUG5KTBOfE/SgXUg==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@iiif/presentation-3/-/presentation-3-1.0.5.tgz",
+      "integrity": "sha512-hIfq8q0eC//l47TEniXxvb23+8zXZjNfhtbPgJHqTUgcvG9JsYnqjjzbhVMeLPSpzqjHNCImgcrLIGwLX5P0nA==",
       "requires": {
         "@types/geojson": "^7946.0.7"
       }
@@ -11756,46 +11732,15 @@
       }
     },
     "@samvera/nectar-iiif": {
-      "version": "0.0.4-alpha.1",
-      "resolved": "https://registry.npmjs.org/@samvera/nectar-iiif/-/nectar-iiif-0.0.4-alpha.1.tgz",
-      "integrity": "sha512-qQzEHYtu7DrjM/FeOHDKWVJMKcac5M4AYxK9igeqznTIA87qy2lKDPpLIk0cHkfuhmkcuCDX1+YInt2+Lqv/Pw==",
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@samvera/nectar-iiif/-/nectar-iiif-0.0.12.tgz",
+      "integrity": "sha512-EtfBaZs/qjkUdfT2elSf4ZjZBjD47jdifyYzqnKvltRzPq+8yttgZRpre4e2bJGAv5z+2DQBf/Vmt1JRuAVcTg==",
       "requires": {
-        "@iiif/presentation-3": "^1.0.4",
         "@stitches/react": "^1.2.7",
-        "@types/react": "^17.0.0",
-        "@types/react-dom": "^17.0.0",
-        "react": "^17.0.2",
-        "react-dom": "^17.0.2"
-      },
-      "dependencies": {
-        "react": {
-          "version": "17.0.2",
-          "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
-          "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1"
-          }
-        },
-        "react-dom": {
-          "version": "17.0.2",
-          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
-          "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1",
-            "scheduler": "^0.20.2"
-          }
-        },
-        "scheduler": {
-          "version": "0.20.2",
-          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
-          "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1"
-          }
-        }
+        "dompurify": "^2.3.8",
+        "hls.js": "^1.1.5",
+        "react": "^16.8  || ^17.0 || ^18.0",
+        "react-dom": "^16.8  || ^17.0 || ^18.0"
       }
     },
     "@sinonjs/commons": {
@@ -12027,12 +11972,14 @@
     "@types/prop-types": {
       "version": "15.7.4",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
-      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
+      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==",
+      "devOptional": true
     },
     "@types/react": {
       "version": "17.0.43",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.43.tgz",
       "integrity": "sha512-8Q+LNpdxf057brvPu1lMtC5Vn7J119xrP1aq4qiaefNioQUYANF/CYeK4NsKorSZyUGJ66g0IM+4bbjwx45o2A==",
+      "devOptional": true,
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -12043,6 +11990,7 @@
       "version": "17.0.14",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.14.tgz",
       "integrity": "sha512-H03xwEP1oXmSfl3iobtmQ/2dHF5aBHr8aUMwyGZya6OW45G+xtdzmq6HkncefiBt5JU8DVyaWl/nWZbjZCnzAQ==",
+      "dev": true,
       "requires": {
         "@types/react": "*"
       }
@@ -12059,7 +12007,8 @@
     "@types/scheduler": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
-      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
+      "devOptional": true
     },
     "@types/stack-utils": {
       "version": "2.0.1",
@@ -12864,6 +12813,11 @@
           "dev": true
         }
       }
+    },
+    "dompurify": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.3.8.tgz",
+      "integrity": "sha512-eVhaWoVibIzqdGYjwsBWodIQIaXFSB+cKDf4cfxLMsK0xiud6SE+/WCVx/Xw/UwQsa4cS3T2eITcdtmTg2UKcw=="
     },
     "electron-to-chromium": {
       "version": "1.4.106",
@@ -14956,7 +14910,8 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "object-inspect": {
       "version": "1.12.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@radix-ui/react-radio-group": "^0.1.6-rc.20",
     "@radix-ui/react-tabs": "^0.1.6-rc.13",
     "@samvera/clover-iiif": "^1.10.1",
-    "@samvera/nectar-iiif": "^0.0.4-alpha.1",
+    "@samvera/nectar-iiif": "^0.0.12",
     "@stitches/react": "^1.2.6",
     "next": "^12.0.10",
     "react": "^18.0.0",
@@ -32,6 +32,7 @@
   },
   "devDependencies": {
     "@elastic/elasticsearch": "^7.17.0",
+    "@iiif/presentation-3": "^1.0.5",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.0.0",
     "@testing-library/user-event": "^14.0.4",

--- a/pages/works/[id].tsx
+++ b/pages/works/[id].tsx
@@ -4,24 +4,28 @@ import Container from "@/components/Shared/Container";
 import { ErrorBoundary } from "react-error-boundary";
 import ErrorFallback from "@/components/Shared/ErrorFallback";
 import Layout from "components/layout";
+import { Manifest } from "@iiif/presentation-3";
 import React from "react";
 import { WorkShape } from "@/types/components/works";
 import WorkTopInfo from "@/components/Work/TopInfo";
 import WorkViewerWrapper from "@/components/Work/ViewerWrapper";
+import { buildPres3Manifest } from "@/lib/iiif/manifest-helpers";
 
 interface WorkPageProps {
+  manifest?: Manifest;
   work: WorkShape;
 }
-const WorkPage: NextPage<WorkPageProps> = ({ work }) => {
+const WorkPage: NextPage<WorkPageProps> = ({ manifest, work }) => {
   if (!work) {
     return null;
   }
+
   return (
     <Layout>
       <ErrorBoundary FallbackComponent={ErrorFallback}>
         <WorkViewerWrapper manifestId={work.iiif_manifest} />
         <Container>
-          <WorkTopInfo work={work} />
+          <WorkTopInfo manifest={manifest} work={work} />
         </Container>
       </ErrorBoundary>
     </Layout>
@@ -39,9 +43,11 @@ export async function getStaticPaths() {
 }
 
 export async function getStaticProps({ params }: GetStaticPropsContext) {
-  const work = params?.id && (await getWork(params.id as string));
+  const work = params?.id ? await getWork(params.id as string) : undefined;
+  const manifest = work ? await buildPres3Manifest(work) : undefined;
+
   return {
-    props: { work },
+    props: { manifest, work },
     revalidate: 10, // In seconds
   };
 }

--- a/types/api/response.ts
+++ b/types/api/response.ts
@@ -41,7 +41,7 @@ export interface ApiResponseDataShape {
  * Response shape coming back from [API URL GOES HERE]/works/{id}
  */
 export interface ApiWorkResponse {
-  data: WorkShape;
+  data: WorkShape | undefined;
 }
 
 /**

--- a/types/declarations.d.ts
+++ b/types/declarations.d.ts
@@ -1,0 +1,7 @@
+/**
+ * Declare any modules here which don't have
+ * types exported with their package.  Without
+ * this, TypeScript complains.
+ */
+
+declare module "@samvera/nectar-iiif";


### PR DESCRIPTION
## What does this PR do?

In essence, it renders out UI based on data from a Work's IIIF Manifest rather than our API data.  

Since most of our manifests currently referenced in the API Work response contain little to no metadata, this PR implements a helper function which constructs a bare-bones IIIF Presentation 3 manifest.  This manifest object is then delivered to the Work page (at build time), maintaining the static page delivered to end users.

Next, this PR utilizes Nectar to easily display IIIF data on the page.  

![image](https://user-images.githubusercontent.com/3020266/170566851-d91970ee-6ab4-4435-8cb0-dc4ef4c50249.png)
