### PR TITLE
Implement social sharing via OpenGraph

### DIFF
--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -30,14 +30,6 @@ const Layout: React.FC<LayoutProps> = ({
       <Head>
         <link rel="icon" href="/favicon.ico" />
         <meta name="description" content="NUL Digital Collections v2" />
-        <meta
-          property="og:image"
-          content={`https://og-image.vercel.app/${encodeURI(
-            siteTitle
-          )}.png?theme=light&md=0&fontSize=75px&images=https%3A%2F%2Fassets.zeit.co%2Fimage%2Fupload%2Ffront%2Fassets%2Fdesign%2Fnextjs-black-logo.svg`}
-        />
-        <meta name="og:title" content={siteTitle} />
-        <meta name="twitter:card" content="summary_large_image" />
         <title>{title}</title>
       </Head>
       <Header isHero={header === "hero"} />

--- a/lib/constants/endpoints.ts
+++ b/lib/constants/endpoints.ts
@@ -1,4 +1,5 @@
 const DCAPI_ENDPOINT = process.env.NEXT_PUBLIC_DCAPI_ENDPOINT;
 const DC_API_SEARCH_URL = `${DCAPI_ENDPOINT}/search`;
+const PRODUCTION_URL = "https://digitalcollections.library.northwestern.edu";
 
-export { DCAPI_ENDPOINT, DC_API_SEARCH_URL };
+export { DCAPI_ENDPOINT, DC_API_SEARCH_URL, PRODUCTION_URL };

--- a/lib/ga/data-layer.ts
+++ b/lib/ga/data-layer.ts
@@ -1,11 +1,13 @@
+import { WorkShape } from "@/types/components/works";
+
 interface DataLayer {
   adminset?: string;
   collections?: string | null;
-  creatorsContributors?: Array<string>;
+  creatorsContributors?: Array<string> | string;
   isLoggedIn?: boolean;
   pageTitle: string;
   rightsStatement?: string | null;
-  subjects?: Array<string>;
+  subjects?: Array<string> | string;
   visibility?: string;
 }
 
@@ -25,4 +27,39 @@ export function buildDataLayer(obj: DataLayer) {
     ...defaultDataLayer,
     ...obj,
   };
+}
+
+export function buildWorkDataLayer(work: WorkShape): DataLayer {
+  if (!work) return defaultDataLayer;
+
+  const creators = work?.creator.map((creator) => creator.label);
+  const contributors = work?.contributor.map(
+    (contributor) => contributor.label
+  );
+  const creatorsContributors: string[] = [];
+  if (creators && creators.length > 0) {
+    creatorsContributors.push(...creators);
+  }
+  if (contributors && contributors.length > 0) {
+    creatorsContributors.push(...contributors);
+  }
+  const subjects =
+    work?.subject && work?.subject.length > 0
+      ? work?.subject.map((subject) => subject.label)
+      : [];
+
+  const dataLayer: DataLayer = buildDataLayer({
+    adminset: work?.library_unit,
+    collections: work?.collection?.title ? work.collection.title : null,
+    creatorsContributors,
+    isLoggedIn: false,
+    pageTitle: work?.title || "",
+    rightsStatement: work?.rights_statement?.label
+      ? work.rights_statement.label
+      : null,
+    subjects,
+    visibility: work?.visibility,
+  });
+
+  return dataLayer;
 }

--- a/lib/json-ld.ts
+++ b/lib/json-ld.ts
@@ -1,9 +1,9 @@
 import { CollectionShape } from "@/types/components/collections";
+import { PRODUCTION_URL } from "@/lib/constants/endpoints";
 import { WorkShape } from "@/types/components/works";
 
 const acquireLicensePage =
   "https://www.library.northwestern.edu/about/administration/policies/rights-permissions.html";
-const productionUrl = "https://digitalcollections.library.northwestern.edu";
 
 /**
  * Load default values for Google Structured Data
@@ -33,7 +33,7 @@ export function loadCollectionStructuredData(
     "@context": "https://schema.org/",
     "@type": "Collection",
     name: collection.title,
-    url: `${productionUrl}${pathname}`,
+    url: `${PRODUCTION_URL}${pathname}`,
     ...(collection.description && { description: collection.description }),
     thumbnail: `${collection.representative_image?.url}/full/!300,300/0/default.jpg`,
   };
@@ -65,7 +65,7 @@ export function loadItemStructuredData(item: WorkShape, pathname: string) {
     image: item.representative_file_set?.url,
     ...(title && { name: title }),
     thumbnail,
-    url: `${productionUrl}${pathname}`,
+    url: `${PRODUCTION_URL}${pathname}`,
     ...(subject.length > 0 && { about: subject?.map((x) => x.label) }),
     acquireLicensePage,
     ...(creator.length > 0 && {

--- a/lib/open-graph.test.ts
+++ b/lib/open-graph.test.ts
@@ -1,0 +1,23 @@
+import * as og from "@/lib/open-graph";
+import { sampleWork1 } from "@/mocks/sample-work1";
+
+describe("open-graph.ts helper file", () => {
+  it("should return openGraphData for a Work", () => {
+    const response = og.buildWorkOpenGraphData(sampleWork1);
+    expect(response).toMatchObject({
+      "og:description":
+        "Ima description - The images on this web site are from material in the collections of the University Archives of Northwestern University Libraries, are provided for use by its students, faculty and staff, and by other researchers visiting this site, for research consultation and scholarly purposes only. Further distribution and/or any commercial use of the images from this site is not permitted.",
+      "og:image":
+        "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/93d75ffe-20d8-48ea-9206-8db9114f2731/full/1200,630/0/default.jpg",
+      "og:image:secure_url":
+        "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/93d75ffe-20d8-48ea-9206-8db9114f2731/full/1200,630/0/default.jpg",
+      "og:site_name":
+        "Hawking dental products in outdoor market, Cuernavaca, Mexico - Digital Collections - Libraries - Northwestern University",
+      "og:title":
+        "Hawking dental products in outdoor market, Cuernavaca, Mexico - Digital Collections - Libraries - Northwestern University",
+      "og:type": "website",
+      "og:url":
+        "https://digitalcollections.library.northwestern.edu/items/c16029ff-d027-496a-98b7-6f259395a8f7",
+    });
+  });
+});

--- a/lib/open-graph.ts
+++ b/lib/open-graph.ts
@@ -1,0 +1,55 @@
+import { ObjectLiteral, OpenGraphData } from "@/types/index";
+import { isImageType, isPublicWork } from "@/lib/work-helpers";
+import { PRODUCTION_URL } from "@/lib/constants/endpoints";
+import { WorkShape } from "@/types/components/works";
+import { overviewThumbnails } from "@/lib/constants/homepage";
+
+export const defaultOpenGraphImage = overviewThumbnails[0][0].id;
+
+export const defaultOpenGraphData: OpenGraphData = {
+  "og:description":
+    "Enrich your research with primary sources. Explore millions of high-quality primary sources and images from around the world, including artworks, maps, photographs, and more.",
+  "og:image": defaultOpenGraphImage,
+  "og:image:secure_url": defaultOpenGraphImage,
+  "og:site_name": "Digital Collections - Libraries - Northwestern University",
+  "og:title": "Digital Collections - Libraries - Northwestern University",
+  "og:type": "website",
+  "og:url": PRODUCTION_URL,
+};
+
+export function buildWorkOpenGraphData(
+  work: WorkShape | null
+): ObjectLiteral | OpenGraphData {
+  if (!work) return {};
+
+  const ogTitle = work?.title ? work.title : work?.accession_number;
+  const isPublic = isPublicWork(work?.visibility);
+  const imageUrl =
+    isPublic && isImageType(work?.work_type)
+      ? `${work?.representative_file_set.url}/full/1200,630/0/default.jpg`
+      : work?.thumbnail;
+
+  let ogDescription = "";
+  if (work?.description && work.description.length > 0) {
+    ogDescription = `${work.description.join(" ")} - `;
+  }
+  if (work?.terms_of_use) {
+    ogDescription += work?.terms_of_use;
+  }
+
+  const openGraphData = !work
+    ? {}
+    : {
+        "og:description": ogDescription,
+        "og:image": imageUrl,
+        ...(isPublic && { "og:image:height": "630" }),
+        "og:image:secure_url": imageUrl,
+        ...(isPublic && { "og:image:width": "1200" }),
+        "og:site_name": `${ogTitle} - Digital Collections - Libraries - Northwestern University`,
+        "og:title": `${ogTitle} - Digital Collections - Libraries - Northwestern University`,
+        "og:type": "website",
+        "og:url": `${PRODUCTION_URL}/items/${work.id}`,
+      };
+
+  return openGraphData;
+}

--- a/lib/work-helpers.ts
+++ b/lib/work-helpers.ts
@@ -42,3 +42,11 @@ export async function getWorkIds(): Promise<Array<string>> {
 
   return [];
 }
+
+export function isImageType(work_type: string | undefined) {
+  return work_type === "Image";
+}
+
+export function isPublicWork(visibility: string | undefined) {
+  return visibility === "Public";
+}

--- a/mocks/sample-work1.ts
+++ b/mocks/sample-work1.ts
@@ -27,6 +27,7 @@ export const sampleWork1: WorkShape = {
   create_date: "2021-03-16T15:52:00.377715Z",
   creator: [],
   cultural_contexts: [],
+  description: ["Ima description"],
   file_sets: [
     {
       id: "93d75ffe-20d8-48ea-9206-8db9114f2731",

--- a/mocks/sample-work2.ts
+++ b/mocks/sample-work2.ts
@@ -27,7 +27,7 @@ export const sampleWork2: WorkShape = {
   create_date: "2021-03-16T15:52:00.377715Z",
   creator: [],
   cultural_contexts: [],
-
+  description: ["Ima cool description"],
   file_sets: [
     {
       id: "93d75ffe-20d8-48ea-9206-8db9114f2731",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -3,19 +3,29 @@ import { User, UserContextInterface } from "@/types/context/user";
 import { deleteCookie, getCookie } from "cookies-next";
 import type { AppProps } from "next/app";
 import { DCAPI_ENDPOINT } from "@/lib/constants/endpoints";
+import Head from "next/head";
+import { ObjectLiteral } from "@/types";
 import React from "react";
 import Script from "next/script";
 import { SearchProvider } from "@/context/search-context";
 import Transition from "@/components/Transition";
 import axios from "axios";
+import { defaultOpenGraphData } from "@/lib/open-graph";
 import globalStyles from "@/styles/global";
 
 export const UserContext = React.createContext<UserContextInterface | null>(
   null
 );
 
-function MyApp({ Component, pageProps }: AppProps) {
+interface MyAppProps extends AppProps {
+  pageProps: ObjectLiteral;
+}
+
+function MyApp({ Component, pageProps }: MyAppProps) {
   globalStyles();
+
+  const { openGraphData = {} } = pageProps;
+  const ogData = { ...defaultOpenGraphData, ...openGraphData };
 
   const [user, setUser] = React.useState<User | null>(null);
 
@@ -41,6 +51,9 @@ function MyApp({ Component, pageProps }: AppProps) {
     }
   }, []);
 
+  {
+    /** Add GTM (Google Tag Manager) data */
+  }
   React.useEffect(() => {
     if (typeof window !== "undefined") {
       // @ts-ignore
@@ -53,15 +66,21 @@ function MyApp({ Component, pageProps }: AppProps) {
   }, [pageProps]);
 
   const logout = () => {
-    // Remove user from client context
     setUser(null);
-
     // Delete cookie - Maybe move to new /logout API route if we want to delete NUSSO cookie
     deleteCookie(API_TOKEN_COOKIE, { domain: AUTH_DOMAIN });
   };
 
   return (
     <>
+      <Head>
+        {/* Add Open Graph <meta></meta> tags here */}
+        {Object.keys(ogData).map((key) => (
+          // @ts-ignore
+          <meta property={key} content={ogData[key]} key={key} />
+        ))}
+      </Head>
+
       <UserContext.Provider value={{ logout, user }}>
         <Transition>
           <SearchProvider>

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -2,6 +2,7 @@ import Container from "@/components/Shared/Container";
 import Head from "next/head";
 import Layout from "components/layout";
 import { NextPage } from "next";
+import { PRODUCTION_URL } from "@/lib/constants/endpoints";
 import { PlaceholderBlock } from "@/components/Shared/PlaceholderBlock.styled";
 import { buildDataLayer } from "@/lib/ga/data-layer";
 import { loadDefaultStructuredData } from "@/lib/json-ld";
@@ -34,8 +35,12 @@ export async function getStaticProps() {
     pageTitle: "About page",
   });
 
+  const openGraphData = {
+    "og:url": `${PRODUCTION_URL}/about`,
+  };
+
   return {
-    props: { dataLayer },
+    props: { dataLayer, openGraphData },
   };
 }
 

--- a/pages/collections/[id].tsx
+++ b/pages/collections/[id].tsx
@@ -134,15 +134,38 @@ export async function getStaticProps({ params }: GetStaticPropsContext) {
       ? await getMetadataAggs(id as string, "subject.label")
       : null;
 
+  /** Add values to GTM's dataLayer object */
   const dataLayer = buildDataLayer({
-    pageTitle: "Homepage",
+    adminset: "",
+    collections: "",
+    creatorsContributors: "",
+    isLoggedIn: false,
+    pageTitle: collection?.title as string,
+    rightsStatement: "",
+    subjects: "",
+    visibility: collection?.visibility,
   });
+
+  /** Populate OpenGraph data */
+  const imageUrl = `${collection?.representative_image.url}/full/600,600/0/default.jpg`;
+  const openGraphData = !collection
+    ? {}
+    : {
+        "og:description": collection.description,
+        "og:image": imageUrl,
+        "og:image:secure_url": imageUrl,
+        "og:site_name": `${collection.title} - Digital Collections - Libraries - Northwestern University`,
+        "og:title": `${collection.title} - Digital Collections - Libraries - Northwestern University`,
+        "og:type": "website",
+        "og:url": `${process.env.DC_URL}/collections/${collection.id}`,
+      };
 
   return {
     props: {
       collection,
       dataLayer,
       metadata,
+      openGraphData,
     },
   };
 }

--- a/pages/collections/index.tsx
+++ b/pages/collections/index.tsx
@@ -8,6 +8,7 @@ import Head from "next/head";
 import Heading from "@/components/Heading/Heading";
 import Layout from "components/layout";
 import { NextPage } from "next";
+import { PRODUCTION_URL } from "@/lib/constants/endpoints";
 import { buildDataLayer } from "@/lib/ga/data-layer";
 import { getCollectionList } from "@/lib/collection-helpers";
 import { loadDefaultStructuredData } from "@/lib/json-ld";
@@ -86,8 +87,12 @@ export async function getStaticProps() {
     next_url = response?.pagination.next_url;
   }
 
+  const openGraphData = {
+    "og:url": `${PRODUCTION_URL}/collections`,
+  };
+
   return {
-    props: { collections, dataLayer },
+    props: { collections, dataLayer, openGraphData },
   };
 }
 

