### PR TITLE
Create dismissable global 'harmful content' message.

### DIFF
--- a/components/Shared/Message/Message.styled.ts
+++ b/components/Shared/Message/Message.styled.ts
@@ -1,0 +1,56 @@
+import { VariantProps, styled } from "@/stitches.config";
+
+/* eslint sort-keys: 0 */
+
+const MessageContent = styled("div", {
+  display: "flex",
+  padding: "$gr4 0",
+  color: "$white",
+  lineHeight: "1.15em",
+  overflow: "hidden",
+
+  "& div:first-child": {
+    marginRight: "$gr6",
+  },
+
+  button: {
+    color: "inherit",
+    fontFamily: "$sansBold",
+    textDecoration: "underline",
+  },
+});
+
+const MessageTitle = styled("span", {
+  display: "block",
+  fontFamily: "$displayBook",
+  fontSize: "$gr5",
+  margin: "0 0 $gr2",
+});
+
+const MessageText = styled("span", {
+  display: "block",
+  fontFamily: "$sansLight",
+  fontSize: "$gr3",
+});
+
+const MessageStyled = styled("div", {
+  position: "fixed",
+  display: "flex",
+  bottom: "0",
+  zIndex: "1",
+  width: "100%",
+  backgroundColor: "$darkBlueA",
+
+  variants: {
+    status: {
+      false: {
+        height: "0",
+        opacity: "0",
+      },
+    },
+  },
+});
+
+export type ExpandVariants = VariantProps<typeof MessageStyled>;
+
+export { MessageContent, MessageTitle, MessageText, MessageStyled };

--- a/components/Shared/Message/Message.tsx
+++ b/components/Shared/Message/Message.tsx
@@ -1,0 +1,59 @@
+import {
+  MessageContent,
+  MessageStyled,
+  MessageText,
+  MessageTitle,
+} from "@/components/Shared/Message/Message.styled";
+import { Button } from "@nulib/design-system";
+import Container from "@/components/Shared/Container";
+import { useEffect } from "react";
+import useSessionStorage from "@/hooks/useSessionStorage";
+
+const Message = () => {
+  const current = Date.now() / 1000;
+  const interval = 86400; // 24 hours
+
+  const [status, setStatus] = useSessionStorage("message_status", true);
+  const [timestamp, setTimestamp] = useSessionStorage(
+    "message_timestamp",
+    current
+  );
+
+  const handleDismiss = () => {
+    setStatus(false);
+    setTimestamp(current);
+  };
+
+  useEffect(() => {
+    if (current > timestamp + interval) {
+      setStatus(true);
+    }
+  }, [setStatus, current, timestamp]);
+
+  if (!status) return <></>;
+
+  return (
+    <MessageStyled data-nosnippet status={status}>
+      <Container>
+        <MessageContent>
+          <div>
+            <MessageTitle>Donec sollicitudin molestie massa</MessageTitle>
+            <MessageText>
+              Nulla fringilla elementum odio eget efficitur. Mauris placerat
+              velit sapien, vitae gravida nibh feugiat at. Sed a congue turpis.
+              Aliquam nibh nulla, ullamcorper non purus vel, cursus interdum
+              augue. Suspendisse turpis ex, mollis non consequat quis, interdum
+              vel diam.
+            </MessageText>
+          </div>
+          <div>
+            <Button isText isLowercase onClick={handleDismiss}>
+              Dismiss
+            </Button>
+          </div>
+        </MessageContent>
+      </Container>
+    </MessageStyled>
+  );
+};
+export default Message;

--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -1,6 +1,7 @@
 import Footer from "@/components/Footer/Footer";
 import Head from "next/head";
 import Header from "@/components/Header/Header";
+import Message from "@/components/Shared/Message/Message";
 import React from "react";
 
 export const siteTitle = "Digital Collections v2";
@@ -31,6 +32,7 @@ const Layout: React.FC<LayoutProps> = ({ children, header = "default" }) => {
       <Header isHero={header === "hero"} />
       <main>{children}</main>
       <Footer />
+      <Message />
     </>
   );
 };

