### PR TITLE
Add Bloom (IIIF Collection Slider) to work page

### DIFF
--- a/components/Shared/RelatedItems.test.tsx
+++ b/components/Shared/RelatedItems.test.tsx
@@ -1,0 +1,23 @@
+import RelatedItems, {
+  RelatedItemsProps,
+} from "@/components/Shared/RelatedItems";
+import { render, screen, waitFor } from "@/test-utils";
+
+const props: RelatedItemsProps = {
+  collections: ["http://localhost:3000/something.json"],
+  title: "Explore Further",
+};
+
+xdescribe("RelatedItems component", () => {
+  it("renders a wrapping element for Clover", async () => {
+    render(<RelatedItems {...props} />);
+    await waitFor(() => {
+      expect(screen.getByTestId("related-items")).toBeInTheDocument;
+    });
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent(
+        "Explore Further"
+      );
+    });
+  });
+});

--- a/components/Shared/RelatedItems.tsx
+++ b/components/Shared/RelatedItems.tsx
@@ -1,0 +1,25 @@
+import BloomIIIF from "@samvera/bloom-iiif";
+import { ErrorBoundary } from "react-error-boundary";
+import ErrorFallback from "@/components/Shared/ErrorFallback";
+
+export interface RelatedItemsProps {
+  collections?: string[];
+  title: string;
+}
+
+const RelatedItems: React.FC<RelatedItemsProps> = ({ collections, title }) => {
+  if (collections && collections.length === 0) return <></>;
+
+  return (
+    <section data-testid="related-items">
+      <h2>{title}</h2>
+      <ErrorBoundary FallbackComponent={ErrorFallback}>
+        {collections &&
+          collections.map((collectionId) => (
+            <BloomIIIF collectionId={collectionId} key={collectionId} />
+          ))}
+      </ErrorBoundary>
+    </section>
+  );
+};
+export default RelatedItems;

--- a/components/Work/ViewerWrapper.tsx
+++ b/components/Work/ViewerWrapper.tsx
@@ -1,9 +1,11 @@
 import React from "react";
 import dynamic from "next/dynamic";
 
-export const DynamicComponentWithNoSSR = dynamic(
+export const CloverIIIF: React.ComponentType<{ manifestId: string }> = dynamic(
   () => import("@samvera/clover-iiif"),
-  { ssr: false }
+  {
+    ssr: false,
+  }
 );
 
 interface WrapperProps {
@@ -13,7 +15,7 @@ interface WrapperProps {
 const WorkViewerWrapper: React.FC<WrapperProps> = ({ manifestId }) => {
   return (
     <section data-testid="work-viewer-wrapper">
-      {manifestId && <DynamicComponentWithNoSSR manifestId={manifestId} />}
+      {manifestId && <CloverIIIF manifestId={manifestId} />}
     </section>
   );
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@radix-ui/react-popover": "^0.1.7-rc.18",
         "@radix-ui/react-radio-group": "^0.1.6-rc.20",
         "@radix-ui/react-tabs": "^0.1.6-rc.13",
+        "@samvera/bloom-iiif": "^0.2.0",
         "@samvera/clover-iiif": "^1.10.1",
         "@samvera/nectar-iiif": "^0.0.14",
         "@stitches/react": "^1.2.6",
@@ -1557,6 +1558,19 @@
         "react-dom": "^16.8 || ^17.0 || ^18.0"
       }
     },
+    "node_modules/@radix-ui/react-aspect-ratio": {
+      "version": "0.1.5-rc.41",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-aspect-ratio/-/react-aspect-ratio-0.1.5-rc.41.tgz",
+      "integrity": "sha512-JtCP7blBIpwqX/TRujuKjsb0XG4EGfFonD6E8aeTy+Tw4TX6cJjEe8YGi9OtAvVGLPK0mFSXg1nWCx5AEGya2g==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-primitive": "0.1.5-rc.41"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      }
+    },
     "node_modules/@radix-ui/react-checkbox": {
       "version": "0.1.6-rc.41",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-0.1.6-rc.41.tgz",
@@ -2386,6 +2400,19 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.1.4.tgz",
       "integrity": "sha512-LwzQKA4vzIct1zNZzBmRKI9QuNpLgTQMEjsQLf3BXuGYb3QPTP4Yjf6mkdX+X1mYttZ808QpOwAzZjv28kq7DA==",
       "dev": true
+    },
+    "node_modules/@samvera/bloom-iiif": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@samvera/bloom-iiif/-/bloom-iiif-0.2.0.tgz",
+      "integrity": "sha512-dyWYEt/jqu66cbAxaUFwP33ZjYuANDe/57V0vHegQYgH2P5prargcwAnY0a2Pexsm10286r5ptRnzJE36eA82A==",
+      "dependencies": {
+        "@iiif/vault": "^0.9.18",
+        "@radix-ui/react-aspect-ratio": "^0.1.5-rc.41",
+        "@samvera/nectar-iiif": "^0.0.14",
+        "@stitches/react": "^1.2.8",
+        "react": "^16.13.1  || ^17 || ^18",
+        "react-dom": "^16.13.1  || ^17 || ^18"
+      }
     },
     "node_modules/@samvera/clover-iiif": {
       "version": "1.10.1",
@@ -10206,6 +10233,15 @@
         "@radix-ui/react-primitive": "0.1.5-rc.41"
       }
     },