--- a/pages/contact.tsx
+++ b/pages/contact.tsx
@@ -2,6 +2,7 @@ import Container from "@/components/Shared/Container";
 import Head from "next/head";
 import Layout from "components/layout";
 import { NextPage } from "next";
+import { PRODUCTION_URL } from "@/lib/constants/endpoints";
 import { PlaceholderBlock } from "@/components/Shared/PlaceholderBlock.styled";
 import { buildDataLayer } from "@/lib/ga/data-layer";
 import { loadDefaultStructuredData } from "@/lib/json-ld";
@@ -34,8 +35,12 @@ export async function getStaticProps() {
     pageTitle: "Contact page",
   });
 
+  const openGraphData = {
+    "og:url": `${PRODUCTION_URL}/contact`,
+  };
+
   return {
-    props: { dataLayer },
+    props: { dataLayer, openGraphData },
   };
 }
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,7 @@
-import Head from 'next/head';
+import Head from "next/head";
 import Layout from "@/components/layout";
 import Overview from "@/components/Home/Overview";
+import { PRODUCTION_URL } from "@/lib/constants/endpoints";
 import { PlaceholderBlock } from "@/components/Shared/PlaceholderBlock.styled";
 import { buildDataLayer } from "@/lib/ga/data-layer";
 import { loadDefaultStructuredData } from "@/lib/json-ld";
