### PR TITLE
Add placeholder dialog windows for Work action buttons

### DIFF
--- a/components/Facets/Filter/Filter.styled.ts
+++ b/components/Facets/Filter/Filter.styled.ts
@@ -69,19 +69,6 @@ const FilterFloating = styled("div", {
 
 const FilterClose = styled(Dialog.Close, {});
 
-const FilterOverlay = styled(Dialog.Overlay, {
-  background: "rgba(0 0 0 / 0.618)",
-  position: "fixed",
-  top: 0,
-  left: 0,
-  right: 0,
-  bottom: 0,
-  display: "grid",
-  placeItems: "center",
-  overflowY: "auto",
-  zIndex: "1",
-});
-
 const FilterBodyInner = styled("div", {
   display: "flex",
   flexGrow: "1",
@@ -252,5 +239,4 @@ export {
   FilterFloating,
   FilterFooter,
   FilterHeader,
-  FilterOverlay,
 };

--- a/components/Facets/Filter/Filter.tsx
+++ b/components/Facets/Filter/Filter.tsx
@@ -3,9 +3,9 @@ import {
   FilterActivate,
   FilterContent,
   FilterFloating,
-  FilterOverlay,
 } from "@/components/Facets/Filter/Filter.styled";
 import { FilterProvider, useFilterState } from "@/context/filter-context";
+import { DialogOverlay } from "@/components/Shared/Dialog.styled";
 import FacetsCurrentUser from "@/components/Facets/UserFacets/UserFacets";
 import FilterModal from "@/components/Facets/Filter/Modal";
 import Icon from "@/components/Shared/Icon";
@@ -45,7 +45,7 @@ const DialogWrapper: React.FC = () => {
         <FacetsCurrentUser screen="search" />
       </FilterFloating>
       <Dialog.Portal>
-        <FilterOverlay />
+        <DialogOverlay />
         <FilterContent data-testid="modal-content">
           <FilterModal q={q} setIsModalOpen={setIsModalOpen} />
         </FilterContent>

--- a/components/Shared/Dialog.styled.ts
+++ b/components/Shared/Dialog.styled.ts
@@ -1,0 +1,109 @@
+import * as Dialog from "@radix-ui/react-dialog";
+import { styled } from "@/stitches.config";
+
+/* eslint sort-keys: 0 */
+
+const DialogClose = styled(Dialog.Close, {});
+
+const DialogOverlay = styled(Dialog.Overlay, {
+  background: "rgba(0 0 0 / 0.618)",
+  position: "fixed",
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+  display: "grid",
+  placeItems: "center",
+  overflowY: "auto",
+  zIndex: "1",
+});
+
+const DialogBody = styled("div", {
+  margin: "3.5rem 0 4.5rem",
+  maxHeight: "calc(100% - 8rem)",
+  minHeight: "calc(100% - 8rem)",
+  overflow: "scroll",
+  padding: "1rem",
+
+  "&:before": {
+    position: "absolute",
+    display: "block",
+    width: "100%",
+    height: "1px",
+    backgroundColor: "$black10",
+    margin: "-1rem 0 0 -1rem",
+  },
+});
+
+const DialogHeader = styled("header", {
+  position: "absolute",
+  top: "0",
+  padding: "1rem",
+  display: "flex",
+  width: "100%",
+  justifyContent: "space-between",
+  backgroundColor: "$white",
+
+  h2: {
+    fontSize: "1rem",
+    lineHeight: "1.5rem",
+    padding: "0",
+    margin: "0",
+    color: "$black50",
+  },
+
+  em: {
+    color: "$black80",
+    lineHeight: "1.5rem",
+    fontSize: "0.8333rem",
+  },
+
+  [`& ${DialogClose}`]: {
+    display: "flex",
+    height: "1.5rem",
+    width: "1.5rem",
+    justifyContent: "center",
+    textAlign: "center",
+    alignItems: "center",
+    cursor: "pointer",
+    backgroundColor: "transparent",
+    zIndex: "1",
+    border: "none",
+    borderRadius: "50%",
+    marginRight: "0.5rem",
+    fill: "$black50",
+    stroke: "$black50",
+    transition: "all 200ms ease-in-out",
+    flexShrink: "0",
+
+    svg: {
+      transition: "all 200ms ease-in-out",
+      fill: "inherit",
+      stroke: "inherit",
+    },
+  },
+});
+
+const DialogContent = styled(Dialog.Content, {
+  width: "calc(100vw - 20rem)",
+  height: "calc(100vh - 20rem)",
+  background: "white",
+  position: "fixed",
+  top: "10rem",
+  left: "10rem",
+  right: 0,
+  bottom: 0,
+  overflowY: "auto",
+  zIndex: "2",
+  borderRadius: "3px",
+  boxShadow: "5px 5px 11px #0002",
+
+  "@sm": {
+    width: "calc(100vw - 1rem)",
+    height: "calc(100vh - 1rem)",
+    top: "0.5rem",
+    left: "0.5rem",
+  },
+});
+
+export { DialogBody, DialogClose, DialogContent, DialogHeader, DialogOverlay };

--- a/components/Shared/Dialog.test.tsx
+++ b/components/Shared/Dialog.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from "@/test-utils";
+import SharedDialogComponent from "@/components/Shared/Dialog";
+
+const props = {
+  handleCloseClick: jest.fn(),
+  isOpen: true,
+  title: "Ima title",
+};
+
+describe("SharedDialog component", () => {
+  it("renders title and content", () => {
+    render(
+      <SharedDialogComponent {...props}>
+        <p>I am dialog content</p>
+      </SharedDialogComponent>
+    );
+    expect(screen.getByText("Ima title"));
+    expect(screen.getByText("I am dialog content"));
+  });
+});

--- a/components/Shared/Dialog.tsx
+++ b/components/Shared/Dialog.tsx
@@ -1,0 +1,47 @@
+import * as Dialog from "@radix-ui/react-dialog";
+import {
+  DialogBody,
+  DialogClose,
+  DialogContent,
+  DialogHeader,
+  DialogOverlay,
+} from "@/components/Shared/Dialog.styled";
+import { IconClear } from "@/components/Shared/SVG/Icons";
+import { ReactNode } from "react";
+
+interface SharedDialogProps {
+  children: ReactNode;
+  handleCloseClick: () => void;
+  isOpen: boolean;
+  title: string;
+}
+
+const SharedDialog: React.FC<SharedDialogProps> = ({
+  children,
+  handleCloseClick,
+  isOpen,
+  title,
+}) => {
+  return (
+    <Dialog.Root open={isOpen}>
+      <Dialog.Portal>
+        <DialogOverlay />
+        <DialogContent onInteractOutside={handleCloseClick}>
+          <DialogHeader>
+            <Dialog.Title>{title}</Dialog.Title>
+            <DialogClose
+              data-testid="facets-filter-close"
+              aria-label="Cancel"
+              onClick={handleCloseClick}
+            >
+              <IconClear />
+            </DialogClose>
+          </DialogHeader>
+          <DialogBody>{children}</DialogBody>
+        </DialogContent>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+};
+
+export default SharedDialog;

--- a/components/Work/ActionsDialog.tsx
+++ b/components/Work/ActionsDialog.tsx
@@ -1,0 +1,39 @@
+import { ActionsDialog } from "@/components/Work/TopInfo";
+import SharedDialog from "@/components/Shared/Dialog";
+
+interface WorkActionsDialogProps {
+  actionsDialog: ActionsDialog;
+  close: () => void;
+}
+
+const WorkActionsDialog: React.FC<WorkActionsDialogProps> = ({
+  actionsDialog: { activeDialog },
+  close,
+}) => {
+  function renderTitle() {
+    switch (activeDialog) {
+      case "CITE":
+        return "Cite this item";
+      case "FIND":
+        return "Find this item";
+      case "DOWNLOAD":
+        return "Download this item";
+      default:
+        return "";
+    }
+  }
+
+  return (
+    <SharedDialog
+      handleCloseClick={close}
+      isOpen={!!activeDialog}
+      title={renderTitle()}
+    >
+      {activeDialog === "CITE" && <>Cite content goes here</>}
+      {activeDialog === "FIND" && <>Find content goes here</>}
+      {activeDialog === "DOWNLOAD" && <>Download content goes here</>}
+    </SharedDialog>
+  );
+};
+
+export default WorkActionsDialog;

--- a/components/Work/TopInfo.styled.ts
+++ b/components/Work/TopInfo.styled.ts
@@ -7,6 +7,13 @@ const ActionButtons = styled("div", {
   flexDirection: "row",
   justifyContent: "space-around",
   padding: "1rem 0",
+
+  "@sm": {
+    flexDirection: "column",
+    "& button": {
+      marginRight: "0",
+    },
+  },
 });
 
 const MetadataWrapper = styled("div", {

--- a/components/Work/TopInfo.tsx
+++ b/components/Work/TopInfo.tsx
@@ -9,18 +9,47 @@ import {
   RequiredStatement,
   Summary,
 } from "@samvera/nectar-iiif";
+import React, { MouseEvent } from "react";
 import { Button } from "@nulib/design-system";
 import Card from "@/components/Shared/Card";
 import { Manifest } from "@iiif/presentation-3";
+import WorkActionsDialog from "@/components/Work/ActionsDialog";
 import { WorkShape } from "@/types/components/works";
 
 interface TopInfoProps {
   manifest?: Manifest;
   work: WorkShape;
 }
+
+export interface ActionsDialog {
+  activeDialog: "CITE" | "DOWNLOAD" | "FIND" | undefined;
+}
+
 const WorkTopInfo: React.FC<TopInfoProps> = ({ manifest, work }) => {
+  const [actionsDialog, setActionsDialog] = React.useState<ActionsDialog>({
+    activeDialog: undefined,
+  });
+
   if (!work) return null;
   if (!manifest) return <p>Error grabbing manifest</p>;
+
+  const handleActionsButtonClick = (e: MouseEvent<HTMLButtonElement>) => {
+    const button = e.target as HTMLButtonElement;
+
+    switch (button.name) {
+      case "cite":
+        setActionsDialog({ activeDialog: "CITE" });
+        break;
+      case "find":
+        setActionsDialog({ activeDialog: "FIND" });
+        break;
+      case "download":
+        setActionsDialog({ activeDialog: "DOWNLOAD" });
+        break;
+      default:
+        break;
+    }
+  };
 
   return (
     <TopInfoWrapper>
@@ -28,10 +57,22 @@ const WorkTopInfo: React.FC<TopInfoProps> = ({ manifest, work }) => {
         <Label label={manifest.label} as="h1" data-testid="title" />
         <Summary summary={manifest.summary} as="p" data-testid="summary" />
         <ActionButtons>
-          <Button>Find this item</Button>
-          <Button>Cite this item</Button>
-          <Button>Download and share</Button>
+          <Button name="find" onClick={handleActionsButtonClick}>
+            Find this item
+          </Button>
+          <Button name="cite" onClick={handleActionsButtonClick}>
+            Cite this item
+          </Button>
+          <Button name="download" onClick={handleActionsButtonClick}>
+            Download and share
+          </Button>
         </ActionButtons>
+
+        <WorkActionsDialog
+          actionsDialog={actionsDialog}
+          close={() => setActionsDialog({ activeDialog: undefined })}
+        />
+
         <MetadataWrapper>
           <Metadata metadata={manifest.metadata} data-testid="metadata" />
           <RequiredStatement requiredStatement={manifest.requiredStatement} />


### PR DESCRIPTION
## What does this do?
Adds very basic dialog stubs for the Work action buttons.

<img width="832" alt="image" src="https://user-images.githubusercontent.com/3020266/171948442-5aaee3e4-8346-424f-b4d5-58c80934056f.png">

<img width="1267" alt="image" src="https://user-images.githubusercontent.com/3020266/171948514-da75990a-e39f-4cb7-9c96-4122d88e8eab.png">


It pulls (and replaces) some styles already defined for the `Filter` modal component, for more generic use case.   Eventually we might want to further consolidate the two, but for now this gets us going.

