### PR TITLE
2744 pagination setup

### DIFF
--- a/components/Search/Pagination.styled.ts
+++ b/components/Search/Pagination.styled.ts
@@ -1,0 +1,93 @@
+import { styled } from "@/stitches.config";
+
+const linkActiveVariant = {
+  active: {
+    false: {
+      visibility: "hidden",
+    },
+  },
+};
+
+const prevNextStyles = {
+  display: "flex",
+  flexGrow: 1,
+  marginTop: "-1px",
+
+  "& a": {
+    display: "inline-flex",
+    alignItems: "center",
+    paddingTop: "$gr3",
+    borderTop: "2px solid transparent",
+
+    "&:hover": {
+      borderTop: "2px solid $black20",
+    },
+  },
+};
+
+/* eslint sort-keys: 0 */
+export const PaginationStyled = styled("nav", {
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "center",
+  fontSize: "$gr3",
+  color: "$black80",
+  margin: "0 $gr3 $gr4",
+  borderTop: "1px solid $black10",
+
+  "& svg": {
+    width: "$gr3",
+  },
+});
+
+export const LeftNav = styled("div", {
+  ...prevNextStyles,
+  "& svg": {
+    marginRight: "$gr2",
+  },
+
+  variants: { ...linkActiveVariant },
+});
+
+export const RightNav = styled("div", {
+  ...prevNextStyles,
+  justifyContent: "end",
+
+  "& svg": {
+    marginLeft: "$gr2",
+  },
+
+  variants: { ...linkActiveVariant },
+});
+
+export const PaginationLinks = styled("div", {
+  display: "flex",
+  marginTop: "-1px",
+
+  "@sm": {
+    display: "none",
+  },
+});
+
+export const PageNumber = styled("a", {
+  display: "inline-flex",
+  alignItems: "center",
+  cursor: "pointer",
+  padding: "$gr3 $gr3 0 $gr3",
+  borderTop: "2px solid transparent",
+  color: "$black50",
+
+  "&:hover": {
+    color: "$black80",
+    borderTop: "2px solid $black20",
+  },
+
+  variants: {
+    isCurrent: {
+      true: {
+        color: "$purple",
+        borderTop: "2px solid $purple",
+      },
+    },
+  },
+});

--- a/components/Search/Pagination.tsx
+++ b/components/Search/Pagination.tsx
@@ -1,0 +1,69 @@
+import { IconArrowBack, IconArrowForward } from "@/components/Shared/SVG/Icons";
+import {
+  LeftNav,
+  PageNumber,
+  PaginationLinks,
+  PaginationStyled,
+  RightNav,
+} from "@/components/Search/Pagination.styled";
+import Link from "next/link";
+import { Pagination as PaginationShape } from "@/types/api/response";
+import { useRouter } from "next/router";
+
+interface PaginationProps {
+  pagination: PaginationShape;
+}
+
+export const Pagination: React.FC<PaginationProps> = ({ pagination }) => {
+  const { current_page, next_url, prev_url, total_pages } = pagination;
+  const { query, pathname } = useRouter();
+
+  const pages = [];
+  for (let i = 0; i < total_pages; i++) {
+    pages.push(i + 1);
+  }
+
+  return (
+    <PaginationStyled>
+      <LeftNav active={!!prev_url}>
+        <Link
+          href={{
+            pathname,
+            query: { ...query, page: current_page - 1 },
+          }}
+        >
+          <a>
+            <IconArrowBack aria-hidden="true" />
+            Previous
+          </a>
+        </Link>
+      </LeftNav>
+      <PaginationLinks>
+        {pages.map((page) => (
+          <Link
+            key={page}
+            href={{
+              pathname,
+              query: { ...query, page },
+            }}
+          >
+            <PageNumber isCurrent={page === current_page}>{page}</PageNumber>
+          </Link>
+        ))}
+      </PaginationLinks>
+      <RightNav active={!!next_url}>
+        <Link
+          href={{
+            pathname,
+            query: { ...query, page: current_page + 1 },
+          }}
+        >
+          <a>
+            Next
+            <IconArrowForward aria-hidden="true" />
+          </a>
+        </Link>
+      </RightNav>
+    </PaginationStyled>
+  );
+};

