### PR TITLE
Support deep linking of user selected facets

### DIFF
--- a/components/Collection/Tabs/Metadata.tsx
+++ b/components/Collection/Tabs/Metadata.tsx
@@ -5,7 +5,6 @@ import {
 import { ApiResponseBucket } from "@/types/api/response";
 import React from "react";
 import { useRouter } from "next/router";
-import { useSearchState } from "@/context/search-context";
 
 interface CollectionTabsMetadataProps {
   metadata: ApiResponseBucket[];
@@ -19,7 +18,6 @@ const CollectionTabsMetadata: React.FC<CollectionTabsMetadataProps> = ({
 }) => {
   const router = useRouter();
   const grouped: Groups = {};
-  const { searchDispatch } = useSearchState();
 
   /**
    * Make the flat list of metadata aggs into an alphabetized, grouped list
@@ -31,13 +29,7 @@ const CollectionTabsMetadata: React.FC<CollectionTabsMetadataProps> = ({
   });
 
   const handleMetadataClick = (key: string) => {
-    searchDispatch({
-      type: "updateUserFacets",
-      userFacets: {
-        subject: [key],
-      },
-    });
-    router.push("/search");
+    router.push({ pathname: "/search", query: { subject: [key] } });
   };
 
   return (

--- a/components/Facets/Facet/Options.tsx
+++ b/components/Facets/Facet/Options.tsx
@@ -29,7 +29,7 @@ const FacetOptions: React.FC<FacetOptionsProps> = ({
     aggsFilterValue,
     searchTerm: q,
     size: 0,
-    userFacets: userFacetsUnsubmitted,
+    urlFacets: userFacetsUnsubmitted,
   });
 
   if (loading) return <SpinLoader />;

--- a/components/Facets/Filter/Filter.tsx
+++ b/components/Facets/Filter/Filter.tsx
@@ -11,13 +11,15 @@ import FacetsCurrentUser from "@/components/Facets/UserFacets/UserFacets";
 import FilterModal from "@/components/Facets/Filter/Modal";
 import Icon from "@/components/Shared/Icon";
 import { IconFilter } from "@/components/Shared/SVG/Icons";
+import useQueryParams from "@/hooks/useQueryParams";
 import { useSearchState } from "@/context/search-context";
 
 const DialogWrapper: React.FC = () => {
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const { filterDispatch } = useFilterState();
   const { searchState } = useSearchState();
-  const { q, userFacets } = searchState;
+  const { q } = searchState;
+  const { urlFacets } = useQueryParams();
 
   const handleDialogChange = () => {
     /**
@@ -27,7 +29,7 @@ const DialogWrapper: React.FC = () => {
     if (!isModalOpen) {
       filterDispatch({
         type: "updateUserFacets",
-        userFacetsUnsubmitted: userFacets,
+        userFacetsUnsubmitted: urlFacets,
       });
     }
     setIsModalOpen(!isModalOpen);
@@ -42,7 +44,7 @@ const DialogWrapper: React.FC = () => {
           </Icon>
           Filter
         </FilterActivate>
-        <FacetsCurrentUser screen="search" />
+        <FacetsCurrentUser screen="search" urlFacets={urlFacets} />
       </FilterFloating>
       <Dialog.Portal>
         <DialogOverlay />

--- a/components/Facets/Filter/Modal.tsx
+++ b/components/Facets/Filter/Modal.tsx
@@ -34,7 +34,7 @@ const FilterModal: React.FC<FilterModalProps> = ({ q, setIsModalOpen }) => {
   } = useFetchApiData({
     searchTerm: q,
     size: 5,
-    userFacets: userFacetsUnsubmitted,
+    urlFacets: userFacetsUnsubmitted,
   });
 
   if (error) console.warn(error);

--- a/components/Facets/Filter/Submit.test.tsx
+++ b/components/Facets/Filter/Submit.test.tsx
@@ -1,10 +1,13 @@
 import { fireEvent, render, screen } from "@/test-utils";
 import FacetsSubmit from "@/components/Facets/Filter/Submit";
+import mockRouter from "next-router-mock";
 
+jest.mock("next/router", () => require("next-router-mock"));
 const mockFn = jest.fn();
 
 describe("Submit component", () => {
   function renderHelper() {
+    mockRouter.setCurrentUrl("/search");
     return render(<FacetsSubmit setIsModalOpen={mockFn} />);
   }
 

--- a/components/Facets/Filter/Submit.tsx
+++ b/components/Facets/Filter/Submit.tsx
@@ -1,32 +1,44 @@
 import { Button } from "@nulib/design-system";
 import { SetIsModalOpenType } from "@/components/Facets/Filter/Modal";
 import { useFilterState } from "@/context/filter-context";
-import { useSearchState } from "@/context/search-context";
+import useQueryParams from "@/hooks/useQueryParams";
+import { useRouter } from "next/router";
 
-interface FacetsSubmitProps {
+interface FacetsFilterSubmitProps {
   setIsModalOpen: SetIsModalOpenType;
   total?: number;
 }
 
-const FacetsSubmit: React.FC<FacetsSubmitProps> = ({
+const FacetsFilterSubmit: React.FC<FacetsFilterSubmitProps> = ({
   setIsModalOpen,
   total,
 }) => {
+  const router = useRouter();
+  const { query: q } = router;
+  const { urlFacets } = useQueryParams();
+
   const {
     filterDispatch,
     filterState: { userFacetsUnsubmitted },
   } = useFilterState();
-  const { searchDispatch } = useSearchState();
 
   const handleSubmit = () => {
-    searchDispatch({
-      type: "updateUserFacets",
-      userFacets: userFacetsUnsubmitted,
-    });
     filterDispatch({
       type: "updateUserFacets",
       userFacetsUnsubmitted: {},
     });
+
+    const newQueryObj = {
+      ...(q && q),
+      ...urlFacets,
+      ...userFacetsUnsubmitted,
+    };
+
+    router.push({
+      pathname: "/search",
+      query: newQueryObj,
+    });
+
     setIsModalOpen(false);
   };
 
@@ -39,4 +51,4 @@ const FacetsSubmit: React.FC<FacetsSubmitProps> = ({
   );
 };
 
-export default FacetsSubmit;
+export default FacetsFilterSubmit;

--- a/components/Facets/UserFacets/UserFacets.tsx
+++ b/components/Facets/UserFacets/UserFacets.tsx
@@ -7,13 +7,14 @@ import {
 import { useEffect, useState } from "react";
 import FacetsCurrentUserValue from "@/components/Facets/UserFacets/Value";
 import { IconChevronDown } from "@/components/Shared/SVG/Icons";
-import { UserFacets } from "@/types/context/search-context";
+import { UrlFacets } from "@/types/context/filter-context";
 import { getFacetById } from "@/lib/utils/facet-helpers";
 import { useFilterState } from "@/context/filter-context";
-import { useSearchState } from "@/context/search-context";
+import { useRouter } from "next/router";
 
 interface FacetsCurrentUserProps {
   screen: "modal" | "search";
+  urlFacets?: UrlFacets;
 }
 
 export interface CurrentFacet {
@@ -22,17 +23,19 @@ export interface CurrentFacet {
   value: string;
 }
 
-const FacetsUserFacets: React.FC<FacetsCurrentUserProps> = ({ screen }) => {
+const FacetsCurrentUser: React.FC<FacetsCurrentUserProps> = ({
+  screen,
+  urlFacets,
+}) => {
   const [currentOptions, setCurrentOptions] = useState<CurrentFacet[]>([]);
-
-  const { searchDispatch, searchState } = useSearchState();
+  const router = useRouter();
   const { filterDispatch, filterState } = useFilterState();
 
-  let facets: UserFacets | undefined;
+  let facets: UrlFacets | undefined;
 
   switch (screen) {
     case "search":
-      facets = searchState.userFacets;
+      facets = urlFacets;
       break;
     case "modal":
       facets = filterState.userFacetsUnsubmitted;
@@ -52,9 +55,10 @@ const FacetsUserFacets: React.FC<FacetsCurrentUserProps> = ({ screen }) => {
       const facet = getFacetById(facetId);
       if (facet) {
         const { id, label } = facet;
-        facetKeys.forEach((value) => {
-          current.push({ id, label, value });
-        });
+        facetKeys &&
+          facetKeys.forEach((value) => {
+            current.push({ id, label, value });
+          });
       }
     }
     setCurrentOptions(current);
@@ -63,14 +67,14 @@ const FacetsUserFacets: React.FC<FacetsCurrentUserProps> = ({ screen }) => {
   function handleRemoval(instance: CurrentFacet) {
     if (instance && facets) {
       const { id, value } = instance;
-      const newObj: UserFacets = { ...facets };
+      const newObj: UrlFacets = { ...facets };
 
       newObj[id] = newObj[id].filter((key) => key !== value);
 
       if (screen === "search")
-        searchDispatch({
-          type: "updateUserFacets",
-          userFacets: newObj,
+        router.push({
+          pathname: "/search",
+          query: { ...router.query, ...newObj },
         });
 
       if (screen === "modal")
@@ -83,7 +87,7 @@ const FacetsUserFacets: React.FC<FacetsCurrentUserProps> = ({ screen }) => {
   }
 
   /**
-   * If user has no selected facet options, return an empty fragement.
+   * If user has no selected facet options, return an empty fragment.
    */
 
   if (currentOptions.length === 0) return <></>;
@@ -126,4 +130,4 @@ const FacetsUserFacets: React.FC<FacetsCurrentUserProps> = ({ screen }) => {
   );
 };
 
-export default FacetsUserFacets;
+export default FacetsCurrentUser;

--- a/components/Facets/WorkType/WorkType.tsx
+++ b/components/Facets/WorkType/WorkType.tsx
@@ -1,33 +1,18 @@
 import { useEffect, useState } from "react";
 import { FACETS_WORK_TYPE } from "@/lib/constants/facets-model";
 import RadioGroup from "./RadioGroup";
-import { UserFacets } from "@/types/context/search-context";
 import { WorkTypeOptions } from "@/types/components/facets";
-// import useFetchApiData from "@/hooks/useFetchApiData";
-import { useSearchState } from "@/context/search-context";
+import useQueryParams from "@/hooks/useQueryParams";
+import { useRouter } from "next/router";
 
 const WorkType: React.FC = () => {
+  const router = useRouter();
   const [currentValue, setCurrentValue] = useState<WorkTypeOptions>("All");
   const { id } = FACETS_WORK_TYPE.facets[0];
+  const { urlFacets } = useQueryParams();
+  const { query: q } = router;
 
-  const { searchDispatch, searchState } = useSearchState();
-  const { userFacets } = searchState;
-
-  const workTypeFacet = userFacets[id];
-
-  /**
-   * set non-context search request params
-   */
-  // const size = 0;
-  // const activeFacets = FACETS_WORK_TYPE.facets;
-  // const searchTerm = q;
-
-  // const { data } = useFetchApiData({
-  //   activeFacets,
-  //   searchTerm,
-  //   size,
-  //   userFacets,
-  // });
+  const workTypeFacet = urlFacets[id];
 
   useEffect(() => {
     if (workTypeFacet && workTypeFacet.length > 0) {
@@ -38,7 +23,7 @@ const WorkType: React.FC = () => {
   }, [workTypeFacet]);
 
   const handleValueChange = (value: string) => {
-    const newObj: UserFacets = { ...userFacets };
+    const newObj = { ...urlFacets };
 
     switch (value) {
       case "All":
@@ -49,9 +34,9 @@ const WorkType: React.FC = () => {
         break;
     }
 
-    searchDispatch({
-      type: "updateUserFacets",
-      userFacets: newObj,
+    router.push({
+      pathname: "/search",
+      query: { ...(q && q), ...newObj },
     });
 
     return;

--- a/components/Search/Search.tsx
+++ b/components/Search/Search.tsx
@@ -8,7 +8,7 @@ import {
   useState,
 } from "react";
 import { IconClear, IconSearch } from "../Shared/SVG/Icons";
-import Router, { useRouter } from "next/router";
+import { useRouter } from "next/router";
 import { useSearchState } from "@/context/search-context";
 interface SearchProps {
   isSearchActive: (value: boolean) => void;
@@ -24,12 +24,15 @@ const Search: React.FC<SearchProps> = ({ isSearchActive }) => {
 
   const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
     e.preventDefault();
-    let query = "";
-    if (searchValue) query = `?q=${encodeURI(searchValue.replace(/ /g, "+"))}`;
-    Router.push(`/search${query}`);
     searchDispatch({
       q: searchValue,
       type: "updateSearch",
+    });
+    router.push({
+      pathname: "/search",
+      query: {
+        q: searchValue,
+      },
     });
   };
 
@@ -40,7 +43,7 @@ const Search: React.FC<SearchProps> = ({ isSearchActive }) => {
     setSearchValue(e.target.value);
 
   const clearSearchResults = () => {
-    Router.push(`/search`);
+    router.push(`/search`);
     setSearchValue("");
     if (search.current) search.current.value = "";
   };

--- a/context/filter-context.tsx
+++ b/context/filter-context.tsx
@@ -1,7 +1,4 @@
-import {
-  FilterContextStore,
-  UserFacetsUnsubmitted,
-} from "@/types/context/filter-context";
+import { FilterContextStore, UrlFacets } from "@/types/context/filter-context";
 import { FacetsInstance } from "@/types/components/facets";
 import React from "react";
 
@@ -12,7 +9,7 @@ type Action =
     }
   | {
       type: "updateUserFacets";
-      userFacetsUnsubmitted: UserFacetsUnsubmitted;
+      userFacetsUnsubmitted: UrlFacets;
     };
 type Dispatch = (action: Action) => void;
 type State = FilterContextStore;

--- a/context/search-context.tsx
+++ b/context/search-context.tsx
@@ -1,6 +1,6 @@
-import { SearchContextStore, UserFacets } from "@/types/context/search-context";
 import { ApiResponseAggregation } from "@/types/api/response";
 import React from "react";
+import { SearchContextStore } from "@/types/context/search-context";
 
 type Action =
   | {
@@ -8,8 +8,7 @@ type Action =
       aggregations: ApiResponseAggregation | undefined;
     }
   | { type: "updateSearch"; q: string }
-  | { type: "updateSearchFixed"; searchFixed: boolean }
-  | { type: "updateUserFacets"; userFacets: UserFacets };
+  | { type: "updateSearchFixed"; searchFixed: boolean };
 
 type Dispatch = (action: Action) => void;
 type State = SearchContextStore;
@@ -22,7 +21,6 @@ const defaultState: SearchContextStore = {
   aggregations: {},
   q: "",
   searchFixed: false,
-  userFacets: {},
 };
 
 const SearchStateContext = React.createContext<
@@ -47,12 +45,6 @@ function searchReducer(state: State, action: Action) {
       return {
         ...state,
         searchFixed: action.searchFixed,
-      };
-    }
-    case "updateUserFacets": {
-      return {
-        ...state,
-        userFacets: action.userFacets,
       };
     }
     default: {

--- a/hooks/useQueryParams.ts
+++ b/hooks/useQueryParams.ts
@@ -1,0 +1,16 @@
+import React from "react";
+import { UrlFacets } from "@/types/context/filter-context";
+import { parseUrlFacets } from "@/lib/utils/facet-helpers";
+import { useRouter } from "next/router";
+
+export default function useQueryParams() {
+  const router = useRouter();
+  const [urlFacets, setUrlFacets] = React.useState<UrlFacets>({});
+
+  React.useEffect(() => {
+    const obj = parseUrlFacets(router.query);
+    setUrlFacets(obj);
+  }, [router.query]);
+
+  return { urlFacets };
+}

--- a/lib/queries/aggs.ts
+++ b/lib/queries/aggs.ts
@@ -1,6 +1,6 @@
 import { Aggs } from "@/types/api/request";
 import { FacetsInstance } from "@/types/components/facets";
-import { UserFacets } from "@/types/context/search-context";
+import { UrlFacets } from "@/types/context/filter-context";
 
 /**
  * This constructs the `aggs` property as part of an elastic search query request
@@ -9,7 +9,7 @@ import { UserFacets } from "@/types/context/search-context";
 export const buildAggs = (
   facets: FacetsInstance[],
   facetFilterValue: string | undefined,
-  userFacets: UserFacets
+  userFacets: UrlFacets
 ) => {
   const aggs: Aggs = {};
 

--- a/lib/queries/builder.ts
+++ b/lib/queries/builder.ts
@@ -1,7 +1,7 @@
 import { buildSearchPart, querySearchTemplate } from "@/lib/queries/search";
 import { ApiSearchRequest } from "@/types/api/request";
 import { FacetsInstance } from "@/types/components/facets";
-import { UserFacets } from "@/types/context/search-context";
+import { UrlFacets } from "@/types/context/filter-context";
 import { buildAggs } from "@/lib/queries/aggs";
 import { buildFacetPart } from "@/lib/queries/facet";
 
@@ -10,11 +10,11 @@ type BuildQueryProps = {
   aggsFilterValue?: string;
   size?: number;
   term: string;
-  userFacets: UserFacets;
+  urlFacets: UrlFacets;
 };
 
 export function buildQuery(obj: BuildQueryProps) {
-  const { aggs, aggsFilterValue, size, term, userFacets } = obj;
+  const { aggs, aggsFilterValue, size, term, urlFacets } = obj;
   let newQuery: ApiSearchRequest = JSON.parse(
     JSON.stringify(querySearchTemplate)
   );
@@ -29,21 +29,21 @@ export function buildQuery(obj: BuildQueryProps) {
   /**
    * Add facets to the API query
    */
-  newQuery = addFacetsToQuery(newQuery, userFacets);
+  newQuery = addFacetsToQuery(newQuery, urlFacets);
 
   /**
    * Add aggregations to the API query
    */
-  if (aggs) newQuery.aggs = buildAggs(aggs, aggsFilterValue, userFacets);
+  if (aggs) newQuery.aggs = buildAggs(aggs, aggsFilterValue, urlFacets);
 
   return newQuery;
 }
 
 export function addFacetsToQuery(
   query: ApiSearchRequest,
-  userFacets: UserFacets
+  urlFacets: UrlFacets
 ) {
-  for (const [key, value] of Object.entries(userFacets)) {
+  for (const [key, value] of Object.entries(urlFacets)) {
     if (value?.length > 0) {
       query.query.bool.must.push(buildFacetPart(key, value));
     }

--- a/lib/utils/facet-helpers.ts
+++ b/lib/utils/facet-helpers.ts
@@ -1,5 +1,6 @@
 import { ALL_FACETS, FACETS } from "@/lib/constants/facets-model";
 import { FacetsGroup, FacetsInstance } from "@/types/components/facets";
+import { UrlFacets } from "@/types/context/filter-context";
 
 export const getFacetById = (id: string): FacetsInstance | undefined => {
   return ALL_FACETS.facets.find((facet) => facet.id === id);
@@ -7,4 +8,24 @@ export const getFacetById = (id: string): FacetsInstance | undefined => {
 
 export const getFacetGroup = (id: string): FacetsGroup | undefined => {
   return FACETS.find((group) => group.facets.find((facet) => facet.id === id));
+};
+
+/**
+ * Filter out "q" and "page" from the browser url query params
+ * to get only facet query param data
+ */
+type NextJSRouterQuery = NodeJS.Dict<string[] | string>;
+export const parseUrlFacets = (routerQuery: NextJSRouterQuery) => {
+  if (!routerQuery) return {};
+  const obj: UrlFacets = {};
+
+  for (const [key, value] of Object.entries(routerQuery)) {
+    if (!["q", "page"].includes(key)) {
+      if (key && value) {
+        obj[key] = Array.isArray(value) ? value : [value];
+      }
+    }
+  }
+
+  return obj;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "husky": "^8.0.1",
         "jest": "^28.1.2",
         "jest-environment-jsdom": "^28.1.2",
+        "next-router-mock": "^0.7.4",
         "prettier": "^2.6.2",
         "typescript": "^4.5.5"
       },
@@ -4036,9 +4037,9 @@
       }
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.24.36",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.36.tgz",
-      "integrity": "sha512-KxQQnSP+5x+JbBbnz0ZwCK0KQ06Wsvt8eYCUsBkt+h80+iXaVJzfDQ9GmAcypfUk/HrQL+l1Hjz1Fjeznfs+Uw==",
+      "version": "0.24.38",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.38.tgz",
+      "integrity": "sha512-IbYB6vdhLFmzGEyXXEdFAJKyq7S4/RsivkgxNzs/LzwYuUJHmeNQ0cHkjG/Yqm6VgUzzZDLMZAf0XgeeaZAocA==",
       "dev": true
     },
     "node_modules/@sinonjs/commons": {
@@ -5766,9 +5767,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.242",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.242.tgz",
-      "integrity": "sha512-nPdgMWtjjWGCtreW/2adkrB2jyHjClo9PtVhR6rW+oxa4E4Wom642Tn+5LslHP3XPL5MCpkn5/UEY60EXylNeQ==",
+      "version": "1.4.243",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.243.tgz",
+      "integrity": "sha512-BgLD2gBX43OSXwlT01oYRRD5NIB4n3okTRxkzEAC6G0SZG4TTlyrWMjbOo0fajCwqwpRtMHXQNMjtRN6qpNtfw==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -6303,9 +6304,9 @@
       }
     },
     "node_modules/eslint-plugin-testing-library": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-5.6.1.tgz",
-      "integrity": "sha512-url6n7SbPg77TM2MLy1XkcrQEWiS5nKcDiJgwOYz2qGCEMywM7gizPzLi3XalJPdpIkQAo2BJFQZC6jggsyCuQ==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-5.6.2.tgz",
+      "integrity": "sha512-imakD/MY+8Rp3r69G7Pt1egmLZscSWoIhrxgdVR3kr2nlHImRRh7LeFcoqfAA5CK1rzFFV6rBEp3GTfOEYMpNw==",
       "dev": true,
       "dependencies": {
         "@typescript-eslint/utils": "^5.13.0"
@@ -6984,9 +6985,9 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-7.2.1.tgz",
-      "integrity": "sha512-bt2ZqqGpPsW6UojYUa5poWQJu3sDr4Dp3IZsdVBYdKUJ8p+9PxOk1fYRAT8lTGGmaC5HFoKrbDXQeKWGAKZz9g==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-7.3.2.tgz",
+      "integrity": "sha512-BTG0BqJSwxoFBWpwaaxS/954DGZFsluF+dUv9Hfq53VNkwUt5g+wYTEM66oTUhiH/+6R/y0Rq+BmkUBcmzbyMQ==",
       "dependencies": {
         "@motionone/dom": "10.13.1",
         "framesync": "6.1.2",
@@ -10568,6 +10569,16 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-router-mock": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/next-router-mock/-/next-router-mock-0.7.4.tgz",
+      "integrity": "sha512-phYLFXOQ9klg6gxVRJJdH0QoD+5bAbAdDYM9O3YdGZ+IFEbvIoIns+o9SoSfTkCjzoU2R1ARoFc8WHp0+hnD8A==",
+      "dev": true,
+      "peerDependencies": {
+        "next": ">=10.0.0",
+        "react": ">=17.0.0"
       }
     },
     "node_modules/node-domexception": {
@@ -15567,9 +15578,9 @@
       }
     },
     "@sinclair/typebox": {
-      "version": "0.24.36",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.36.tgz",
-      "integrity": "sha512-KxQQnSP+5x+JbBbnz0ZwCK0KQ06Wsvt8eYCUsBkt+h80+iXaVJzfDQ9GmAcypfUk/HrQL+l1Hjz1Fjeznfs+Uw==",
+      "version": "0.24.38",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.38.tgz",
+      "integrity": "sha512-IbYB6vdhLFmzGEyXXEdFAJKyq7S4/RsivkgxNzs/LzwYuUJHmeNQ0cHkjG/Yqm6VgUzzZDLMZAf0XgeeaZAocA==",
       "dev": true
     },
     "@sinonjs/commons": {
@@ -16889,9 +16900,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.242",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.242.tgz",
-      "integrity": "sha512-nPdgMWtjjWGCtreW/2adkrB2jyHjClo9PtVhR6rW+oxa4E4Wom642Tn+5LslHP3XPL5MCpkn5/UEY60EXylNeQ==",
+      "version": "1.4.243",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.243.tgz",
+      "integrity": "sha512-BgLD2gBX43OSXwlT01oYRRD5NIB4n3okTRxkzEAC6G0SZG4TTlyrWMjbOo0fajCwqwpRtMHXQNMjtRN6qpNtfw==",
       "dev": true
     },
     "emittery": {
@@ -17435,9 +17446,9 @@
       "requires": {}
     },
     "eslint-plugin-testing-library": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-5.6.1.tgz",
-      "integrity": "sha512-url6n7SbPg77TM2MLy1XkcrQEWiS5nKcDiJgwOYz2qGCEMywM7gizPzLi3XalJPdpIkQAo2BJFQZC6jggsyCuQ==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-5.6.2.tgz",
+      "integrity": "sha512-imakD/MY+8Rp3r69G7Pt1egmLZscSWoIhrxgdVR3kr2nlHImRRh7LeFcoqfAA5CK1rzFFV6rBEp3GTfOEYMpNw==",
       "dev": true,
       "requires": {
         "@typescript-eslint/utils": "^5.13.0"
@@ -17792,9 +17803,9 @@
       }
     },
     "framer-motion": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-7.2.1.tgz",
-      "integrity": "sha512-bt2ZqqGpPsW6UojYUa5poWQJu3sDr4Dp3IZsdVBYdKUJ8p+9PxOk1fYRAT8lTGGmaC5HFoKrbDXQeKWGAKZz9g==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-7.3.2.tgz",
+      "integrity": "sha512-BTG0BqJSwxoFBWpwaaxS/954DGZFsluF+dUv9Hfq53VNkwUt5g+wYTEM66oTUhiH/+6R/y0Rq+BmkUBcmzbyMQ==",
       "requires": {
         "@emotion/is-prop-valid": "^0.8.2",
         "@motionone/dom": "10.13.1",
@@ -20458,6 +20469,13 @@
         "styled-jsx": "5.0.4",
         "use-sync-external-store": "1.2.0"
       }
+    },
+    "next-router-mock": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/next-router-mock/-/next-router-mock-0.7.4.tgz",
+      "integrity": "sha512-phYLFXOQ9klg6gxVRJJdH0QoD+5bAbAdDYM9O3YdGZ+IFEbvIoIns+o9SoSfTkCjzoU2R1ARoFc8WHp0+hnD8A==",
+      "dev": true,
+      "requires": {}
     },
     "node-domexception": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "husky": "^8.0.1",
     "jest": "^28.1.2",
     "jest-environment-jsdom": "^28.1.2",
+    "next-router-mock": "^0.7.4",
     "prettier": "^2.6.2",
     "typescript": "^4.5.5"
   },

--- a/pages/collections/[id].tsx
+++ b/pages/collections/[id].tsx
@@ -26,7 +26,6 @@ import CollectionTabsMetadata from "@/components/Collection/Tabs/Metadata";
 import Container from "@/components/Shared/Container";
 import Layout from "components/layout";
 import { useRouter } from "next/router";
-import { useSearchState } from "@/context/search-context";
 
 interface CollectionProps {
   collection: CollectionShape | null;
@@ -34,7 +33,6 @@ interface CollectionProps {
 }
 
 const Collection: NextPage<CollectionProps> = ({ collection, metadata }) => {
-  const { searchDispatch } = useSearchState();
   const router = useRouter();
 
   if (!collection) return null;
@@ -46,13 +44,7 @@ const Collection: NextPage<CollectionProps> = ({ collection, metadata }) => {
     : "";
 
   const handleSearchClick = () => {
-    searchDispatch({
-      type: "updateUserFacets",
-      userFacets: {
-        collection: [title],
-      },
-    });
-    router.push("/search");
+    router.push({ pathname: "/search", query: { collection: [title] } });
   };
 
   return (

--- a/types/context/filter-context.ts
+++ b/types/context/filter-context.ts
@@ -1,9 +1,13 @@
 import { FacetsInstance } from "@/types/components/facets";
 export interface FilterContextStore {
   recentFacet?: FacetsInstance;
-  userFacetsUnsubmitted: UserFacetsUnsubmitted;
+  userFacetsUnsubmitted: UrlFacets;
 }
 
-export interface UserFacetsUnsubmitted {
-  [key: string]: string[];
-}
+export type UrlFacets =
+  | {
+      [key: string]: never;
+    }
+  | {
+      [key: string]: string[];
+    };

--- a/types/context/search-context.ts
+++ b/types/context/search-context.ts
@@ -1,12 +1,11 @@
-import { ApiResponseAggregation } from "../api/response";
+import { ApiResponseAggregation } from "@/types/api/response";
 
 export interface SearchContextStore {
   aggregations?: ApiResponseAggregation;
   q: string;
-  userFacets: UserFacets;
   searchFixed: boolean;
 }
 
 export interface UserFacets {
-  [key: string]: string[];
+  [key: string]: string[] | undefined;
 }


### PR DESCRIPTION
## What does this do?

- Moves tracking/handling user selected facets out of the `SearchProvider` component.
- Current user facets are now read and updated by individual components, via `Next/Link`'s routing object.
- Tests updated to reflect a change in the `SearchProvider` component and supports mocking Next's Router package
- In the Search page component, we bypass the `useFetchApiData` hook and grab the information we want directly from the component.  There were a lot of timing errors relying upon the convenience hook (for some reason), and after trying a bunch of different approaches, this seemed to simplify things and produce consistent results.

<img width="917" alt="image" src="https://user-images.githubusercontent.com/3020266/189720638-57c62600-2c51-4001-8faf-e925b8cb8cf9.png">


## To Test
1. Go to the /search page
2. Try a combination of searching for terms, applying facets, removing facets, etc.
3. New search terms should wipe out previous facet selections.   
4. New facet selections should retain the search query, and narrow down the results
5. Try doing hard refreshes in the browser and notice we can save complex Search page filtering now