+    "@radix-ui/react-aspect-ratio": {
+      "version": "0.1.5-rc.41",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-aspect-ratio/-/react-aspect-ratio-0.1.5-rc.41.tgz",
+      "integrity": "sha512-JtCP7blBIpwqX/TRujuKjsb0XG4EGfFonD6E8aeTy+Tw4TX6cJjEe8YGi9OtAvVGLPK0mFSXg1nWCx5AEGya2g==",
+      "requires": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/react-primitive": "0.1.5-rc.41"
+      }
+    },
     "@radix-ui/react-checkbox": {
       "version": "0.1.6-rc.41",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-checkbox/-/react-checkbox-0.1.6-rc.41.tgz",
@@ -10858,6 +10894,19 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.1.4.tgz",
       "integrity": "sha512-LwzQKA4vzIct1zNZzBmRKI9QuNpLgTQMEjsQLf3BXuGYb3QPTP4Yjf6mkdX+X1mYttZ808QpOwAzZjv28kq7DA==",
       "dev": true
+    },
+    "@samvera/bloom-iiif": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@samvera/bloom-iiif/-/bloom-iiif-0.2.0.tgz",
+      "integrity": "sha512-dyWYEt/jqu66cbAxaUFwP33ZjYuANDe/57V0vHegQYgH2P5prargcwAnY0a2Pexsm10286r5ptRnzJE36eA82A==",
+      "requires": {
+        "@iiif/vault": "^0.9.18",
+        "@radix-ui/react-aspect-ratio": "^0.1.5-rc.41",
+        "@samvera/nectar-iiif": "^0.0.14",
+        "@stitches/react": "^1.2.8",
+        "react": "^16.13.1  || ^17 || ^18",
+        "react-dom": "^16.13.1  || ^17 || ^18"
+      }
     },
     "@samvera/clover-iiif": {
       "version": "1.10.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@radix-ui/react-popover": "^0.1.7-rc.18",
     "@radix-ui/react-radio-group": "^0.1.6-rc.20",
     "@radix-ui/react-tabs": "^0.1.6-rc.13",
+    "@samvera/bloom-iiif": "^0.2.0",
     "@samvera/clover-iiif": "^1.10.1",
     "@samvera/nectar-iiif": "^0.0.14",
     "@stitches/react": "^1.2.6",

--- a/pages/works/[id].tsx
+++ b/pages/works/[id].tsx
@@ -6,6 +6,7 @@ import ErrorFallback from "@/components/Shared/ErrorFallback";
 import Layout from "components/layout";
 import { Manifest } from "@iiif/presentation-3";
 import React from "react";
+import RelatedItems from "@/components/Shared/RelatedItems";
 import { WorkShape } from "@/types/components/works";
 import WorkTopInfo from "@/components/Work/TopInfo";
 import WorkViewerWrapper from "@/components/Work/ViewerWrapper";
@@ -13,9 +14,11 @@ import { buildPres3Manifest } from "@/lib/iiif/manifest-helpers";
 
 interface WorkPageProps {
   manifest?: Manifest;
+  related?: string[];
   work: WorkShape;
 }
-const WorkPage: NextPage<WorkPageProps> = ({ manifest, work }) => {
+
+const WorkPage: NextPage<WorkPageProps> = ({ manifest, related, work }) => {
   return (
     <Layout>
       <ErrorBoundary FallbackComponent={ErrorFallback}>
@@ -24,6 +27,7 @@ const WorkPage: NextPage<WorkPageProps> = ({ manifest, work }) => {
             <WorkViewerWrapper manifestId={work.iiif_manifest} />
             <Container>
               <WorkTopInfo manifest={manifest} work={work} />
+              <RelatedItems collections={related} title="Explore Further" />
             </Container>
           </>
         )}
@@ -51,8 +55,16 @@ export async function getStaticProps({ params }: GetStaticPropsContext) {
   const work = params?.id ? await getWork(params.id as string) : null;
   const manifest = work ? await buildPres3Manifest(work) : null;
 
+  /**
+   * @todo: replace these hardcoded URIs with a method to get related collection URIs
+   */
+  const related = [
+    "http://localhost:3000/fixtures/iiif/collection/masks.json",
+    "http://localhost:3000/fixtures/iiif/collection/football.json",
+  ];
+
   return {
-    props: { manifest, work },
+    props: { manifest, related, work },
     revalidate: 10, // In seconds
   };
 }

--- a/public/fixtures/iiif/collection/football.json
+++ b/public/fixtures/iiif/collection/football.json
@@ -1,0 +1,233 @@
+{
+  "@context": ["http://iiif.io/api/presentation/3/context.json"],
+  "id": "http://localhost:3000/fixtures/iiif/collection/football.json",
+  "type": "Collection",
+  "label": {
+    "none": ["Athletic Department Football Films"]
+  },
+  "summary": {
+    "none": [
+      "Northwestern University football films dating between 1929 and 1984 with a gap for the period 1932–1934."
+    ]
+  },
+  "homepage": [
+    {
+      "id": "https://dc.library.northwestern.edu/collections/c373ecd2-2c45-45f2-9f9e-52dc244870bd",
+      "type": "Text",
+      "label": { "none": ["Commedia dell'Arte: The Masks of Antonio Fava"] },
+      "format": "text/html"
+    }
+  ],
+  "items": [
+    {
+      "id": "http://localhost:3000/fixtures/iiif/manifest/football/wisconsin-1937.json",
+      "type": "Manifest",
+      "label": { "none": ["Northwestern Football vs. Wisconsin, 1937"] },
+      "summary": { "none": ["Video"] },
+      "thumbnail": [
+        {
+          "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/posters/b287374d-c6eb-48bc-ad38-43533fe32926/full/200,/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "service": [
+            {
+              "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/posters/b287374d-c6eb-48bc-ad38-43533fe32926",
+              "profile": "http://iiif.io/api/image/2/level2.json",
+              "type": "ImageService2"
+            }
+          ],
+          "width": 200,
+          "height": 200
+        }
+      ],
+      "homepage": [
+        {
+          "id": "https://dc.library.northwestern.edu/items/4b193e9d-5326-4208-acf6-7da7e36baf2c",
+          "type": "Text",
+          "label": { "none": ["Northwestern Football vs. Wisconsin, 1937"] },
+          "format": "text/html"
+        }
+      ]
+    },
+    {
+      "id": "http://localhost:3000/fixtures/iiif/manifest/football/ohio-state-1963.json",
+      "type": "Manifest",
+      "label": { "none": ["Northwestern Football vs. Ohio State, 1963"] },
+      "summary": { "none": ["Video"] },
+      "thumbnail": [
+        {
+          "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/posters/df13396b-46e6-47e0-aa60-3b7a7b0585f4/full/200,/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "service": [
+            {
+              "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/posters/df13396b-46e6-47e0-aa60-3b7a7b0585f4",
+              "profile": "http://iiif.io/api/image/2/level2.json",
+              "type": "ImageService2"
+            }
+          ],
+          "width": 200,
+          "height": 200
+        }
+      ],
+      "homepage": [
+        {
+          "id": "https://dc.library.northwestern.edu/items/cf4e3336-1025-4f0f-a635-5364fdedf9d5",
+          "type": "Text",
+          "label": { "none": ["Northwestern Football vs. Ohio State, 1963"] },
+          "format": "text/html"
+        }
+      ]
+    },
+    {
+      "id": "https://iiif.stack.rdc.library.northwestern.edu/public/iiif3/ee/50/c5/57/-1/60/b-/42/e3/-9/35/3-/99/eb/83/ac/bd/8b-manifest.json",
+      "type": "Manifest",
+      "label": { "none": ["Northwestern Football vs. Wisconsin, 1973"] },
+      "summary": { "none": ["Video"] },
+      "thumbnail": [
+        {
+          "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/posters/d184195b-2a7a-4faa-8221-d6c761441d26/full/200,/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "service": [
+            {
+              "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/posters/d184195b-2a7a-4faa-8221-d6c761441d26",
+              "profile": "http://iiif.io/api/image/2/level2.json",
+              "type": "ImageService2"
+            }
+          ],
+          "width": 200,
+          "height": 200
+        }
+      ],
+      "homepage": [
+        {
+          "id": "https://dc.library.northwestern.edu/items/ee50c557-160b-42e3-9353-99eb83acbd8b",
+          "type": "Text",
+          "label": { "none": ["Northwestern Football vs. Wisconsin, 1973"] },
+          "format": "text/html"
+        }
+      ]
+    },
+    {
+      "id": "https://iiif.stack.rdc.library.northwestern.edu/public/iiif3/0c/a4/55/c5/-3/b5/f-/40/89/-a/21/9-/c1/c2/71/b5/b8/bc-manifest.json",
+      "type": "Manifest",
+      "label": { "none": ["Northwestern Football vs. Notre Dame, 1935"] },
+      "summary": { "none": ["Video"] },
+      "thumbnail": [
+        {
+          "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/posters/2a429d80-e696-470f-b88d-935cfb24b01d/full/200,/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "service": [
+            {
+              "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/posters/2a429d80-e696-470f-b88d-935cfb24b01d",
+              "profile": "http://iiif.io/api/image/2/level2.json",
+              "type": "ImageService2"
+            }
+          ],
+          "width": 200,
+          "height": 200
+        }
+      ],
+      "homepage": [
+        {
+          "id": "https://dc.library.northwestern.edu/items/0ca455c5-3b5f-4089-a219-c1c271b5b8bc",
+          "type": "Text",
+          "label": { "none": ["Northwestern Football vs. Notre Dame, 1935"] },
+          "format": "text/html"
+        }
+      ]
+    },
+    {
+      "id": "https://iiif.stack.rdc.library.northwestern.edu/public/iiif3/2d/cb/09/a7/-5/db/c-/44/a9/-b/40/7-/4d/8a/dc/d2/0e/12-manifest.json",
+      "type": "Manifest",
+      "label": { "none": ["Northwestern Football vs. Purdue, 1931"] },
+      "summary": { "none": ["Video"] },
+      "thumbnail": [
+        {
+          "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/posters/49668e48-8d55-4e33-a6be-adc8a44edd74/full/200,/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "service": [
+            {
+              "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/posters/49668e48-8d55-4e33-a6be-adc8a44edd74",
+              "profile": "http://iiif.io/api/image/2/level2.json",
+              "type": "ImageService2"
+            }
+          ],
+          "width": 200,
+          "height": 200
+        }
+      ],
+      "homepage": [
+        {
+          "id": "https://dc.library.northwestern.edu/items/2dcb09a7-5dbc-44a9-b407-4d8adcd20e12",
+          "type": "Text",
+          "label": { "none": ["Northwestern Football vs. Purdue, 1931"] },
+          "format": "text/html"
+        }
+      ]
+    },
+    {
+      "id": "https://iiif.stack.rdc.library.northwestern.edu/public/iiif3/1b/58/2d/e6/-3/95/8-/4f/f8/-9/d3/c-/98/98/3a/83/4a/93-manifest.json",
+      "type": "Manifest",
+      "label": { "none": ["Northwestern Football vs. Iowa, 1976"] },
+      "summary": { "none": ["Video"] },
+      "thumbnail": [
+        {
+          "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/posters/2c5b2a7c-cf15-4bc0-b181-bc909f17fefa/full/200,/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "service": [
+            {
+              "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/posters/2c5b2a7c-cf15-4bc0-b181-bc909f17fefa",
+              "profile": "http://iiif.io/api/image/2/level2.json",
+              "type": "ImageService2"
+            }
+          ],
+          "width": 200,
+          "height": 200
+        }
+      ],
+      "homepage": [
+        {
+          "id": "https://dc.library.northwestern.edu/items/1b582de6-3958-4ff8-9d3c-98983a834a93",
+          "type": "Text",
+          "label": { "none": ["Northwestern Football vs. Iowa, 1976"] },
+          "format": "text/html"
+        }
+      ]
+    },
+    {
+      "id": "https://iiif.stack.rdc.library.northwestern.edu/public/iiif3/74/aa/4b/9c/-e/60/d-/48/0a/-a/e3/5-/5e/1a/90/c9/57/d8-manifest.json",
+      "type": "Manifest",
+      "label": { "none": ["Northwestern Football vs. Michigan, 1987"] },
+      "summary": { "none": ["Video"] },
+      "thumbnail": [
+        {
+          "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/posters/ccf35071-c43a-42b1-bac7-7cec3a7f8de0/full/200,/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "service": [
+            {
+              "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/posters/ccf35071-c43a-42b1-bac7-7cec3a7f8de0",
+              "profile": "http://iiif.io/api/image/2/level2.json",
+              "type": "ImageService2"
+            }
+          ],
+          "width": 200,
+          "height": 200
+        }
+      ],
+      "homepage": [
+        {
+          "id": "https://dc.library.northwestern.edu/items/74aa4b9c-e60d-480a-ae35-5e1a90c957d8",
+          "type": "Text",
+          "label": { "none": ["Northwestern Football vs. Michigan, 1987"] },
+          "format": "text/html"
+        }
+      ]
+    }
+  ]
+}