@@ -8,8 +9,8 @@ import { loadDefaultStructuredData } from "@/lib/json-ld";
 const HomePage: React.FC = () => {
   return (
     <>
-       {/* Google Structured Data via JSON-LD */}
-       <Head>
+      {/* Google Structured Data via JSON-LD */}
+      <Head>
         <script
           key="app-ld-json"
           id="app-ld-json"
@@ -32,8 +33,12 @@ export async function getStaticProps() {
     pageTitle: "Homepage",
   });
 
+  const openGraphData = {
+    "og:url": PRODUCTION_URL,
+  };
+
   return {
-    props: { dataLayer },
+    props: { dataLayer, openGraphData },
   };
 }
 

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -9,6 +9,7 @@ import Head from "next/head";
 import Heading from "@/components/Heading/Heading";
 import Layout from "@/components/layout";
 import { NextPage } from "next";
+import { PRODUCTION_URL } from "@/lib/constants/endpoints";
 import { Pagination } from "@/components/Search/Pagination";
 import axios from "axios";
 import { buildDataLayer } from "@/lib/ga/data-layer";
@@ -139,8 +140,12 @@ export async function getStaticProps() {
     pageTitle: "Search page",
   });
 
+  const openGraphData = {
+    "og:url": `${PRODUCTION_URL}/contact`,
+  };
+
   return {
-    props: { dataLayer },
+    props: { dataLayer, openGraphData },
   };
 }
 

