### PR TITLE
Fix JSON LD Schema.org validation for type Collection

### DIFF
--- a/lib/json-ld.test.ts
+++ b/lib/json-ld.test.ts
@@ -51,7 +51,6 @@ describe("collection structured data", () => {
     expect(obj).toHaveProperty("name");
     expect(obj).toHaveProperty("description");
     expect(obj).toHaveProperty("url");
-    expect(obj).toHaveProperty("thumbnail");
   });
 
   it("does not add empty values", () => {

--- a/lib/json-ld.ts
+++ b/lib/json-ld.ts
@@ -35,7 +35,6 @@ export function loadCollectionStructuredData(
     name: collection.title,
     url: `${productionUrl}${pathname}`,
     ...(collection.description && { description: collection.description }),
-    thumbnail: `${collection.representative_image?.url}/full/!300,300/0/default.jpg`,
   };
 
   return obj;


### PR DESCRIPTION
Remove `thumbnail` property from JSON LD Schema Collection @type, so it validates.