### PR TITLE
Init sliders using real data.

### DIFF
--- a/lib/constants/endpoints.ts
+++ b/lib/constants/endpoints.ts
@@ -1,4 +1,5 @@
-const DCAPI_ENDPOINT = process.env.NEXT_PUBLIC_DCAPI_ENDPOINT
+const DCAPI_ENDPOINT = process.env.NEXT_PUBLIC_DCAPI_ENDPOINT;
+const DC_API_SEARCH_IIIF_URL = `https://po7domtjl7iairyivuzuzpysrm0lcphj.lambda-url.us-east-1.on.aws/`;
 const DC_API_SEARCH_URL = `${DCAPI_ENDPOINT}/search`;
 
-export { DCAPI_ENDPOINT, DC_API_SEARCH_URL };
+export { DCAPI_ENDPOINT, DC_API_SEARCH_IIIF_URL, DC_API_SEARCH_URL };

--- a/lib/iiif/collection-helpers.test.js
+++ b/lib/iiif/collection-helpers.test.js
@@ -1,0 +1,17 @@
+import { getRelatedCollections } from "@/lib/iiif/collection-helpers";
+import { sampleWork1 } from "@/mocks/sample-work1";
+
+describe("Function to generate IIIF collection URIs", () => {
+  it("successfully builds an array of IIIF collection endpoints", () => {
+    const related = getRelatedCollections(sampleWork1);
+    expect(related[0]).toBe(
+      `https://po7domtjl7iairyivuzuzpysrm0lcphj.lambda-url.us-east-1.on.aws/?query=collection.title.keyword:"Jim Roberts Photographs, 1968-1972" AND NOT id:"c16029ff-d027-496a-98b7-6f259395a8f7"&collectionLabel=Jim Roberts Photographs, 1968-1972&collectionSummary=Collection`
+    );
+    expect(related).toEqual(
+      expect.arrayContaining([
+        `https://po7domtjl7iairyivuzuzpysrm0lcphj.lambda-url.us-east-1.on.aws/?query=workType.label.keyword:\"Image\" AND NOT id:\"c16029ff-d027-496a-98b7-6f259395a8f7\"&collectionLabel=Image&collectionSummary=Work Type`,
+      ])
+    );
+    expect(related.length).toBe(5);
+  });
+});

--- a/lib/iiif/collection-helpers.ts
+++ b/lib/iiif/collection-helpers.ts
@@ -1,0 +1,51 @@
+import { sample, shuffle } from "@/lib/utils/array-helpers";
+import { DC_API_SEARCH_IIIF_URL } from "@/lib/constants/endpoints";
+import { WorkShape } from "@/types/components/works";
+
+export const getRelatedCollections = (work: WorkShape) => {
+  let related = [];
+
+  /**
+   * Append `2` subject based IIIF collections
+   */
+  const subjects = shuffle(work?.subject_labels).filter(
+    (label: string, index: number) => index < 2 && label
+  );
+  related.push(
+    ...subjects.map(
+      (subject: string) =>
+        `${DC_API_SEARCH_IIIF_URL}?query=subject:"${subject}" AND NOT id:"${work.id}"&collectionLabel=${subject}&collectionSummary=Subject`
+    )
+  );
+
+  /**
+   * Append genre based IIIF collection
+   */
+  const genre = sample(work?.genre_labels);
+  related.push(
+    `${DC_API_SEARCH_IIIF_URL}?query=descriptiveMetadata.genre.term.label.keyword:"${genre}" AND NOT id:"${work.id}"&collectionLabel=${genre}&collectionSummary=Genre`
+  );
+
+  /**
+   * Append work type IIIF collection
+   */
+  const type = work?.work_type_labels;
+  related.push(
+    `${DC_API_SEARCH_IIIF_URL}?query=workType.label.keyword:"${type}" AND NOT id:"${work.id}"&collectionLabel=${type}&collectionSummary=Work Type`
+  );
+
+  /**
+   * Add some variance and shuffle the deck
+   */
+  related = shuffle(related);
+
+  /**
+   * Add named collection based IIIF collection to top of related array
+   */
+  const collection = work?.collection_title;
+  related.unshift(
+    `${DC_API_SEARCH_IIIF_URL}?query=collection.title.keyword:"${collection}" AND NOT id:"${work.id}"&collectionLabel=${collection}&collectionSummary=Collection`
+  );
+
+  return related;
+};