--- a/types/components/works.ts
+++ b/types/components/works.ts
@@ -53,6 +53,7 @@ export interface WorkShape {
   create_date: string;
   creator: Array<GenericIdLabel>;
   cultural_contexts: Array<string>;
+  description: Array<string>;
   file_sets: Array<FileSet>;
   folder_names: Array<string>;
   folder_numbers: Array<string>;

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,15 +1,3 @@
-export interface AdministrativeMetadata {
-  libraryUnit: any;
-  preservationLevel: any;
-  projectCycle: string;
-  projectDesc: Array<string>;
-  projectManager: Array<string>;
-  projectName: Array<string>;
-  projectProposer: Array<string>;
-  projectTaskNumber: Array<string>;
-  status: any;
-}
-
 export interface Collection {
   adminEmail: string | null;
   createDate: Date;
@@ -25,6 +13,24 @@ export interface Collection {
   title: string;
   visibility: Visibility;
 }
+
+export type ObjectLiteral =
+  | {
+      [key: string]: never;
+    }
+  | {
+      [key: string]: string[];
+    };
+
+export type OpenGraphData = {
+  "og:description": string;
+  "og:image"?: string;
+  "og:image:secure_url"?: string;
+  "og:site_name": string;
+  "og:title": string;
+  "og:type": string;
+  "og:url": string;
+};
 
 export interface Model {
   application: string;
@@ -53,25 +59,6 @@ export interface Visibility {
   id: VisibilityIDStrings;
   label: string;
   scheme: string;
-}
-
-export interface Work {
-  accessionNumber: string;
-  administrativeMetadata: AdministrativeMetadata;
-  alternateTitle: Array<string>;
-  batches: Array<string>;
-  collection: {
-    id: string;
-    title: string;
-  };
-  collectionTitle: string;
-  contributor: Array<string>;
-  createDate: string;
-  creator: Array<string>;
-  dateCreated: Array<string>;
-  description: Array<string>;
-  descriptiveMetadata: any;
-  // Do we really need this?
 }
 
 export interface WorkType {


### PR DESCRIPTION
## What does this do?
Implements the [OpenGraph](https://ogp.me/) protocol to generate data when sharing app links.

![image](https://user-images.githubusercontent.com/3020266/195369996-25266b75-286b-4d79-ab5e-63c5c014ba6e.png)

<img width="1136" alt="image" src="https://user-images.githubusercontent.com/3020266/195443402-64d62a1a-61b5-4b4d-884a-b4536efc3391.png">


## How to test
1. Run the app in your AWS environment (or just inspect locally in browser console)
2. On each page, verify opengraph data exists in browser console
3. If in AWS environment, you can use this validation tool to view OpenGraph data: https://www.opengraph.xyz/

