### PR TITLE
Update bloom, dynamic import for swiper integration.

### DIFF
--- a/components/Shared/RelatedItems.tsx
+++ b/components/Shared/RelatedItems.tsx
@@ -1,12 +1,18 @@
-import BloomIIIF from "@samvera/bloom-iiif";
 import { ErrorBoundary } from "react-error-boundary";
 import ErrorFallback from "@/components/Shared/ErrorFallback";
 import { RelatedItemsStyled } from "@/components/Shared/RelatedItems.styled";
+import dynamic from "next/dynamic";
 
 export interface RelatedItemsProps {
   collections?: string[];
   title: string;
 }
+
+export const BloomIIIF: React.ComponentType<{
+  collectionId: string;
+}> = dynamic(() => import("@samvera/bloom-iiif"), {
+  ssr: false,
+});
 
 const RelatedItems: React.FC<RelatedItemsProps> = ({ collections, title }) => {
   if (collections && collections.length === 0) return <></>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@radix-ui/react-radio-group": "^0.1.6-rc.20",
         "@radix-ui/react-select": "^1.0.0",
         "@radix-ui/react-tabs": "^0.1.6-rc.13",
-        "@samvera/bloom-iiif": "^0.2.1",
+        "@samvera/bloom-iiif": "^0.3.2",
         "@samvera/clover-iiif": "^1.10.3",
         "@samvera/nectar-iiif": "^0.0.16",
         "@stitches/react": "^1.2.6",
@@ -3435,16 +3435,17 @@
       "dev": true
     },
     "node_modules/@samvera/bloom-iiif": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@samvera/bloom-iiif/-/bloom-iiif-0.2.1.tgz",
-      "integrity": "sha512-gCFLfHP80vDzvHK61V19lRvlTZssXb9eJfEtbXu58rQeCI5VAvoeIQfzJOxiGkT5Vteso031g149LAPye4Psuw==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@samvera/bloom-iiif/-/bloom-iiif-0.3.2.tgz",
+      "integrity": "sha512-G1rZrNPKP26Mq2wHi2Go/wIkh0tuTj/3M7FIs9KNp6y/IJqAW9UFNxqsEk5V0dWH2sWnfsB76IniggOY5qIyrw==",
       "dependencies": {
         "@iiif/vault": "^0.9.18",
         "@radix-ui/react-aspect-ratio": "^0.1.5-rc.41",
         "@samvera/nectar-iiif": "^0.0.15",
         "@stitches/react": "^1.2.8",
         "react": "^16.13.1  || ^17 || ^18",
-        "react-dom": "^16.13.1  || ^17 || ^18"
+        "react-dom": "^16.13.1  || ^17 || ^18",
+        "swiper": "^8.3.2"
       }
     },
     "node_modules/@samvera/bloom-iiif/node_modules/@samvera/nectar-iiif": {
@@ -13872,16 +13873,17 @@
       "dev": true
     },
     "@samvera/bloom-iiif": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@samvera/bloom-iiif/-/bloom-iiif-0.2.1.tgz",
-      "integrity": "sha512-gCFLfHP80vDzvHK61V19lRvlTZssXb9eJfEtbXu58rQeCI5VAvoeIQfzJOxiGkT5Vteso031g149LAPye4Psuw==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@samvera/bloom-iiif/-/bloom-iiif-0.3.2.tgz",
+      "integrity": "sha512-G1rZrNPKP26Mq2wHi2Go/wIkh0tuTj/3M7FIs9KNp6y/IJqAW9UFNxqsEk5V0dWH2sWnfsB76IniggOY5qIyrw==",
       "requires": {
         "@iiif/vault": "^0.9.18",
         "@radix-ui/react-aspect-ratio": "^0.1.5-rc.41",
         "@samvera/nectar-iiif": "^0.0.15",
         "@stitches/react": "^1.2.8",
         "react": "^16.13.1  || ^17 || ^18",
-        "react-dom": "^16.13.1  || ^17 || ^18"
+        "react-dom": "^16.13.1  || ^17 || ^18",
+        "swiper": "^8.3.2"
       },
       "dependencies": {
         "@samvera/nectar-iiif": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@radix-ui/react-radio-group": "^0.1.6-rc.20",
     "@radix-ui/react-select": "^1.0.0",
     "@radix-ui/react-tabs": "^0.1.6-rc.13",
-    "@samvera/bloom-iiif": "^0.2.1",
+    "@samvera/bloom-iiif": "^0.3.2",
     "@samvera/clover-iiif": "^1.10.3",
     "@samvera/nectar-iiif": "^0.0.16",
     "@stitches/react": "^1.2.6",


### PR DESCRIPTION
## What does this do?

This updates Bloom to a version supporting baseline responsiveness (using Swiper) that works with Next.js. I also switched it to a dynamic import --- required by the swiper dependency.

![image](https://user-images.githubusercontent.com/7376450/186512747-bdbdd3cd-ec45-490a-956c-4495a581c513.png)