--- a/public/fixtures/iiif/collection/masks.json
+++ b/public/fixtures/iiif/collection/masks.json
@@ -1,0 +1,293 @@
+{
+  "@context": ["http://iiif.io/api/presentation/3/context.json"],
+  "id": "http://localhost:3000/fixtures/iiif/collection/masks.json",
+  "type": "Collection",
+  "label": {
+    "none": ["Commedia dell'Arte: The Masks of Antonio Fava"]
+  },
+  "summary": {
+    "none": [
+      "The Commedia dell'Arte, the famous improvisational theatre style born in Renaissance Italy, remains a major influence in today's theatre. Antonio Fava is an actor, comedian, author, director, musician, mask maker and Internationally renowned Maestro of Commedia dell'Arte."
+    ]
+  },
+  "homepage": [
+    {
+      "id": "https://dc.library.northwestern.edu/collections/c373ecd2-2c45-45f2-9f9e-52dc244870bd",
+      "type": "Text",
+      "label": { "none": ["Commedia dell'Arte: The Masks of Antonio Fava"] },
+      "format": "text/html"
+    }
+  ],
+  "items": [
+    {
+      "id": "https://iiif.stack.rdc.library.northwestern.edu/public/72/98/fd/ce/-a/dc/1-/45/01/-9/e1/4-/9e/8b/d9/85/e1/49-manifest.json",
+      "type": "Manifest",
+      "label": { "none": ["Pantalone classico"] },
+      "summary": { "none": ["Image"] },
+      "thumbnail": [
+        {
+          "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/180682c9-dfaf-4881-b7b6-1f2f21092d4f/full/200,/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "service": [
+            {
+              "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/180682c9-dfaf-4881-b7b6-1f2f21092d4f",
+              "profile": "http://iiif.io/api/image/2/level2.json",
+              "type": "ImageService2"
+            }
+          ],
+          "width": 200,
+          "height": 200
+        }
+      ],
+      "homepage": [
+        {
+          "id": "https://dc.library.northwestern.edu/items/7298fdce-adc1-4501-9e14-9e8bd985e149",
+          "type": "Text",
+          "label": { "none": ["Pantalone classico"] },
+          "format": "text/html"
+        }
+      ]
+    },
+    {
+      "id": "https://iiif.stack.rdc.library.northwestern.edu/public/a0/37/a4/fb/-a/dd/4-/40/af/-8/ad/d-/9a/02/e5/57/34/71-manifest.json",
+      "type": "Manifest",
+      "label": { "none": ["Francatrippa"] },
+      "summary": { "none": ["Image"] },
+      "thumbnail": [
+        {
+          "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/42d07b28-083e-4dfb-a3e9-88f2dfc3a571/full/200,/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "service": [
+            {
+              "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/42d07b28-083e-4dfb-a3e9-88f2dfc3a571",
+              "profile": "http://iiif.io/api/image/2/level2.json",
+              "type": "ImageService2"
+            }
+          ],
+          "width": 200,
+          "height": 200
+        }
+      ],
+      "homepage": [
+        {
+          "id": "https://dc.library.northwestern.edu/items/a037a4fb-add4-40af-8add-9a02e5573471",
+          "type": "Text",
+          "label": { "none": ["Francatrippa"] },
+          "format": "text/html"
+        }
+      ]
+    },
+    {
+      "id": "https://iiif.stack.rdc.library.northwestern.edu/public/05/2b/b6/f0/-b/6f/5-/45/90/-9/51/b-/ff/df/49/ff/af/03-manifest.json",
+      "type": "Manifest",
+      "label": { "none": ["Pulcinella \"Stronzo\" o \"Arcigno\""] },
+      "summary": { "none": ["Image"] },
+      "thumbnail": [
+        {
+          "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/0d3531f0-2d7f-4e53-bb07-8019f94e44da/full/200,/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "service": [
+            {
+              "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/0d3531f0-2d7f-4e53-bb07-8019f94e44da",
+              "profile": "http://iiif.io/api/image/2/level2.json",
+              "type": "ImageService2"
+            }
+          ],
+          "width": 200,
+          "height": 200
+        }
+      ],
+      "homepage": [
+        {
+          "id": "https://dc.library.northwestern.edu/items/052bb6f0-b6f5-4590-951b-ffdf49ffaf03",
+          "type": "Text",
+          "label": { "none": ["Pulcinella \"Stronzo\" o \"Arcigno\""] },
+          "format": "text/html"
+        }
+      ]
+    },
+    {
+      "id": "https://iiif.stack.rdc.library.northwestern.edu/public/71/15/33/79/-4/28/3-/43/be/-8/b0/f-/4e/7e/3b/fd/a2/75-manifest.json",
+      "type": "Manifest",
+      "label": { "none": ["Zagna \"lunga\""] },
+      "summary": { "none": ["Image"] },
+      "thumbnail": [
+        {
+          "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/44d0ad4d-6a0d-4632-82a3-b6ab8fd4e5b7/full/200,/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "service": [
+            {
+              "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/44d0ad4d-6a0d-4632-82a3-b6ab8fd4e5b7",
+              "profile": "http://iiif.io/api/image/2/level2.json",
+              "type": "ImageService2"
+            }
+          ],
+          "width": 200,
+          "height": 200
+        }
+      ],
+      "homepage": [
+        {
+          "id": "https://dc.library.northwestern.edu/items/71153379-4283-43be-8b0f-4e7e3bfda275",
+          "type": "Text",
+          "label": { "none": ["Zagna \"lunga\""] },
+          "format": "text/html"
+        }
+      ]
+    },
+    {
+      "id": "https://iiif.stack.rdc.library.northwestern.edu/public/8b/04/ee/13/-e/69/6-/4b/eb/-8/a3/3-/a9/d1/1c/de/e5/9b-manifest.json",
+      "type": "Manifest",
+      "label": { "none": ["Grande Zanni"] },
+      "summary": { "none": ["Image"] },
+      "thumbnail": [
+        {
+          "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/04f87867-903f-465f-81b8-c41a1d6957fa/full/200,/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "service": [
+            {
+              "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/04f87867-903f-465f-81b8-c41a1d6957fa",
+              "profile": "http://iiif.io/api/image/2/level2.json",
+              "type": "ImageService2"
+            }
+          ],
+          "width": 200,
+          "height": 200
+        }
+      ],
+      "homepage": [
+        {
+          "id": "https://dc.library.northwestern.edu/items/8b04ee13-e696-4beb-8a33-a9d11cdee59b",
+          "type": "Text",
+          "label": { "none": ["Grande Zanni"] },
+          "format": "text/html"
+        }
+      ]
+    },
+    {
+      "id": "https://iiif.stack.rdc.library.northwestern.edu/public/a3/c6/40/28/-d/1d/c-/4e/97/-8/2b/b-/1e/23/af/95/f5/e3-manifest.json",
+      "type": "Manifest",
+      "label": { "none": ["Bravazzo"] },
+      "summary": { "none": ["Image"] },
+      "thumbnail": [
+        {
+          "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/38062d63-cbf3-421f-ba74-49081beb2ff6/full/200,/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "service": [
+            {
+              "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/38062d63-cbf3-421f-ba74-49081beb2ff6",
+              "profile": "http://iiif.io/api/image/2/level2.json",
+              "type": "ImageService2"
+            }
+          ],
+          "width": 200,
+          "height": 200
+        }
+      ],
+      "homepage": [
+        {
+          "id": "https://dc.library.northwestern.edu/items/a3c64028-d1dc-4e97-82bb-1e23af95f5e3",
+          "type": "Text",
+          "label": { "none": ["Bravazzo"] },
+          "format": "text/html"
+        }
+      ]
+    },
+    {
+      "id": "https://iiif.stack.rdc.library.northwestern.edu/public/eb/b4/94/ad/-1/d5/6-/4a/d4/-9/77/2-/f2/28/06/7d/5a/79-manifest.json",
+      "type": "Manifest",
+      "label": { "none": ["Arlecchino \"Scimmia\""] },
+      "summary": { "none": ["Image"] },
+      "thumbnail": [
+        {
+          "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/47ba6136-4c7f-48a5-9bfb-11c2f86026f8/full/200,/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "service": [
+            {
+              "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/47ba6136-4c7f-48a5-9bfb-11c2f86026f8",
+              "profile": "http://iiif.io/api/image/2/level2.json",
+              "type": "ImageService2"
+            }
+          ],
+          "width": 200,
+          "height": 200
+        }
+      ],
+      "homepage": [
+        {
+          "id": "https://dc.library.northwestern.edu/items/ebb494ad-1d56-4ad4-9772-f228067d5a79",
+          "type": "Text",
+          "label": { "none": ["Arlecchino \"Scimmia\""] },
+          "format": "text/html"
+        }
+      ]
+    },
+    {
+      "id": "https://iiif.stack.rdc.library.northwestern.edu/public/2d/e0/35/5c/-8/e4/8-/44/78/-9/3a/f-/8c/bd/14/37/bd/16-manifest.json",
+      "type": "Manifest",
+      "label": { "none": ["Pulcinella \"tiepolano\""] },
+      "summary": { "none": ["Image"] },
+      "thumbnail": [
+        {
+          "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/3d42aceb-73ad-44cc-817e-459993a50be6/full/200,/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "service": [
+            {
+              "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/3d42aceb-73ad-44cc-817e-459993a50be6",
+              "profile": "http://iiif.io/api/image/2/level2.json",
+              "type": "ImageService2"
+            }
+          ],
+          "width": 200,
+          "height": 200
+        }
+      ],
+      "homepage": [
+        {
+          "id": "https://dc.library.northwestern.edu/items/2de0355c-8e48-4478-93af-8cbd1437bd16",
+          "type": "Text",
+          "label": { "none": ["Pulcinella \"tiepolano\""] },
+          "format": "text/html"
+        }
+      ]
+    },
+    {
+      "id": "https://iiif.stack.rdc.library.northwestern.edu/public/f9/12/a5/81/-d/9e/8-/43/d6/-a/7c/8-/a8/d4/6e/ff/75/17-manifest.json",
+      "type": "Manifest",
+      "label": { "none": ["Dottor Plus Quam Perfectus"] },
+      "summary": { "none": ["Image"] },
+      "thumbnail": [
+        {
+          "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/156b56cf-fcc5-457c-86cc-5f806b7c280a/full/200,/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "service": [
+            {
+              "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/156b56cf-fcc5-457c-86cc-5f806b7c280a",
+              "profile": "http://iiif.io/api/image/2/level2.json",
+              "type": "ImageService2"
+            }
+          ],
+          "width": 200,
+          "height": 200
+        }
+      ],
+      "homepage": [
+        {
+          "id": "https://dc.library.northwestern.edu/items/f912a581-d9e8-43d6-a7c8-a8d46eff7517",
+          "type": "Text",
+          "label": { "none": ["Dottor Plus Quam Perfectus"] },
+          "format": "text/html"
+        }
+      ]
+    }
+  ]
+}