--- a/lib/iiif/manifest-helpers.ts
+++ b/lib/iiif/manifest-helpers.ts
@@ -51,14 +51,11 @@ export const buildPres3Manifest = async (
         value: [...work.subject_labels],
       },
       {
-        label: "Accession Number",
-        value: work.accession_number,
-      },
-      {
-        label: "Terms of Use",
-        value: work.terms_of_use,
+        label: "Genre",
+        value: [...work.genre_labels],
       },
     ]);
+    manifest.requiredStatement?.value.none?.push(work.terms_of_use);
   } catch (err) {
     console.error("Error building manifest locally");
     return null;

--- a/lib/utils/array-helpers.js
+++ b/lib/utils/array-helpers.js
@@ -1,0 +1,20 @@
+export const sample = (array) => {
+  return array[Math.floor(Math.random() * array.length)];
+};
+
+export const shuffle = (array) => {
+  let currentIndex = array.length,
+    randomIndex;
+
+  while (currentIndex != 0) {
+    randomIndex = Math.floor(Math.random() * currentIndex);
+    currentIndex--;
+
+    [array[currentIndex], array[randomIndex]] = [
+      array[randomIndex],
+      array[currentIndex],
+    ];
+  }
+
+  return array;
+};

--- a/mocks/sample-work1.ts
+++ b/mocks/sample-work1.ts
@@ -13,7 +13,7 @@ export const sampleWork1: WorkShape = {
   captions: [],
   catalog_keys: [],
   collection_id: "51d4475f-5a0a-42a4-8901-bde73a1fae99",
-  collection_title: "51d4475f-5a0a-42a4-8901-bde73a1fae99",
+  collection_title: "Jim Roberts Photographs, 1968-1972",
   contributor_ids: ["http://id.loc.gov/authorities/names/n83209441"],
   contributor_labels: ["Roberts, James S."],
   contributors_with_roles: ["Roberts, James S. (Photographer)"],

--- a/pages/works/[id].tsx
+++ b/pages/works/[id].tsx
@@ -11,14 +11,16 @@ import { WorkShape } from "@/types/components/works";
 import WorkTopInfo from "@/components/Work/TopInfo";
 import WorkViewerWrapper from "@/components/Work/ViewerWrapper";
 import { buildPres3Manifest } from "@/lib/iiif/manifest-helpers";
+import { getRelatedCollections } from "@/lib/iiif/collection-helpers";
 
 interface WorkPageProps {
   manifest?: Manifest;
-  related?: string[];
   work: WorkShape;
 }
 
-const WorkPage: NextPage<WorkPageProps> = ({ manifest, related, work }) => {
+const WorkPage: NextPage<WorkPageProps> = ({ manifest, work }) => {
+  const related = getRelatedCollections(work);
+
   return (
     <Layout>
       <ErrorBoundary FallbackComponent={ErrorFallback}>
@@ -55,17 +57,9 @@ export async function getStaticProps({ params }: GetStaticPropsContext) {
   const work = params?.id ? await getWork(params.id as string) : null;
   const manifest = work ? await buildPres3Manifest(work) : null;
 
-  /**
-   * @todo: replace these hardcoded URIs with a method to get related collection URIs
-   */
-  const related = [
-    "http://localhost:3000/fixtures/iiif/collection/masks.json",
-    "http://localhost:3000/fixtures/iiif/collection/football.json",
-  ];
-
   return {
-    props: { manifest, related, work },
-    revalidate: 10, // In seconds
+    props: { manifest, work },
+    revalidate: 10, // seconds
   };
 }
 


### PR DESCRIPTION
## What does this do?

![image](https://user-images.githubusercontent.com/7376450/179049124-1c3a85e7-faea-43d3-a27b-aabc1e5d47c2.png)

This adds helps to the a Work page that return an array of IIIF collection endpoints for the `related` prop in the Bloom IIIF driven **`<RelatedItems>`** subcomponent. 

Currently, this will build  up to five IIIF collections URIs that render related items as IIIF Collections:
- The named **Collection** the work is a part of
- Up to two **Subject** based IIIF collections by labels that are randomly selected if they exist
- A **Genre** based collection if it exists
- A **Work Type** collection

### Notes
- The named collection is always at the top of the `related` array
- Other collection endpoints are shuffled below it to add some variance
- Because we don't have a lot of items in staging, some subjects or genres might contain less than 5 items and I'm thinking this might be a future issue to tackle
- The AWS lambda (currently **mat_tester**) shuffles the items in each collection

## How should we review?
Go to various works from different collections. Collections should render below it with the named collection being at the top.

## Related issue
https://github.com/nulib/repodev_planning_and_docs/issues/3030 (for some reason, ZenHub isn't showing the connect issue button)