### PR TITLE
Update Search figure src to thumbnail endpoint.

### DIFF
--- a/components/Grid/Grid.tsx
+++ b/components/Grid/Grid.tsx
@@ -1,8 +1,10 @@
 import { GridItem, GridStyled } from "@/components/Grid/Grid.styled";
 import Container from "@/components/Shared/Container";
+import { DCAPI_ENDPOINT } from "@/lib/constants/endpoints";
 import Figure from "@/components/Figure/Figure";
 import Link from "next/link";
 import { SearchShape } from "@/types/api/response";
+
 interface GridProps {
   data: SearchShape[];
   info: { total?: number };
@@ -18,12 +20,12 @@ const Grid: React.FC<GridProps> = ({ data = [] }) => {
         columnClassName="dc-grid-column"
       >
         {data.map((item: SearchShape) => (
-          <GridItem key={item.accession_number}>
+          <GridItem key={item.accession_number} data-item-id={item.id}>
             <Link href={`/items/${item.id}`}>
               <a>
                 <Figure
                   data={{
-                    src: item.thumbnail,
+                    src: `${DCAPI_ENDPOINT}/works/${item.id}/thumbnail`,
                     supplementalInfo: item.work_type,
                     title: item.title ? item.title : item.accession_number,
                   }}


### PR DESCRIPTION
## What does this do?

This change swaps out the `src` prop value to use the /`thumbnail` endpoint for search results on works.

![image](https://user-images.githubusercontent.com/7376450/193332483-40e29ceb-ee88-4320-aa81-a667ec808c05.png)
