### PR TITLE
Create Expand component.

### DIFF
--- a/components/Figure/Figure.styled.ts
+++ b/components/Figure/Figure.styled.ts
@@ -41,6 +41,8 @@ const FigureStyled = styled("figure", {
   variants: {
     isPromoted: {
       true: {
+        [`& ${Image}`]: { maxHeight: "200px" },
+
         [`& ${Title}`]: {
           fontSize: "$5",
           fontFamily: "$displayBold",

--- a/components/Shared/Expand/Expand.styled.ts
+++ b/components/Shared/Expand/Expand.styled.ts
@@ -1,0 +1,54 @@
+import { VariantProps, styled } from "@/stitches.config";
+import { Button } from "@nulib/design-system";
+
+/* eslint sort-keys: 0 */
+
+const ExpandButton = styled(Button, {
+  margin: "0 auto",
+  opacity: "1",
+  transition: "$all",
+});
+
+const ExpandEdge = styled("div", {
+  position: "absolute",
+  width: "100%",
+  bottom: "0",
+  display: "flex",
+  justifyContent: "center",
+  padding: "$4 0 0",
+  backgroundColor: "$white",
+  background: "linear-gradient(to bottom, #fff0 0%, #fff 61.8%)",
+  transition: "$all",
+  overflow: "hidden",
+});
+
+const ExpandContent = styled("div", {
+  backgroundColor: "transparent",
+});
+
+const ExpandStyled = styled("div", {
+  position: "relative",
+  overflow: "hidden",
+  transition: "$all",
+  backgroundColor: "transparent",
+
+  variants: {
+    isExpanded: {
+      true: {
+        [`& ${ExpandEdge}`]: {
+          background: "transparent",
+          height: "0",
+          padding: "0",
+        },
+
+        [`& ${ExpandButton}`]: {
+          opacity: "0",
+        },
+      },
+    },
+  },
+});
+
+export type ExpandVariants = VariantProps<typeof ExpandStyled>;
+
+export { ExpandButton, ExpandContent, ExpandEdge, ExpandStyled };

--- a/components/Shared/Expand/Expand.test.tsx
+++ b/components/Shared/Expand/Expand.test.tsx
@@ -1,0 +1,43 @@
+import { fireEvent, render, screen } from "@/test-utils";
+import Expand from "@/components/Shared/Expand/Expand";
+
+describe("Expand component", () => {
+  it("renders a wrapping Expand component with prescribed props", async () => {
+    render(
+      <Expand buttonText="Expand something" initialHeight={350}>
+        <div>Some content</div>
+      </Expand>
+    );
+
+    const expand = screen.getByTestId("expand");
+    const button = screen.getByRole("button");
+
+    expect(expand).toBeInTheDocument;
+    expect(expand).toContainHTML("<div>Some content</div>");
+    expect(expand.getAttribute("style")).toBe("max-height: 350px;");
+
+    expect(button).toHaveTextContent("Expand something");
+
+    /**
+     * expect the max-height to adjust on button click
+     */
+    fireEvent.click(button);
+    expect(expand.getAttribute("style")).toBe("max-height: 0px;");
+  });
+
+  it("renders a wrapping Expand component with default prop values", () => {
+    render(
+      <Expand>
+        <div>Other content</div>
+      </Expand>
+    );
+    const expand = screen.getByTestId("expand");
+    const button = screen.getByRole("button");
+
+    expect(expand).toBeInTheDocument;
+    expect(expand).toContainHTML("<div>Other content</div>");
+    expect(expand.getAttribute("style")).toBe("max-height: 500px;");
+
+    expect(button).toHaveTextContent("Show More");
+  });
+});

--- a/components/Shared/Expand/Expand.tsx
+++ b/components/Shared/Expand/Expand.tsx
@@ -1,0 +1,48 @@
+import {
+  ExpandButton,
+  ExpandContent,
+  ExpandEdge,
+  ExpandStyled,
+  ExpandVariants,
+} from "@/components/Shared/Expand/Expand.styled";
+import { ReactNode, useEffect, useRef, useState } from "react";
+
+export interface ExpandProps {
+  buttonText?: string;
+  children: ReactNode | ReactNode[];
+  initialHeight?: number;
+}
+
+const Expand: React.FC<ExpandProps & ExpandVariants> = ({
+  buttonText = "Show More",
+  children,
+  initialHeight = 500,
+}) => {
+  const [isExpanded, setIsExpanded] = useState<boolean>(false);
+  const [maxHeight, setMaxHeight] = useState<number>(initialHeight);
+
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  const handleExpand = () => setIsExpanded(true);
+
+  useEffect(() => {
+    if (isExpanded && contentRef?.current)
+      setMaxHeight(contentRef?.current?.offsetHeight);
+  }, [isExpanded, contentRef]);
+
+  return (
+    <ExpandStyled
+      isExpanded={isExpanded}
+      style={{ maxHeight: `${maxHeight}px` }}
+      data-testid="expand"
+    >
+      <ExpandContent ref={contentRef}>{children}</ExpandContent>
+      <ExpandEdge>
+        <ExpandButton onClick={handleExpand} isLowercase disabled={isExpanded}>
+          {buttonText}
+        </ExpandButton>
+      </ExpandEdge>
+    </ExpandStyled>
+  );
+};
+export default Expand;

--- a/components/Work/TopInfo.styled.ts
+++ b/components/Work/TopInfo.styled.ts
@@ -23,6 +23,13 @@ const ActionButtons = styled("div", {
   },
 });
 
+const TopInfoContent = styled("div", {
+  display: "grid",
+  gap: "$7",
+  gridTemplateColumns: "618fr 382fr",
+  margin: "$3 0",
+});
+
 const TopInfoWrapper = styled("section", {
   margin: "$6 0",
 
@@ -55,17 +62,6 @@ const TopInfoWrapper = styled("section", {
       lineHeight: "1.47em",
     },
   },
-
-  [`> div`]: {
-    display: "grid",
-    gap: "$7",
-    gridTemplateColumns: "618fr 382fr",
-    margin: "$3 0",
-  },
-
-  "@md": {
-    gridTemplateColumns: "1fr",
-  },
 });
 
 const TopInfoCollection = styled("div", {
@@ -78,4 +74,4 @@ const TopInfoCollection = styled("div", {
   },
 });
 
-export { ActionButtons, TopInfoCollection, TopInfoWrapper };
+export { ActionButtons, TopInfoCollection, TopInfoContent, TopInfoWrapper };

--- a/components/Work/TopInfo.tsx
+++ b/components/Work/TopInfo.tsx
@@ -1,6 +1,7 @@
 import {
   ActionButtons,
   TopInfoCollection,
+  TopInfoContent,
   TopInfoWrapper,
 } from "@/components//Work/TopInfo.styled";
 import {
@@ -13,6 +14,7 @@ import React, { MouseEvent } from "react";
 import { Button } from "@nulib/design-system";
 import Card from "@/components/Shared/Card";
 import { DefinitionListWrapper } from "@/components/Shared/DefinitionList.styled";
+import Expand from "@/components/Shared/Expand/Expand";
 import { Manifest } from "@iiif/presentation-3";
 import WorkActionsDialog from "@/components/Work/ActionsDialog/ActionsDialog";
 import { WorkShape } from "@/types/components/works";
@@ -91,30 +93,32 @@ const WorkTopInfo: React.FC<TopInfoProps> = ({ manifest, work }) => {
           close={() => setActionsDialog({ activeDialog: undefined })}
         />
       </header>
-      <div>
-        <div data-testid="work-top-info-wrapper">
-          <DefinitionListWrapper>
-            {manifest?.metadata && (
-              <Metadata metadata={manifest.metadata} data-testid="metadata" />
-            )}
-            {manifest?.requiredStatement && (
-              <RequiredStatement
-                requiredStatement={manifest.requiredStatement}
-              />
-            )}
-          </DefinitionListWrapper>
-        </div>
-        <TopInfoCollection>
-          <h2>Collection</h2>
-          <Card
-            title={work.collection_title}
-            description="Cras mollis lorem sed nisi consequat aliquet. Mauris fringilla pretium nibh, ut laoreet mi luctus nec. Integer luctus urna sed nisi rhoncus mollis."
-            href={`/collections/${work.collection_id}`}
-            imageUrl={work.thumbnail}
-            supplementalInfo="678 Works"
-          />
-        </TopInfoCollection>
-      </div>
+      <Expand initialHeight={600} buttonText="Show More">
+        <TopInfoContent>
+          <div data-testid="work-top-info-wrapper">
+            <DefinitionListWrapper>
+              {manifest?.metadata && (
+                <Metadata metadata={manifest.metadata} data-testid="metadata" />
+              )}
+              {manifest?.requiredStatement && (
+                <RequiredStatement
+                  requiredStatement={manifest.requiredStatement}
+                />
+              )}
+            </DefinitionListWrapper>
+          </div>
+          <TopInfoCollection>
+            <h2>Collection</h2>
+            <Card
+              title={work.collection_title}
+              description="Cras mollis lorem sed nisi consequat aliquet. Mauris fringilla pretium nibh, ut laoreet mi luctus nec. Integer luctus urna sed nisi rhoncus mollis."
+              href={`/collections/${work.collection_id}`}
+              imageUrl={work.thumbnail}
+              supplementalInfo="678 Works"
+            />
+          </TopInfoCollection>
+        </TopInfoContent>
+      </Expand>
     </TopInfoWrapper>
   );
 };


### PR DESCRIPTION
## What does this do?

This adds an `<Expand>` component to our Shared components library that wraps child content and includes a Button for expanding content vertically. I opted for creating this as a shared component for reuse elsewhere, likely on the Collections level pages.

![image](https://user-images.githubusercontent.com/7376450/182626689-ae2b5967-816b-4643-833b-6b1e0a5ffb70.png)

onClick of the `ExpandButton`, the **maxHeight** will adjust to the actual height of the `ExpandContent` element. A CSS transition adds a smooth push down of content that is rendered below the `<Expand>`. Defaults are set for both the **buttonText** ("Show More") and **initialHeight** (500) values for smoother implementation.