### PR TITLE
Add JSON-LD structured data for Google to the app

### DIFF
--- a/lib/json-ld.test.ts
+++ b/lib/json-ld.test.ts
@@ -1,0 +1,97 @@
+import {
+  loadCollectionStructuredData,
+  loadDefaultStructuredData,
+  loadItemStructuredData,
+} from "@/lib/json-ld";
+import { CollectionShape } from "@/types/components/collections";
+import { sampleWork2 } from "@/mocks/sample-work2";
+
+const collectionMock = {
+  admin_email: null,
+  api_link:
+    "https://dcapi.rdc-staging.library.northwestern.edu/api/v2/collections/bfeeb065-5b12-4b10-9883-f32b133c7cd1",
+  api_model: "Collection",
+  create_date: "2021-03-12T02:11:32.342977Z",
+  description:
+    "These images were from the Slide Library which was once in the Visual Media Center under the Department of Art History at Northwestern University.",
+  featured: null,
+  finding_aid_url: null,
+  id: "bfeeb065-5b12-4b10-9883-f32b133c7cd1",
+  indexed_at: "2022-10-03T23:44:19.807482",
+  keywords: [],
+  modified_date: "2022-02-24T23:51:16.111583Z",
+  published: true,
+  representative_image: {
+    url: "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/1ceaa647-1b1b-4e9d-8e3f-2a1539af3410",
+    work_id: "ff520ae7-1621-4b59-9da7-6cf10450b717",
+  },
+  title: "Department of Art History || Slide Collection",
+  visibility: "Institution",
+};
+const pathName = "/ima/path";
+
+it("returns the expected default structured data ", () => {
+  const obj = loadDefaultStructuredData();
+  expect(Object.keys(obj).length).toBeGreaterThan(0);
+  expect(obj["@type"]).toEqual("WebSite");
+  expect(obj).toHaveProperty("@context");
+  expect(obj).toHaveProperty("name");
+  expect(obj).toHaveProperty("description");
+  expect(obj).toHaveProperty("url");
+});
+
+describe("collection structured data", () => {
+  it("returns the expected collection structured data ", () => {
+    const obj = loadCollectionStructuredData(
+      collectionMock as CollectionShape,
+      pathName
+    );
+    expect(obj["@type"]).toEqual("Collection");
+    expect(obj).toHaveProperty("@context");
+    expect(obj).toHaveProperty("name");
+    expect(obj).toHaveProperty("description");
+    expect(obj).toHaveProperty("url");
+    expect(obj).toHaveProperty("thumbnail");
+  });
+
+  it("does not add empty values", () => {
+    const anotherMock = { ...collectionMock };
+    anotherMock.description = "";
+    const obj = loadCollectionStructuredData(
+      anotherMock as CollectionShape,
+      pathName
+    );
+    expect(obj).not.toHaveProperty("description");
+  });
+});
+
+describe("work structured data", () => {
+  it("returns the expected work structured data ", () => {
+    const obj = loadItemStructuredData(sampleWork2, pathName);
+
+    expect(obj["@type"]).toEqual("ImageObject");
+    expect(obj).toHaveProperty("@context");
+    expect(obj.about).toEqual(["Mexico--Cuernavaca", "Mexicans"]);
+    expect(obj.contentLocation).toEqual("");
+    expect(obj.contentUrl).toEqual(
+      "https://iiif.stack.rdc-staging.library.northwestern.edu/public/c1/60/29/ff/-d/02/7-/49/6a/-9/8b/7-/6f/25/93/95/a8/f7-manifest.json"
+    );
+    expect(obj.contributor).toEqual('"Roberts, James S."');
+    expect(obj.dateCreated).toEqual("2021-03-16T15:52:00.377715Z");
+    expect(obj.description).toBeUndefined();
+    expect(obj.genre![0]).toEqual("Ima Genre1");
+    expect(obj.image).toEqual(
+      "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/93d75ffe-20d8-48ea-9206-8db9114f2731"
+    );
+    expect(obj.license).toEqual("In Copyright - Educational Use Permitted");
+    expect(obj.name).toEqual(
+      "Hawking dental products in outdoor market, Cuernavaca, Mexico"
+    );
+    expect(obj.thumbnail).toEqual(
+      "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/93d75ffe-20d8-48ea-9206-8db9114f2731/full/!300,300/0/default.jpg"
+    );
+    expect(obj.url).toEqual(
+      "https://digitalcollections.library.northwestern.edu/ima/path"
+    );
+  });
+});

