### PR TITLE
Address Download and Share mapping error.

### DIFF
--- a/components/Work/ActionsDialog/DownloadAndShare.tsx
+++ b/components/Work/ActionsDialog/DownloadAndShare.tsx
@@ -51,12 +51,16 @@ const DownloadAndShare: React.FC = () => {
           <CopyText textPrompt="Copy" textToCopy={embedViewerHTML} />
         </EmbedViewer>
 
-        <h3>Download and Embed</h3>
-        <div>
-          {manifest.items.map((item) => (
-            <Item item={item} key={item.id} />
-          ))}
-        </div>
+        {Array.isArray(manifest?.items) && (
+          <>
+            <h3>Download and Embed</h3>
+            <div>
+              {manifest.items.map((item) => (
+                <Item item={item} key={item.id} />
+              ))}
+            </div>
+          </>
+        )}
       </Content>
     </ActionsDialogStyled>
   );

--- a/lib/iiif/manifest-helpers.ts
+++ b/lib/iiif/manifest-helpers.ts
@@ -108,7 +108,7 @@ export const getCanvases = async (id: string) => {
 
     return item;
   });
-  return converted;
+  return converted.items;
 };
 
 export const getInfoResponse = (canvas: Canvas) => {


### PR DESCRIPTION
## What does this do?
This fixes an error on the download and share modal where Canvas items were being improperly packed into the manifest that is delivered to the Work. To further protect from future issues like this we are also now checking to ensure the `manifest.items` is an Array before mapping the values.

## How do we test?
- Go to any work (ex: https://devbox.library.northwestern.edu:3000/items/752cbc86-4b35-4a20-b06a-b87088c164cc)
- Click Download and Share
- Modal should render, with each Image canvas mapped under **Download and Embed**

![image](https://user-images.githubusercontent.com/7376450/193278353-690a33f9-2d17-49f6-b8ad-e8c2af322c4d.png)