--- a/public/fixtures/iiif/manifest/ohio-state-1937.json
+++ b/public/fixtures/iiif/manifest/ohio-state-1937.json
@@ -1,0 +1,213 @@
+{
+  "id": "http://localhost:3000/fixtures/iiif/manifest/ohio-state-1937.json",
+  "items": [
+    {
+      "annotations": [
+        {
+          "id": "https://iiif.stack.rdc.library.northwestern.edu/public/iiif3/cf/4e/33/36/-1/02/5-/4f/0f/-a/63/5-/53/64/fd/ed/f9/d5-manifest.json/canvas/df13396b-46e6-47e0-aa60-3b7a7b0585f4/annotation_page/a1",
+          "items": [
+            {
+              "body": {
+                "format": "text/vtt",
+                "id": "https://iiif.stack.rdc.library.northwestern.edu/public/vtt/df/13/39/6b/-4/6e/6-/47/e0/-a/a6/0-/3b/7a/7b/05/85/f4/df13396b-46e6-47e0-aa60-3b7a7b0585f4.vtt",
+                "label": {
+                  "en": ["Chapters"]
+                },
+                "language": "en",
+                "type": "Text"
+              },
+              "id": "https://iiif.stack.rdc.library.northwestern.edu/public/iiif3/cf/4e/33/36/-1/02/5-/4f/0f/-a/63/5-/53/64/fd/ed/f9/d5-manifest.json/canvas/df13396b-46e6-47e0-aa60-3b7a7b0585f4/annotation_page/1/annotation/2",
+              "motivation": "supplementing",
+              "target": "https://iiif.stack.rdc.library.northwestern.edu/public/iiif3/cf/4e/33/36/-1/02/5-/4f/0f/-a/63/5-/53/64/fd/ed/f9/d5-manifest.json/canvas/df13396b-46e6-47e0-aa60-3b7a7b0585f4",
+              "type": "Annotation"
+            }
+          ],
+          "type": "AnnotationPage"
+        }
+      ],
+      "duration": 791.125,
+      "height": 480,
+      "id": "https://iiif.stack.rdc.library.northwestern.edu/public/iiif3/cf/4e/33/36/-1/02/5-/4f/0f/-a/63/5-/53/64/fd/ed/f9/d5-manifest.json/canvas/df13396b-46e6-47e0-aa60-3b7a7b0585f4",
+      "items": [
+        {
+          "id": "https://iiif.stack.rdc.library.northwestern.edu/public/iiif3/cf/4e/33/36/-1/02/5-/4f/0f/-a/63/5-/53/64/fd/ed/f9/d5-manifest.json/canvas/df13396b-46e6-47e0-aa60-3b7a7b0585f4/annotation_page/1",
+          "items": [
+            {
+              "body": {
+                "duration": 791.125,
+                "format": "video/mp4",
+                "height": 1536,
+                "id": "https://meadow-streaming.rdc.library.northwestern.edu/df/13/39/6b/-4/6e/6-/47/e0/-a/a6/0-/3b/7a/7b/05/85/f4/inu-fball_ac_1963_ohio-offense-r1.mov.m3u8",
+                "type": "Video",
+                "width": 2048
+              },
+              "id": "https://iiif.stack.rdc.library.northwestern.edu/public/iiif3/cf/4e/33/36/-1/02/5-/4f/0f/-a/63/5-/53/64/fd/ed/f9/d5-manifest.json/canvas/df13396b-46e6-47e0-aa60-3b7a7b0585f4/annotation_page/1/annotation/1",
+              "motivation": "painting",
+              "target": "https://iiif.stack.rdc.library.northwestern.edu/public/iiif3/cf/4e/33/36/-1/02/5-/4f/0f/-a/63/5-/53/64/fd/ed/f9/d5-manifest.json/canvas/df13396b-46e6-47e0-aa60-3b7a7b0585f4",
+              "type": "Annotation"
+            }
+          ],
+          "type": "AnnotationPage"
+        }
+      ],
+      "label": {
+        "en": ["First half offense"]
+      },
+      "thumbnail": [
+        {
+          "format": "image/jpeg",
+          "height": 300,
+          "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/posters/df13396b-46e6-47e0-aa60-3b7a7b0585f4/full/!300,300/0/default.jpg",
+          "service": [
+            {
+              "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/posters/df13396b-46e6-47e0-aa60-3b7a7b0585f4",
+              "profile": "http://iiif.io/api/image/2/level2.json",
+              "type": "ImageService2"
+            }
+          ],
+          "type": "Image",
+          "width": 300
+        },
+        {
+          "duration": 30,
+          "format": "video/mp4",
+          "height": 1536,
+          "id": "https://meadow-streaming.rdc.library.northwestern.edu/df/13/39/6b/-4/6e/6-/47/e0/-a/a6/0-/3b/7a/7b/05/85/f4/inu-fball_ac_1963_ohio-offense-r1.mov.m3u8#t=100,130",
+          "type": "Video",
+          "width": 2048
+        }
+      ],
+      "type": "Canvas",
+      "width": 640
+    },
+    {
+      "duration": 470.792,
+      "height": 480,
+      "id": "https://iiif.stack.rdc.library.northwestern.edu/public/iiif3/cf/4e/33/36/-1/02/5-/4f/0f/-a/63/5-/53/64/fd/ed/f9/d5-manifest.json/canvas/ddf29a36-3b5a-4685-a670-451cfc753fde",
+      "items": [
+        {
+          "id": "https://iiif.stack.rdc.library.northwestern.edu/public/iiif3/cf/4e/33/36/-1/02/5-/4f/0f/-a/63/5-/53/64/fd/ed/f9/d5-manifest.json/canvas/ddf29a36-3b5a-4685-a670-451cfc753fde/annotation_page/1",
+          "items": [
+            {
+              "body": {
+                "duration": 470.792,
+                "format": "video/mp4",
+                "height": 1536,
+                "id": "https://meadow-streaming.rdc.library.northwestern.edu/dd/f2/9a/36/-3/b5/a-/46/85/-a/67/0-/45/1c/fc/75/3f/de/inu-fball_ac_1963_ohio-defense-r1.mov.m3u8",
+                "type": "Video",
+                "width": 2048
+              },
+              "id": "https://iiif.stack.rdc.library.northwestern.edu/public/iiif3/cf/4e/33/36/-1/02/5-/4f/0f/-a/63/5-/53/64/fd/ed/f9/d5-manifest.json/canvas/ddf29a36-3b5a-4685-a670-451cfc753fde/annotation_page/1/annotation/1",
+              "motivation": "painting",
+              "target": "https://iiif.stack.rdc.library.northwestern.edu/public/iiif3/cf/4e/33/36/-1/02/5-/4f/0f/-a/63/5-/53/64/fd/ed/f9/d5-manifest.json/canvas/ddf29a36-3b5a-4685-a670-451cfc753fde",
+              "type": "Annotation"
+            }
+          ],
+          "type": "AnnotationPage"
+        }
+      ],
+      "label": {
+        "en": ["First half defense"]
+      },
+      "thumbnail": [
+        {
+          "format": "image/jpeg",
+          "height": 300,
+          "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/posters/ddf29a36-3b5a-4685-a670-451cfc753fde/full/!300,300/0/default.jpg",
+          "service": [
+            {
+              "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/posters/ddf29a36-3b5a-4685-a670-451cfc753fde",
+              "profile": "http://iiif.io/api/image/2/level2.json",
+              "type": "ImageService2"
+            }
+          ],
+          "type": "Image",
+          "width": 300
+        },
+        {
+          "duration": 30,
+          "format": "video/mp4",
+          "height": 1536,
+          "id": "https://meadow-streaming.rdc.library.northwestern.edu/dd/f2/9a/36/-3/b5/a-/46/85/-a/67/0-/45/1c/fc/75/3f/de/inu-fball_ac_1963_ohio-defense-r1.mov.m3u8#t=100,130",
+          "type": "Video",
+          "width": 2048
+        }
+      ],
+      "type": "Canvas",
+      "width": 640
+    },
+    {
+      "duration": 546.709,
+      "height": 480,
+      "id": "https://iiif.stack.rdc.library.northwestern.edu/public/iiif3/cf/4e/33/36/-1/02/5-/4f/0f/-a/63/5-/53/64/fd/ed/f9/d5-manifest.json/canvas/70602b4e-ec3a-43ad-ad51-dd04c4e665ec",
+      "items": [
+        {
+          "id": "https://iiif.stack.rdc.library.northwestern.edu/public/iiif3/cf/4e/33/36/-1/02/5-/4f/0f/-a/63/5-/53/64/fd/ed/f9/d5-manifest.json/canvas/70602b4e-ec3a-43ad-ad51-dd04c4e665ec/annotation_page/1",
+          "items": [
+            {
+              "body": {
+                "duration": 546.709,
+                "format": "video/mp4",
+                "height": 1536,
+                "id": "https://meadow-streaming.rdc.library.northwestern.edu/70/60/2b/4e/-e/c3/a-/43/ad/-a/d5/1-/dd/04/c4/e6/65/ec/inu-fball_ac_1963_ohio-offense-r2.mov.m3u8",
+                "type": "Video",
+                "width": 2048
+              },
+              "id": "https://iiif.stack.rdc.library.northwestern.edu/public/iiif3/cf/4e/33/36/-1/02/5-/4f/0f/-a/63/5-/53/64/fd/ed/f9/d5-manifest.json/canvas/70602b4e-ec3a-43ad-ad51-dd04c4e665ec/annotation_page/1/annotation/1",
+              "motivation": "painting",
+              "target": "https://iiif.stack.rdc.library.northwestern.edu/public/iiif3/cf/4e/33/36/-1/02/5-/4f/0f/-a/63/5-/53/64/fd/ed/f9/d5-manifest.json/canvas/70602b4e-ec3a-43ad-ad51-dd04c4e665ec",
+              "type": "Annotation"
+            }
+          ],
+          "type": "AnnotationPage"
+        }
+      ],
+      "label": {
+        "en": ["Second half offense"]
+      },
+      "thumbnail": [
+        {
+          "format": "image/jpeg",
+          "height": 300,
+          "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/posters/70602b4e-ec3a-43ad-ad51-dd04c4e665ec/full/!300,300/0/default.jpg",
+          "service": [
+            {
+              "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/posters/70602b4e-ec3a-43ad-ad51-dd04c4e665ec",
+              "profile": "http://iiif.io/api/image/2/level2.json",
+              "type": "ImageService2"
+            }
+          ],
+          "type": "Image",
+          "width": 300
+        },
+        {
+          "duration": 30,
+          "format": "video/mp4",
+          "height": 1536,
+          "id": "https://meadow-streaming.rdc.library.northwestern.edu/70/60/2b/4e/-e/c3/a-/43/ad/-a/d5/1-/dd/04/c4/e6/65/ec/inu-fball_ac_1963_ohio-offense-r2.mov.m3u8#t=100,130",
+          "type": "Video",
+          "width": 2048
+        }
+      ],
+      "type": "Canvas",
+      "width": 640
+    }
+  ],
+  "label": {
+    "en": ["Northwestern Football vs. Ohio State, 1963"]
+  },
+  "requiredStatement": {
+    "label": {
+      "en": ["Attribution"]
+    },
+    "value": {
+      "en": ["Courtesy of Northwestern University Libraries"]
+    }
+  },
+  "rights": "http://rightsstatements.org/vocab/InC-EDU/1.0/",
+  "summary": {
+    "en": ["Final score, NU: 17, Ohio State: 8. Coach: Ara Parseghian."]
+  },
+  "type": "Manifest",
+  "@context": "http://iiif.io/api/presentation/3/context.json"
+}