--- a/lib/json-ld.ts
+++ b/lib/json-ld.ts
@@ -1,0 +1,118 @@
+import { CollectionShape } from "@/types/components/collections";
+import { WorkShape } from "@/types/components/works";
+
+const acquireLicensePage =
+  "https://www.library.northwestern.edu/about/administration/policies/rights-permissions.html";
+const productionUrl = "https://digitalcollections.library.northwestern.edu";
+
+/**
+ * Load default values for Google Structured Data
+ */
+export function loadDefaultStructuredData() {
+  return {
+    "@context": "https://schema.org/",
+    "@type": "WebSite",
+    description:
+      "Digital Collections contains thousands of items from Northwestern University Libraries. While only a fraction of materials from the Libraries' collections are represented, the site is representative of the distinction and diversity of collections from the Northwestern Government and Geographic Information collection, Herskovits Library of African Studies, Music Library, McCormick Library of Special Collections, Transportation Library, and University Archives.",
+    name: "Northwestern University Libraries | Digital Collections",
+    potentialAction: {
+      "@type": "SearchAction",
+      "query-input": "required name=search_term_string",
+      target:
+        "https://digitalcollections.library.northwestern.edu/search?q={search_term_string}",
+    },
+    url: "https://digitalcollections.library.northwestern.edu",
+  };
+}
+
+export function loadCollectionStructuredData(
+  collection: CollectionShape,
+  pathname: string
+) {
+  const obj = {
+    "@context": "https://schema.org/",
+    "@type": "Collection",
+    name: collection.title,
+    url: `${productionUrl}${pathname}`,
+    ...(collection.description && { description: collection.description }),
+    thumbnail: `${collection.representative_image?.url}/full/!300,300/0/default.jpg`,
+  };
+
+  return obj;
+}
+
+export function loadItemStructuredData(item: WorkShape, pathname: string) {
+  const {
+    abstract,
+    contributor,
+    creator,
+    create_date,
+    genre,
+    keywords,
+    modified_date,
+    physical_description_material,
+    rights_statement,
+    thumbnail,
+    subject,
+    title,
+    iiif_manifest,
+  } = item;
+
+  const obj = {
+    "@context": "http://schema.org",
+    "@type": "ImageObject",
+    contentUrl: iiif_manifest,
+    image: item.representative_file_set?.url,
+    ...(title && { name: title }),
+    thumbnail,
+    url: `${productionUrl}${pathname}`,
+    ...(subject.length > 0 && { about: subject?.map((x) => x.label) }),
+    acquireLicensePage,
+    ...(creator.length > 0 && {
+      author: item.creator.map((x) => x.label),
+    }),
+    ...(subject.length > 0 && {
+      contentLocation: subject
+        ?.filter((x) => x.role === "GEOGRAPHICAL")
+        .map((x) => accountForCommas(x.role))
+        .join(", "),
+    }),
+    ...(contributor.length > 0 && {
+      contributor: contributor.map((x) => accountForCommas(x.label)).join(", "),
+    }),
+    ...(create_date && {
+      dateCreated: create_date,
+    }),
+    dateModified: modified_date,
+    ...(abstract.length > 0 && {
+      description: abstract?.join(" "),
+    }),
+    ...(genre.length > 0 && {
+      genre: genre.map((x) => x.label),
+    }),
+    ...(keywords.length > 0 && {
+      keywords: keywords?.map((x) => accountForCommas(x)).join(", "),
+    }),
+    ...(rights_statement && {
+      license: rights_statement.label,
+    }),
+    ...(physical_description_material.length > 0 && {
+      material: physical_description_material
+        .map((x) => accountForCommas(x))
+        .join(", "),
+    }),
+  };
+
+  return obj;
+}
+
+/**
+ * Helper function to wrap any values which include a comma, with double quotes to retain context
+ * @param {string} label label value which could be something like "a label value", or "Smith, John"
+ */
+function accountForCommas(label: string) {
+  if (!label) {
+    return "";
+  }
+  return label.indexOf(",") > -1 ? `"${label}"` : label;
+}