--- a/hooks/useEventCallback.ts
+++ b/hooks/useEventCallback.ts
@@ -1,0 +1,17 @@
+import { useCallback, useRef } from "react";
+
+import useIsomorphicLayoutEffect from "@/hooks/useIsomorphicLayoutEffect";
+
+export default function useEventCallback<Args extends unknown[], R>(
+  fn: (...args: Args) => R
+) {
+  const ref = useRef<typeof fn>(() => {
+    throw new Error("Cannot call an event handler while rendering.");
+  });
+
+  useIsomorphicLayoutEffect(() => {
+    ref.current = fn;
+  }, [fn]);
+
+  return useCallback((...args: Args) => ref.current(...args), [ref]);
+}

--- a/hooks/useEventListener.ts
+++ b/hooks/useEventListener.ts
@@ -1,0 +1,71 @@
+import { RefObject, useEffect, useRef } from "react";
+
+import useIsomorphicLayoutEffect from "@/hooks/useIsomorphicLayoutEffect";
+
+// Window Event based useEventListener interface
+function useEventListener<K extends keyof WindowEventMap>(
+  eventName: K,
+  handler: (event: WindowEventMap[K]) => void,
+  element?: undefined,
+  options?: AddEventListenerOptions | boolean
+): void;
+
+// Element Event based useEventListener interface
+function useEventListener<
+  K extends keyof HTMLElementEventMap,
+  T extends HTMLElement = HTMLDivElement
+>(
+  eventName: K,
+  handler: (event: HTMLElementEventMap[K]) => void,
+  element: RefObject<T>,
+  options?: AddEventListenerOptions | boolean
+): void;
+
+// Document Event based useEventListener interface
+function useEventListener<K extends keyof DocumentEventMap>(
+  eventName: K,
+  handler: (event: DocumentEventMap[K]) => void,
+  element: RefObject<Document>,
+  options?: AddEventListenerOptions | boolean
+): void;
+
+function useEventListener<
+  KW extends keyof WindowEventMap,
+  KH extends keyof HTMLElementEventMap,
+  T extends HTMLElement | void = void
+>(
+  eventName: KH | KW,
+  handler: (
+    event: Event | HTMLElementEventMap[KH] | WindowEventMap[KW]
+  ) => void,
+  element?: RefObject<T>,
+  options?: AddEventListenerOptions | boolean
+) {
+  // Create a ref that stores handler
+  const savedHandler = useRef(handler);
+
+  useIsomorphicLayoutEffect(() => {
+    savedHandler.current = handler;
+  }, [handler]);
+
+  useEffect(() => {
+    // Define the listening target
+    const targetElement: T | Window = element?.current || window;
+    if (!(targetElement && targetElement.addEventListener)) {
+      return;
+    }
+
+    // Create event listener that calls handler function stored in ref
+    const eventListener: typeof handler = (event) =>
+      savedHandler.current(event);
+
+    targetElement.addEventListener(eventName, eventListener, options);
+
+    // Remove event listener on cleanup
+    return () => {
+      targetElement.removeEventListener(eventName, eventListener);
+    };
+  }, [eventName, element, options]);
+}
+
+export default useEventListener;

--- a/hooks/useIsomorphicLayoutEffect.ts
+++ b/hooks/useIsomorphicLayoutEffect.ts
@@ -1,0 +1,6 @@
+import { useEffect, useLayoutEffect } from "react";
+
+const useIsomorphicLayoutEffect =
+  typeof window !== "undefined" ? useLayoutEffect : useEffect;
+
+export default useIsomorphicLayoutEffect;