--- a/public/fixtures/iiif/manifest/wisconsin-1937.json
+++ b/public/fixtures/iiif/manifest/wisconsin-1937.json
@@ -1,0 +1,78 @@
+{
+  "id": "http://localhost:3000/fixtures/iiif/manifest/wisconsin-1937.json",
+  "items": [
+    {
+      "duration": 1486.542,
+      "height": 480,
+      "id": "https://iiif.stack.rdc.library.northwestern.edu/public/iiif3/4b/19/3e/9d/-5/32/6-/42/08/-a/cf/6-/7d/a7/e3/6b/af/2c-manifest.json/canvas/b287374d-c6eb-48bc-ad38-43533fe32926",
+      "items": [
+        {
+          "id": "https://iiif.stack.rdc.library.northwestern.edu/public/iiif3/4b/19/3e/9d/-5/32/6-/42/08/-a/cf/6-/7d/a7/e3/6b/af/2c-manifest.json/canvas/b287374d-c6eb-48bc-ad38-43533fe32926/annotation_page/1",
+          "items": [
+            {
+              "body": {
+                "duration": 1486.542,
+                "format": "video/mp4",
+                "height": 1080,
+                "id": "https://meadow-streaming.rdc.library.northwestern.edu/b2/87/37/4d/-c/6e/b-/48/bc/-a/d3/8-/43/53/3f/e3/29/26/numedia_32767-inu-fball_ac_1937_wisconsin.m3u8",
+                "type": "Video",
+                "width": 1920
+              },
+              "id": "https://iiif.stack.rdc.library.northwestern.edu/public/iiif3/4b/19/3e/9d/-5/32/6-/42/08/-a/cf/6-/7d/a7/e3/6b/af/2c-manifest.json/canvas/b287374d-c6eb-48bc-ad38-43533fe32926/annotation_page/1/annotation/1",
+              "motivation": "painting",
+              "target": "https://iiif.stack.rdc.library.northwestern.edu/public/iiif3/4b/19/3e/9d/-5/32/6-/42/08/-a/cf/6-/7d/a7/e3/6b/af/2c-manifest.json/canvas/b287374d-c6eb-48bc-ad38-43533fe32926",
+              "type": "Annotation"
+            }
+          ],
+          "type": "AnnotationPage"
+        }
+      ],
+      "label": {
+        "en": ["numedia_32767-inu-fball_ac_1937_wisconsin.mp4"]
+      },
+      "thumbnail": [
+        {
+          "format": "image/jpeg",
+          "height": 300,
+          "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/posters/b287374d-c6eb-48bc-ad38-43533fe32926/full/!300,300/0/default.jpg",
+          "service": [
+            {
+              "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/posters/b287374d-c6eb-48bc-ad38-43533fe32926",
+              "profile": "http://iiif.io/api/image/2/level2.json",
+              "type": "ImageService2"
+            }
+          ],
+          "type": "Image",
+          "width": 300
+        },
+        {
+          "duration": 30,
+          "format": "video/mp4",
+          "height": 200,
+          "id": "https://meadow-streaming.rdc.library.northwestern.edu/b2/87/37/4d/-c/6e/b-/48/bc/-a/d3/8-/43/53/3f/e3/29/26/numedia_32767-inu-fball_ac_1937_wisconsin.m3u8#t=200,230",
+          "type": "Video",
+          "width": 200
+        }
+      ],
+      "type": "Canvas",
+      "width": 640
+    }
+  ],
+  "label": {
+    "en": ["Northwestern Football vs. Wisconsin, 1937"]
+  },
+  "requiredStatement": {
+    "label": {
+      "en": ["Attribution"]
+    },
+    "value": {
+      "en": ["Courtesy of Northwestern University Libraries"]
+    }
+  },
+  "rights": "http://rightsstatements.org/vocab/InC-EDU/1.0/",
+  "summary": {
+    "en": ["Final Score: NU 14, Wisconsin 6. Coach: Lynn \"Pappy\" Waldorf"]
+  },
+  "type": "Manifest",
+  "@context": "http://iiif.io/api/presentation/3/context.json"
+}