--- a/mocks/sample-collection1.ts
+++ b/mocks/sample-collection1.ts
@@ -15,7 +15,7 @@ export const sampleCollection1 = {
   published: true,
   representative_image: {
     url: "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/bdafc6a1-0924-457d-959b-043bda37f2cd",
-    workId: "f75840a5-3bce-4184-b807-6a10d6dceb7c",
+    work_id: "f75840a5-3bce-4184-b807-6a10d6dceb7c",
   },
   title: "Rosenthal Art Slides",
   visibility: "Institution",

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -2,15 +2,26 @@ import Container from "@/components/Shared/Container";
 import Layout from "components/layout";
 import { NextPage } from "next";
 import { PlaceholderBlock } from "@/components/Shared/PlaceholderBlock.styled";
+import Script from "next/script";
 import { buildDataLayer } from "@/lib/ga/data-layer";
+import { loadDefaultStructuredData } from "@/lib/json-ld";
 
 const AboutPage: NextPage = () => {
   return (
-    <Layout>
-      <Container>
-        <PlaceholderBlock>About page</PlaceholderBlock>
-      </Container>
-    </Layout>
+    <>
+      <Script
+        id="app-ld-json"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(loadDefaultStructuredData(), null, "\t"),
+        }}
+      />
+      <Layout>
+        <Container>
+          <PlaceholderBlock>About page</PlaceholderBlock>
+        </Container>
+      </Layout>
+    </>
   );
 };
 

--- a/pages/collections/[id].tsx
+++ b/pages/collections/[id].tsx
@@ -25,7 +25,9 @@ import CollectionTabsExplore from "@/components/Collection/Tabs/Explore";
 import CollectionTabsMetadata from "@/components/Collection/Tabs/Metadata";
 import Container from "@/components/Shared/Container";
 import Layout from "components/layout";
+import Script from "next/script";
 import { buildDataLayer } from "@/lib/ga/data-layer";
+import { loadCollectionStructuredData } from "@/lib/json-ld";
 import { useRouter } from "next/router";
 
 interface CollectionProps {
@@ -49,53 +51,69 @@ const Collection: NextPage<CollectionProps> = ({ collection, metadata }) => {
   };
 
   return (
-    <Layout>
-      <Container containerType="wide">
-        <HeroStyled>
-          <HeroContentWrapper>
-            <HeroContent>
-              <h1>{title}</h1>
-              <ItemsLabel>2336 Items</ItemsLabel>
-              <p>{description}</p>
-              <div>
-                <Button isPrimary onClick={handleSearchClick}>
-                  Search Collection
-                </Button>
-                <Button>Browse Collection</Button>
-              </div>
-            </HeroContent>
-          </HeroContentWrapper>
-          <HeroImageStyled
-            css={{
-              backgroundImage: `url(${collectionBgImage})`,
-            }}
-          />
-        </HeroStyled>
-      </Container>
+    <>
+      <Script
+        id="app-ld-json"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(
+            loadCollectionStructuredData(
+              collection,
+              `/colllections/${collection.id}`
+            ),
+            null,
+            "\t"
+          ),
+        }}
+      />
+      <Layout>
+        <Container containerType="wide">
+          <HeroStyled>
+            <HeroContentWrapper>
+              <HeroContent>
+                <h1>{title}</h1>
+                <ItemsLabel>2336 Items</ItemsLabel>
+                <p>{description}</p>
+                <div>
+                  <Button isPrimary onClick={handleSearchClick}>
+                    Search Collection
+                  </Button>
+                  <Button>Browse Collection</Button>
+                </div>
+              </HeroContent>
+            </HeroContentWrapper>
+            <HeroImageStyled
+              css={{
+                backgroundImage: `url(${collectionBgImage})`,
+              }}
+            />
+          </HeroStyled>
+        </Container>
 
