### PR TITLE
Improve / Fix Work Facet filtering UX

### DIFF
--- a/components/Facets/Facet/Facet.tsx
+++ b/components/Facets/Facet/Facet.tsx
@@ -1,73 +1,13 @@
 import { FacetsInstance } from "@/types/components/facets";
 import GenericFacet from "@/components/Facets/Facet/GenericFacet";
 import React from "react";
-import useFetchApiData from "@/hooks/useFetchApiData";
-import { useFilterState } from "@/context/filter-context";
-import { useSearchState } from "@/context/search-context";
 
 interface FacetsFacetProps {
   facet: FacetsInstance;
 }
 
 const FacetsFacet: React.FC<FacetsFacetProps> = ({ facet }) => {
-  const facetInstance = facet ? [facet] : undefined;
-  const [aggsFilterValue, setAggsFilterValue] = React.useState("");
-
-  const {
-    searchState: { q },
-  } = useSearchState();
-
-  const {
-    filterState: { userFacetsUnsubmitted },
-  } = useFilterState();
-
-  const { data, error, loading } = useFetchApiData({
-    activeFacets: facetInstance,
-    aggsFilterValue,
-    searchTerm: q,
-    size: 0,
-    userFacets: userFacetsUnsubmitted,
-  });
-
-  /**
-   * @todo: create fancy loader while request and response is occurring
-   */
-
-  if (loading) return <>loader...</>;
-
-  if (error || !data || !data.aggregations) return <>friendly user error...</>;
-
-  /**
-   * return facet aggregation data for this facet instance
-   */
-  const { aggregations } = data;
-  const userFacetsAggregation = aggregations.find(
-    (aggregation) => aggregation.id === "userFacets"
-  );
-
-  const filteredAggregation = aggregations
-    .filter((aggregation) => aggregation.id === facet.id)
-    .map((aggregation) => {
-      const userBuckets = userFacetsAggregation
-        ? userFacetsAggregation.buckets
-        : [];
-      const filteredAggBuckets = aggregation.buckets.filter((ab) => {
-        return !userBuckets.find((ub) => ub.key === ab.key);
-      });
-      const buckets = [...userBuckets, ...filteredAggBuckets];
-
-      return (
-        <GenericFacet
-          filterValue={aggsFilterValue}
-          id={aggregation.id}
-          buckets={buckets}
-          key={aggregation.id}
-          setAggsFilterValue={setAggsFilterValue}
-        />
-      );
-    });
-
-  return <>{filteredAggregation}</>;
+  return <GenericFacet facet={facet} />;
 };
 
 export default FacetsFacet;

--- a/components/Facets/Facet/GenericFacet.test.tsx
+++ b/components/Facets/Facet/GenericFacet.test.tsx
@@ -1,41 +1,33 @@
-import { render, screen, within } from "@/test-utils";
+import { render, screen } from "@/test-utils";
 import GenericFacet from "./GenericFacet";
-import React from "react";
-import { mockAggregation } from "@/mocks/aggregation";
+import { response } from "@/mocks/use-fetch-api-response";
 
-const filterProps = {
-  filterValue: "",
-  setAggsFilterValue: jest.fn(),
-};
+jest.mock("@/hooks/useFetchApiData", () => {
+  return jest.fn(() => response);
+});
 