--- a/types/declarations.d.ts
+++ b/types/declarations.d.ts
@@ -3,3 +3,5 @@
  * types exported with their package.  Without
  * this, TypeScript complains.
  */
+
+declare module "@samvera/bloom-iiif";


### PR DESCRIPTION
## What does this do?

![image](https://user-images.githubusercontent.com/7376450/177778165-c5a91453-b54f-4f84-b8f5-54b3ddde0b6a.png)

This adds a Explore Further section in the footer of a Work page, rendering a multiple Bloom instances using some hardcoded IIIF Collection URIs stashed as fixtures.

The logic for passing in Collections:

- **pages/works/[id].tsx** will use a method in `getStaticProps()` to get an array of IIIF Collection URIs as a `related` prop
- `related` will be passed into the **<WorkPage>** component and _render_ **`<RelatedItems>`**, a shared component we will use anytime we want to render Bloom IIIF collections
- **`<RelatedItems>`** takes the `related` array of strings, along with a `title` string as props
- **`<RelatedItems>`** renders each instance in the `related` array as a **`<BloomIIIF>`** component. 

## How to review

1. Go to a work that is properly rendering (some have some malformed JSON responses currently in the temp API).
http://localhost:3000/works/156a8f8e-549b-4982-86cc-375bf04104ff is a working one. 
2. The **Explore Further** section is rendering with two Bloom instances. 