-      <Container>
-        <Tabs defaultValue="metadata">
-          <TabsList aria-label="Explore">
-            <TabsTrigger value="explore">
-              <NavTabTitle>Explore</NavTabTitle>
-            </TabsTrigger>
-            <TabsTrigger value="metadata">
-              <NavTabTitle>Subjects</NavTabTitle>
-            </TabsTrigger>
-            <TabsTrigger value="organization">
-              <NavTabTitle>Collection Organization</NavTabTitle>
-            </TabsTrigger>
-          </TabsList>
-          <TabsContent value="explore">
-            <CollectionTabsExplore />
-          </TabsContent>
-          <TabsContent value="metadata">
-            <CollectionTabsMetadata metadata={metadata} />
-          </TabsContent>
-          <TabsContent value="organization">Yo</TabsContent>
-        </Tabs>
-      </Container>
-    </Layout>
+        <Container>
+          <Tabs defaultValue="metadata">
+            <TabsList aria-label="Explore">
+              <TabsTrigger value="explore">
+                <NavTabTitle>Explore</NavTabTitle>
+              </TabsTrigger>
+              <TabsTrigger value="metadata">
+                <NavTabTitle>Subjects</NavTabTitle>
+              </TabsTrigger>
+              <TabsTrigger value="organization">
+                <NavTabTitle>Collection Organization</NavTabTitle>
+              </TabsTrigger>
+            </TabsList>
+            <TabsContent value="explore">
+              <CollectionTabsExplore />
+            </TabsContent>
+            <TabsContent value="metadata">
+              <CollectionTabsMetadata metadata={metadata} />
+            </TabsContent>
+            <TabsContent value="organization">Yo</TabsContent>
+          </Tabs>
+        </Container>
+      </Layout>
+    </>
   );
 };
 

--- a/pages/collections/index.tsx
+++ b/pages/collections/index.tsx
@@ -1,13 +1,24 @@
 import Container from "@/components/Shared/Container";
 import Layout from "components/layout";
 import { NextPage } from "next";
+import Script from "next/script";
 import { buildDataLayer } from "@/lib/ga/data-layer";
+import { loadDefaultStructuredData } from "@/lib/json-ld";
 
 const CollectionList: NextPage = () => {
   return (
-    <Layout>
-      <Container>Placeholder homepage for Collections</Container>
-    </Layout>
+    <>
+      <Script
+        id="app-ld-json"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(loadDefaultStructuredData(), null, "\t"),
+        }}
+      />
+      <Layout>
+        <Container>Placeholder homepage for Collections</Container>
+      </Layout>
+    </>
   );
 };
 

--- a/pages/contact.tsx
+++ b/pages/contact.tsx
@@ -2,15 +2,26 @@ import Container from "@/components/Shared/Container";
 import Layout from "components/layout";
 import { NextPage } from "next";
 import { PlaceholderBlock } from "@/components/Shared/PlaceholderBlock.styled";
+import Script from "next/script";
 import { buildDataLayer } from "@/lib/ga/data-layer";
+import { loadDefaultStructuredData } from "@/lib/json-ld";
 
 const ContactPage: NextPage = () => {
   return (
-    <Layout>
-      <Container>
-        <PlaceholderBlock>Contact page</PlaceholderBlock>
-      </Container>
-    </Layout>
+    <>
+      <Script
+        id="app-ld-json"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(loadDefaultStructuredData(), null, "\t"),
+        }}
+      />
+      <Layout>
+        <Container>
+          <PlaceholderBlock>Contact page</PlaceholderBlock>
+        </Container>
+      </Layout>
+    </>
   );
 };
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,14 +1,25 @@
 import Layout from "@/components/layout";
 import Overview from "@/components/Home/Overview";
 import { PlaceholderBlock } from "@/components/Shared/PlaceholderBlock.styled";