-describe("GenericFacet UI component", () => {
-  it("Renders a multi-select facet component.", () => {
-    render(<GenericFacet {...filterProps} {...mockAggregation} />);
-    const facet = screen.getByTestId(`facet-multi-component`);
-    expect(facet).toBeInTheDocument();
+describe("Facet GenericFacet UI component", () => {
+  function setup() {
+    return render(
+      <GenericFacet
+        facet={{
+          field: "descriptiveMetadata.genre.displayFacet",
+          id: "genre",
+          label: "Genre",
+        }}
+      />
+    );
+  }
+  it("renders facet title", () => {
+    setup();
+    expect(screen.getByText("Genre"));
   });
-
-  it("Renders the facet heading.", () => {
-    render(<GenericFacet {...filterProps} {...mockAggregation} />);
-    const heading = screen.getByRole("heading", { level: 3 });
-    expect(heading).toBeInTheDocument();
-    expect(heading).toHaveTextContent("foo");
+  it("renders the filter input", () => {
+    setup();
+    expect(screen.getByLabelText("Find genre"));
   });
-
-  it("Renders the find input.", () => {
-    render(<GenericFacet {...filterProps} {...mockAggregation} />);
-    const find = screen.getByTestId(`facet-find`);
-    const textInput = within(find).getByRole("textbox");
-    expect(find).toBeInTheDocument();
-    expect(textInput).toHaveAttribute("placeholder");
-    expect(textInput.getAttribute("placeholder")).toBe("Find foo");
-    expect(textInput).toHaveAttribute("aria-label");
-    expect(textInput.getAttribute("aria-label")).toBe("Find foo");
-  });
-
-  it("Renders facet options as checkboxes.", () => {
-    render(<GenericFacet {...filterProps} {...mockAggregation} />);
-    const options = screen.getByTestId(`facet-options`);
-    expect(options).toBeInTheDocument();
+  it("renders the facet options", async () => {
+    setup();
+    expect(await screen.findByTestId("facet-options"));
   });
 });

--- a/components/Facets/Facet/GenericFacet.tsx
+++ b/components/Facets/Facet/GenericFacet.tsx
@@ -1,30 +1,19 @@
-import {
-  Find,
-  FindInput,
-  Options,
-  StyledGenericFacet,
-} from "./GenericFacet.styled";
-import { ApiResponseAggregation } from "@/types/api/response";
+import { Find, FindInput, StyledGenericFacet } from "./GenericFacet.styled";
 import { ChangeEvent } from "react";
+import FacetOptions from "@/components/Facets/Facet/Options";
+import { FacetsInstance } from "@/types/components/facets";
 import Heading from "@/components/Heading/Heading";
 import { IconSearch } from "@/components/Shared/SVG/Icons";
-import Option from "./Option";
 import React from "react";
 import { debounce } from "@/lib/utils/debounce";
-import { getFacetById } from "@/lib/utils/facet-helpers";
 
-interface GenericFacetProps extends ApiResponseAggregation {
-  filterValue: string;
-  setAggsFilterValue: (arg0: string) => void;
+interface GenericFacetProps {
+  facet: FacetsInstance;
 }
 
-const GenericFacet: React.FC<GenericFacetProps> = ({
-  filterValue,
-  id,
-  buckets,
-  setAggsFilterValue,
-}) => {
-  const facet = getFacetById(id);
+const GenericFacet: React.FC<GenericFacetProps> = ({ facet }) => {
+  const { id, label } = facet;
+  const [aggsFilterValue, setAggsFilterValue] = React.useState("");
 
   const handleFindChange = async (e: ChangeEvent<HTMLInputElement>) => {
     setAggsFilterValue(e.target.value);
@@ -32,29 +21,24 @@ const GenericFacet: React.FC<GenericFacetProps> = ({
 
   /* eslint-disable */
   const debouncedHandler = React.useCallback(
-    debounce(handleFindChange, 1000),
+    debounce(handleFindChange, 200),
     []
   );
   /* eslint-enable */
 
   return (
     <StyledGenericFacet data-testid="facet-multi-component" id={`facet--${id}`}>
-      <Heading as="h3">{facet ? facet.label : id}</Heading>
+      <Heading as="h3">{facet ? label : id}</Heading>
       <Find className="facet-find" data-testid="facet-find">
         <IconSearch />
         <FindInput
           aria-label={`Find ${id}`}
           placeholder={`Find ${id}`}
-          onChange={handleFindChange}
+          onChange={(e: ChangeEvent<HTMLInputElement>) => debouncedHandler(e)}
           type="text"
-          value={filterValue}
         />
       </Find>
-      <Options className="facet-options" data-testid="facet-options">
-        {buckets.map((bucket, index) => (
-          <Option bucket={bucket} facet={id} index={index} key={bucket.key} />
-        ))}
-      </Options>
+      <FacetOptions aggsFilterValue={aggsFilterValue} facet={facet} />
     </StyledGenericFacet>
   );
 };

--- a/components/Facets/Facet/Options.tsx
+++ b/components/Facets/Facet/Options.tsx
@@ -1,0 +1,81 @@
+import { FacetsInstance } from "@/types/components/facets";
+import Option from "./Option";
+import { Options } from "./GenericFacet.styled";
+import { SpinLoader } from "@/components/Shared/Loader.styled";
+import useFetchApiData from "@/hooks/useFetchApiData";
+import { useFilterState } from "@/context/filter-context";
+import { useSearchState } from "@/context/search-context";
+
+interface FacetOptionsProps {
+  aggsFilterValue: string;
+  facet: FacetsInstance;
+}
+
+const FacetOptions: React.FC<FacetOptionsProps> = ({
+  aggsFilterValue,
+  facet,
+}) => {
+  const facetInstance = facet ? [facet] : undefined;
+  const {
+    searchState: { q },
+  } = useSearchState();
+
+  const {
+    filterState: { userFacetsUnsubmitted },
+  } = useFilterState();
+
+  const { data, error, loading } = useFetchApiData({
+    activeFacets: facetInstance,
+    aggsFilterValue,
+    searchTerm: q,
+    size: 0,
+    userFacets: userFacetsUnsubmitted,
+  });
+
+  if (loading) return <SpinLoader />;
+  if (error || !data || !data.aggregations) return <>friendly user error...</>;
+
+  /**
+   * return facet aggregation data for this facet instance
+   */
+  const { aggregations } = data;
+  const userFacetsAggregation = aggregations.find(
+    (aggregation) => aggregation.id === "userFacets"
+  );
+
+  const filteredAggregations = aggregations.filter(
+    (aggregation) => aggregation.id === facet.id
+  );
+
+  return (
+    <>
+      {filteredAggregations.map((aggregation) => {
+        const userBuckets = userFacetsAggregation
+          ? userFacetsAggregation.buckets
+          : [];
+        const filteredAggBuckets = aggregation.buckets.filter((ab) => {
+          return !userBuckets.find((ub) => ub.key === ab.key);
+        });
+        const buckets = [...userBuckets, ...filteredAggBuckets];
+        return (
+          <Options
+            key={aggregation.id}
+            className="facet-options skeleton-loader"
+            data-testid="facet-options"
+          >
+            {buckets.map((bucket, index) => (
+              <Option
+                bucket={bucket}
+                facet={facet.id}
+                index={index}
+                key={bucket.key}
+              />
+            ))}
+          </Options>
+        );
+      })}
+    </>
+  );
+};
+
+export default FacetOptions;

--- a/components/Facets/Filter/GroupList.test.tsx
+++ b/components/Facets/Filter/GroupList.test.tsx
@@ -66,7 +66,12 @@ describe("FacetsGroupList component", () => {
      * Looks like Radix puts this active state data attribute
      * on the element.... good for testing against:)
      */
-    expect(screen.getByText("Contributor").dataset.state).toEqual("active");
+    expect(
+      screen.getAllByRole("tab", { exact: true })[0].dataset.state
+    ).toEqual("active");
+    expect(
+      screen.getAllByRole("tab", { exact: true })[1].dataset.state
+    ).toEqual("inactive");
   });
 
   it("renders facet aggregations when a facet is clicked upon", async () => {

--- a/components/Shared/Loader.styled.ts
+++ b/components/Shared/Loader.styled.ts
@@ -1,0 +1,21 @@
+import { keyframes, styled } from "@/stitches.config";
+
+/* eslint sort-keys: 0 */
+
+const rotation = keyframes({
+  "0%": { transform: "rotate(0deg)" },
+  "100%": { transform: "rotate(360deg)" },
+});
+
+const SpinLoader = styled("span", {
+  width: "48px",
+  height: "48px",
+  border: "5px solid $black10",
+  borderBottomColor: "transparent",
+  borderRadius: "50%",
+  display: "inline-block",
+  boxSizing: "border-box",
+  animation: `${rotation} 1s linear infinite`,
+});
+
+export { SpinLoader };

--- a/mocks/use-fetch-api-response.ts
+++ b/mocks/use-fetch-api-response.ts
@@ -1,0 +1,37 @@
+export const response = {
+  data: {
+    aggregations: [
+      {
+        buckets: [
+          {
+            doc_count: 36,
+            key: "black-and-white negatives",
+          },
+          { doc_count: 18, key: "black-and-white photographs" },
+          { doc_count: 17, key: "clippings (information artifacts)" },
+          {
+            doc_count: 11,
+            key: "letters (correspondence)",
+          },
+          {
+            doc_count: 9,
+            key: "sculpture (visual works)",
+          },
+          { doc_count: 8, key: "color photographs" },
+          {
+            doc_count: 7,
+            key: "notes (documents)",
+          },
+          { doc_count: 6, key: "photographs" },
+        ],
+        id: "genre",
+      },
+    ],
+    data: [],
+    info: {
+      total: 185,
+    },
+  },
+  error: "",
+  loading: "",
+};


### PR DESCRIPTION
## What does this do?
- Maintains focus state on Facets text filter `input` element
- Adds a small `debounce` to the text filter
- Refactors the location of aggregations data fetching in the `Facet` component to avoid clunky re-renders
- Adds a quick loading spinner

![image](https://user-images.githubusercontent.com/3020266/181624544-952bafb5-d863-4787-bdf1-07b1d26f0451.png)


## To Test
- Go to the Search screen and click the "Filter" button in top menu
- Click into a Facet display where you see all the values
- Text filter via the input box
- Verify if works with user selected facets.  Check some boxes.
