### PR TITLE
Show Collection image on Work page

### DIFF
--- a/components/Work/TopInfo.tsx
+++ b/components/Work/TopInfo.tsx
@@ -113,7 +113,7 @@ const WorkTopInfo: React.FC<TopInfoProps> = ({ manifest, work }) => {
               title={work.collection?.title}
               description="Cras mollis lorem sed nisi consequat aliquet. Mauris fringilla pretium nibh, ut laoreet mi luctus nec. Integer luctus urna sed nisi rhoncus mollis."
               href={`/collections/${work.collection?.id}`}
-              imageUrl={work.thumbnail}
+              imageUrl={`${process.env.NEXT_PUBLIC_DCAPI_ENDPOINT}/collections/${work.collection?.id}/thumbnail`}
               supplementalInfo="678 Works"
             />
           </TopInfoCollection>


### PR DESCRIPTION
## What does this do?

Update Work page to show Collection representative image instead of the Work image (current placeholder).

## How to test
1. Go to any Work/Item
2. Verify Collection image is different from the Work/Item image.  Or if a Collection image does not exist, it will default to a placeholder image

![image](https://user-images.githubusercontent.com/3020266/195094734-abdb2498-af64-4866-95f9-16576624309e.png)