+import Script from "next/script";
 import { buildDataLayer } from "@/lib/ga/data-layer";
+import { loadDefaultStructuredData } from "@/lib/json-ld";
 
 const HomePage: React.FC = () => {
   return (
-    <Layout header="hero">
-      <Overview />
-      <PlaceholderBlock css={{ height: "100vh" }} />
-    </Layout>
+    <>
+      <Script
+        id="app-ld-json"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(loadDefaultStructuredData(), null, "\t"),
+        }}
+      />
+      <Layout header="hero">
+        <Overview />
+        <PlaceholderBlock css={{ height: "100vh" }} />
+      </Layout>
+    </>
   );
 };
 

--- a/pages/items/[id].tsx
+++ b/pages/items/[id].tsx
@@ -7,6 +7,7 @@ import Layout from "components/layout";
 import { Manifest } from "@iiif/presentation-3";
 import React from "react";
 import RelatedItems from "@/components/Shared/RelatedItems";
+import Script from "next/script";
 import { WorkProvider } from "@/context/work-context";
 import { WorkShape } from "@/types/components/works";
 import WorkTopInfo from "@/components/Work/TopInfo";
@@ -14,6 +15,7 @@ import WorkViewerWrapper from "@/components/Work/ViewerWrapper";
 import { buildDataLayer } from "@/lib/ga/data-layer";
 import { buildPres3Manifest } from "@/lib/iiif/manifest-helpers";
 import { getRelatedCollections } from "@/lib/iiif/collection-helpers";
+import { loadItemStructuredData } from "@/lib/json-ld";
 
 interface WorkPageProps {
   manifest?: Manifest;
@@ -31,17 +33,30 @@ const WorkPage: NextPage<WorkPageProps> = ({ manifest, work }) => {
   const related = getRelatedCollections(work);
 
   return (
-    <Layout title={work.title}>
-      <WorkProvider initialState={{ manifest: manifest, work: work }}>
-        <ErrorBoundary FallbackComponent={ErrorFallback}>
-          <WorkViewerWrapper manifestId={work.iiif_manifest} />
-          <Container>
-            <WorkTopInfo manifest={manifest} work={work} />
-            <RelatedItems collections={related} title="Explore Further" />
-          </Container>
-        </ErrorBoundary>
-      </WorkProvider>
-    </Layout>
+    <>
+      <Script
+        id="app-ld-json"
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(
+            loadItemStructuredData(work, `/items/${work.id}`),
+            null,
+            "\t"
+          ),
+        }}
+      />
+      <Layout title={work.title}>
+        <WorkProvider initialState={{ manifest: manifest, work: work }}>
+          <ErrorBoundary FallbackComponent={ErrorFallback}>
+            <WorkViewerWrapper manifestId={work.iiif_manifest} />
+            <Container>
+              <WorkTopInfo manifest={manifest} work={work} />
+              <RelatedItems collections={related} title="Explore Further" />
+            </Container>
+          </ErrorBoundary>
+        </WorkProvider>
+      </Layout>
+    </>
   );
 };
 

--- a/types/components/collections.ts
+++ b/types/components/collections.ts
@@ -12,7 +12,7 @@ export interface CollectionShape {
   published: boolean;
   representative_image: {
     url: string;
-    workId: string;
+    work_id: string;
   };
   title: string;
   visibility: "Institution" | "Private" | "Public";


### PR DESCRIPTION
## What does this do?
This adds JSON LD structured data to each application page, which helps Google identify pages.    This pulls from DC v1's code, but updates the implementation for a NextJS app, and codes around the new shape of indexed data.

## How to test
1. Run the app in the browser.
2. Check for the following info on each page:

![image](https://user-images.githubusercontent.com/3020266/194639444-46004c46-9136-4553-97a5-ff88799357ee.png)
