### PR TITLE
Bump clover to set scrollToZoom false.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@radix-ui/react-radio-group": "^0.1.6-rc.20",
         "@radix-ui/react-tabs": "^0.1.6-rc.13",
         "@samvera/bloom-iiif": "^0.2.1",
-        "@samvera/clover-iiif": "^1.10.1",
+        "@samvera/clover-iiif": "^1.10.3",
         "@samvera/nectar-iiif": "^0.0.14",
         "@stitches/react": "^1.2.6",
         "axios": "^0.27.2",
@@ -3081,9 +3081,9 @@
       }
     },
     "node_modules/@samvera/clover-iiif": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@samvera/clover-iiif/-/clover-iiif-1.10.2.tgz",
-      "integrity": "sha512-RxihRHNpCuPefEZhK1RAkz7TjBSglh+8ozdt3Wt3swVUYts1rLNg+dybLXIKW2iNq9I2KY5WxHJwoHYG+gpBTA==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/@samvera/clover-iiif/-/clover-iiif-1.10.3.tgz",
+      "integrity": "sha512-5BB/XRP5Kg2perDjs+DQkTPhveU5aLgICXN79NKp511f2DzLfZ04CKP8G+OPijMX+kXhjvUZ9XRwBtc/q0OZSw==",
       "dependencies": {
         "@iiif/presentation-3": "^1.0.4",
         "@iiif/vault": "^0.9.17",
@@ -13249,9 +13249,9 @@
       }
     },
     "@samvera/clover-iiif": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/@samvera/clover-iiif/-/clover-iiif-1.10.2.tgz",
-      "integrity": "sha512-RxihRHNpCuPefEZhK1RAkz7TjBSglh+8ozdt3Wt3swVUYts1rLNg+dybLXIKW2iNq9I2KY5WxHJwoHYG+gpBTA==",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/@samvera/clover-iiif/-/clover-iiif-1.10.3.tgz",
+      "integrity": "sha512-5BB/XRP5Kg2perDjs+DQkTPhveU5aLgICXN79NKp511f2DzLfZ04CKP8G+OPijMX+kXhjvUZ9XRwBtc/q0OZSw==",
       "requires": {
         "@iiif/presentation-3": "^1.0.4",
         "@iiif/vault": "^0.9.17",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@radix-ui/react-radio-group": "^0.1.6-rc.20",
     "@radix-ui/react-tabs": "^0.1.6-rc.13",
     "@samvera/bloom-iiif": "^0.2.1",
-    "@samvera/clover-iiif": "^1.10.1",
+    "@samvera/clover-iiif": "^1.10.3",
     "@samvera/nectar-iiif": "^0.0.14",
     "@stitches/react": "^1.2.6",
     "axios": "^0.27.2",


### PR DESCRIPTION
This is just a micro PR to bump clover and set the OpenSeadragon `scrollToZoom` option as false by default.