--- a/components/Shared/SVG/Icons.tsx
+++ b/components/Shared/SVG/Icons.tsx
@@ -1,3 +1,31 @@
+const IconArrowBack: React.FC = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+    <title>Arrow Back</title>
+    <path
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="48"
+      d="M244 400L100 256l144-144M120 256h292"
+    />
+  </svg>
+);
+
+const IconArrowForward: React.FC = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+    <title>Arrow Forward</title>
+    <path
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="48"
+      d="M268 112l144 144-144 144M392 256H100"
+    />
+  </svg>
+);
+
 const IconCheck: React.FC = () => (
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
     <title>Checkmark</title>
@@ -72,6 +100,8 @@ const IconSocialTwitter: React.FC = () => (
 );
 
 export {
+  IconArrowBack,
+  IconArrowForward,
   IconCheck,
   IconChevronDown,
   IconClear,

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -1,27 +1,34 @@
 import React, { useEffect, useState } from "react";
+import { ApiSearchResponse } from "@/types/api/response";
 import Container from "@/components/Shared/Container";
 import Facets from "@/components/Facets/Facets";
 import Grid from "@/components/Grid/Grid";
 import Heading from "@/components/Heading/Heading";
 import Layout from "@/components/layout";
 import { NextPage } from "next";
+import { Pagination } from "@/components/Search/Pagination";
+import axios from "axios";
 import useFetchApiData from "@/hooks/useFetchApiData";
 import { useRouter } from "next/router";
 import { useSearchState } from "@/context/search-context";
 
 const SearchPage: NextPage = () => {
   const router = useRouter();
-  const { q } = router.query;
+  const { q, page } = router.query;
   const {
     searchDispatch,
     searchState: { userFacets },
   } = useSearchState();
 
+  const [paginatedData, setPaginatedData] =
+    React.useState<ApiSearchResponse | null>();
+  const [paginationRequest, setPaginationRequest] = useState({
+    completed: false,
+    isLoading: false,
+  });
+
   const [searchTerm, setSearchTerm] = useState<string>(q as string);
 
-  /**
-   * set non-context search request params
-   */
   const size = 40;
 
   const {
@@ -30,17 +37,36 @@ const SearchPage: NextPage = () => {
     loading,
   } = useFetchApiData({ searchTerm, size, userFacets });
 
-
   useEffect(() => {
     if (searchTerm !== q) setSearchTerm(q as string);
   }, [q, searchTerm]);
 
   useEffect(() => {
-    searchDispatch({
-      aggregations: apiData?.aggregations,
-      type: "updateAggregations",
-    });
-  }, [apiData, searchDispatch]);
+    async function updateGridData() {
+      const isIdle =
+        !paginationRequest.completed && !paginationRequest.isLoading;
+
+      if (page && paginatedData && isIdle) {
+        const url = `${paginatedData?.pagination.query_url}/&page=${page}`;
+        setPaginationRequest({ ...paginationRequest, isLoading: true });
+        const result = await axios.get(url);
+        setPaginatedData(result.data);
+        setPaginationRequest({ completed: true, isLoading: false });
+        return;
+      }
+
+      if (isIdle) {
+        searchDispatch({
+          aggregations: apiData?.aggregations,
+          type: "updateAggregations",
+        });
+        apiData && setPaginatedData(apiData);
+      }
+    }
+    updateGridData();
+  }, [apiData, page, paginatedData, paginationRequest, searchDispatch]);
+
+  if (!paginatedData) return null;
 
   return (
     <Layout data-testid="search-page-wrapper">
@@ -52,7 +78,8 @@ const SearchPage: NextPage = () => {
       {error && <p>{error}</p>}
       {apiData && (
         <Container containerType="wide">
-          <Grid data={apiData.data} info={apiData.info} />
+          <Grid data={paginatedData.data} info={apiData.info} />
+          <Pagination pagination={paginatedData.pagination} />
         </Container>
       )}
     </Layout>

--- a/types/api/response.ts
+++ b/types/api/response.ts
@@ -29,6 +29,7 @@ export type ApiResponseData = CollectionShape | SearchShape[] | WorkShape;
 export interface ApiSearchResponse extends ApiResponse {
   aggregations?: ApiResponseAggregation;
   data: SearchShape[];
+  pagination: Pagination;
 }
 
 /**
@@ -48,6 +49,17 @@ export interface ApiResponseDataShape {
  */
 export interface ApiWorkResponse {
   data: WorkShape | undefined;
+}
+
+export interface Pagination {
+  query_url: string;
+  current_page: number;
+  limit: number;
+  offset: number;
+  total_hits: number;
+  total_pages: number;
+  prev_url?: string;
+  next_url?: string;
 }
 
 /**


### PR DESCRIPTION
## What does this do?
- This handles pagination and makes use of the `pagination` object returned from a `/search` API request.   
- It's a first approach to making the Search Page component aware of pagination, and how and when to fetch paginated data.  Future iterations can build from this initial pattern.
- Pagination is synced to browser url `history` API
- Some base level styling

## What this does *not* do
- It does not update the browser URL when new facets are updated.  It should, but outside the scope of this ticket perhaps.

![image](https://user-images.githubusercontent.com/3020266/187981856-be58f01b-6aaf-43d0-a957-5900169d6a23.png)


## To test
1. Go to the search page and interact with pagination links
2. Try doing a new search, or adding some facets and observe the behavior.