--- a/hooks/useSessionStorage.ts
+++ b/hooks/useSessionStorage.ts
@@ -1,0 +1,104 @@
+import {
+  Dispatch,
+  SetStateAction,
+  useCallback,
+  useEffect,
+  useState,
+} from "react";
+
+import useEventCallback from "@/hooks/useEventCallback";
+import useEventListener from "@/hooks/useEventListener";
+
+declare global {
+  interface WindowEventMap {
+    "session-storage": CustomEvent;
+  }
+}
+
+type SetValue<T> = Dispatch<SetStateAction<T>>;
+
+function useSessionStorage<T>(key: string, initialValue: T): [T, SetValue<T>] {
+  // Get from session storage then
+  // parse stored json or return initialValue
+  const readValue = useCallback((): T => {
+    // Prevent build error "window is undefined" but keep keep working
+    if (typeof window === "undefined") {
+      return initialValue;
+    }
+
+    try {
+      const item = window.sessionStorage.getItem(key);
+      return item ? (parseJSON(item) as T) : initialValue;
+    } catch (error) {
+      console.warn(`Error reading sessionStorage key “${key}”:`, error);
+      return initialValue;
+    }
+  }, [initialValue, key]);
+
+  // State to store our value
+  // Pass initial state function to useState so logic is only executed once
+  const [storedValue, setStoredValue] = useState<T>(readValue);
+
+  // Return a wrapped version of useState's setter function that ...
+  // ... persists the new value to sessionStorage.
+  const setValue: SetValue<T> = useEventCallback((value) => {
+    // Prevent build error "window is undefined" but keeps working
+    if (typeof window == "undefined") {
+      console.warn(
+        `Tried setting sessionStorage key “${key}” even though environment is not a client`
+      );
+    }
+
+    try {
+      // Allow value to be a function so we have the same API as useState
+      const newValue = value instanceof Function ? value(storedValue) : value;
+
+      // Save to session storage
+      window.sessionStorage.setItem(key, JSON.stringify(newValue));
+
+      // Save state
+      setStoredValue(newValue);
+
+      // We dispatch a custom event so every useSessionStorage hook are notified
+      window.dispatchEvent(new Event("session-storage"));
+    } catch (error) {
+      console.warn(`Error setting sessionStorage key “${key}”:`, error);
+    }
+  });
+
+  useEffect(() => {
+    setStoredValue(readValue());
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleStorageChange = useCallback(
+    (event: CustomEvent | StorageEvent) => {
+      if ((event as StorageEvent)?.key && (event as StorageEvent).key !== key) {
+        return;
+      }
+      setStoredValue(readValue());
+    },
+    [key, readValue]
+  );
+
+  // this only works for other documents, not the current one
+  useEventListener("storage", handleStorageChange);
+
+  // this is a custom event, triggered in writeValueTosessionStorage
+  // See: useSessionStorage()
+  useEventListener("session-storage", handleStorageChange);
+
+  return [storedValue, setValue];
+}
+
+export default useSessionStorage;
+
+// A wrapper for "JSON.parse()"" to support "undefined" value
+function parseJSON<T>(value: string | null): T | undefined {
+  try {
+    return value === "undefined" ? undefined : JSON.parse(value ?? "");
+  } catch {
+    console.log("parsing error on", { value });
+    return undefined;
+  }
+}

--- a/styles/fonts.ts
+++ b/styles/fonts.ts
@@ -5,7 +5,7 @@
 const generic = `AkkuratProRegular, Arial, Helvetica, sans-serif`;
 
 const sans = {
-  sansBold: `AkkuratProBold, AkkuratProRegular, ${generic}`,
+  sansBold: `AkkuratProBold, AkkuratProRegular, ${generic} `,
   sansBoldItalic: `AkkuratProBoldItalic, AkkuratProRegular, ${generic}`,
   sansItalic: `AkkuratProItalic, AkkuratProRegular, ${generic}`,
   sansLight: `AkkuratProLight, AkkuratProRegular, ${generic}`,


### PR DESCRIPTION
## What does this do?

This work adds a dismissable message fixed to the bottom of all pages. Data related to this message for `status` and `timestamp` are kept in browser session storage. The current interval for dismissing a message is `86400` seconds (24 hours). Once that that time has elapsed, the message will display once again for the user of that browser.
 
![image](https://user-images.githubusercontent.com/7376450/185227218-6fb17e45-12d8-4af0-9e28-d30c4b9c0cc8.png)