### PR TITLE
Add Embed HTML copyable snippet to Work Download and Embed modal

### DIFF
--- a/components/Shared/SimpleSelect.styled.ts
+++ b/components/Shared/SimpleSelect.styled.ts
@@ -1,0 +1,9 @@
+import { styled } from "@/stitches.config";
+
+const SimpleSelect = styled("select", {
+  borderColor: "$black10",
+  borderRadius: "6px",
+  padding: "$gr1",
+});
+
+export default SimpleSelect;

--- a/components/Work/ActionsDialog/DownloadAndShare.styled.ts
+++ b/components/Work/ActionsDialog/DownloadAndShare.styled.ts
@@ -27,6 +27,20 @@ const EmbedViewer = styled("div", {
   },
 });
 
+const EmbedHTML = styled(EmbedViewer, {
+  marginTop: "$gr3",
+  transition: "all 0.5s ease-in-out",
+});
+
+const EmbedHTMLActionRow = styled("div", {
+  display: "flex",
+  alignItems: "center",
+
+  "& select": {
+    marginLeft: "$gr3",
+  },
+});
+
 const ItemActions = styled("ul", {
   display: "flex",
   padding: "0",
@@ -56,6 +70,11 @@ const ItemContent = styled("div", {
   fontWeight: "700",
 });
 
+const ItemRow = styled("div", {
+  display: "flex",
+  flexDirection: "row",
+});
+
 const ItemThumbnail = styled("div", {
   display: "flex",
   width: "100px",
@@ -74,7 +93,17 @@ const ItemThumbnail = styled("div", {
 
 const ItemStyled = styled("div", {
   display: "flex",
+  flexDirection: "column",
   margin: "$4 0 0",
 });
 
-export { EmbedViewer, ItemActions, ItemContent, ItemStyled, ItemThumbnail };
+export {
+  EmbedHTML,
+  EmbedHTMLActionRow,
+  EmbedViewer,
+  ItemActions,
+  ItemContent,
+  ItemRow,
+  ItemStyled,
+  ItemThumbnail,
+};

--- a/components/Work/ActionsDialog/DownloadAndShare.tsx
+++ b/components/Work/ActionsDialog/DownloadAndShare.tsx
@@ -4,19 +4,22 @@ import {
 } from "@/components/Work/ActionsDialog/ActionsDialog.styled";
 import { Canvas, IIIFExternalWebResource } from "@iiif/presentation-3";
 import {
+  EmbedHTML,
+  EmbedHTMLActionRow,
   EmbedViewer,
   ItemActions,
   ItemContent,
+  ItemRow,
   ItemStyled,
   ItemThumbnail,
 } from "@/components/Work/ActionsDialog/DownloadAndShare.styled";
 import { Label, Thumbnail } from "@samvera/nectar-iiif";
 import ActionsDialogAside from "@/components/Work/ActionsDialog/Aside";
 import CopyText from "@/components/Shared/CopyText";
-
 import { DefinitionListWrapper } from "@/components/Shared/DefinitionList.styled";
 import React from "react";
 import SharedSocial from "@/components/Shared/Social";
+import SimpleSelect from "@/components/Shared/SimpleSelect.styled";
 import { getInfoResponse } from "@/lib/iiif/manifest-helpers";
 import { useWorkState } from "@/context/work-context";
 
@@ -67,31 +70,102 @@ const DownloadAndShare: React.FC = () => {
 };
 
 const Item: React.FC<Record<"item", Canvas>> = ({ item }) => {
+  const [embedHTMLOpen, setEmbedHTMLOpen] = React.useState(false);
+  const [color, setColor] = React.useState("default");
+  const [width, setWidth] = React.useState(3000);
+
+  const colors = [
+    {
+      label: "Default",
+      value: "default",
+    },
+    {
+      label: "Bitonal",
+      value: "bitonal",
+    },
+    {
+      label: "Gray",
+      value: "gray",
+    },
+  ];
+
+  const widths = [
+    {
+      label: "3000px - 100%",
+      value: 3000,
+    },
+    {
+      label: "1800px - 50%",
+      value: 1800,
+    },
+    {
+      label: "900px - 25%",
+      value: 900,
+    },
+    {
+      label: "450px - 12.5%",
+      value: 450,
+    },
+  ];
+
+  const embedHTMLString = `<img src="https://iiif.stack.rdc.library.northwestern.edu/iiif/2/017962ae-0cc5-4e1f-899d-ab102aad71b7/full/${width},/0/${color}.jpg" alt="inu-dil-8ab680fc-4940-4c8e-a0bf-96844a27f5a5.tif" />`;
+
   return (
     <ItemStyled>
-      <ItemThumbnail>
-        {item.thumbnail && (
-          <Thumbnail thumbnail={item.thumbnail as IIIFExternalWebResource[]} />
-        )}
-      </ItemThumbnail>
-      <ItemContent>
-        {item.label && <Label label={item.label} as="span" />}
-        <ItemActions>
-          <li>
-            <a
-              href={`${getInfoResponse(item)}/full/1000,/0/default.jpg`}
-              download
-              rel="noreferrer"
-              target="_blank"
-            >
-              Download JPG
-            </a>
-          </li>
-          <li>
-            <a href="">Embed HTML</a>
-          </li>
-        </ItemActions>
-      </ItemContent>
+      <ItemRow>
+        <ItemThumbnail>
+          {item.thumbnail && (
+            <Thumbnail
+              thumbnail={item.thumbnail as IIIFExternalWebResource[]}
+            />
+          )}
+        </ItemThumbnail>
+        <ItemContent>
+          {item.label && <Label label={item.label} as="span" />}
+          <ItemActions>
+            <li>
+              <a
+                href={`${getInfoResponse(item)}/full/1000,/0/default.jpg`}
+                download
+                rel="noreferrer"
+                target="_blank"
+              >
+                Download JPG
+              </a>
+            </li>
+            <li>
+              <a
+                style={{ cursor: "pointer" }}
+                onClick={() => setEmbedHTMLOpen(!embedHTMLOpen)}
+              >
+                Embed HTML
+              </a>
+            </li>
+          </ItemActions>
+        </ItemContent>
+      </ItemRow>
+      {embedHTMLOpen && (
+        <EmbedHTML>
+          <pre>{embedHTMLString}</pre>
+          <EmbedHTMLActionRow>
+            <CopyText textPrompt="Copy" textToCopy={embedHTMLString} />
+            <SimpleSelect onChange={(e) => setWidth(parseInt(e.target.value))}>
+              {widths.map((width) => (
+                <option key={width.value} value={width.value}>
+                  {width.label}
+                </option>
+              ))}
+            </SimpleSelect>
+            <SimpleSelect onChange={(e) => setColor(e.target.value)}>
+              {colors.map((color) => (
+                <option key={color.value} value={color.value}>
+                  {color.label}
+                </option>
+              ))}
+            </SimpleSelect>
+          </EmbedHTMLActionRow>
+        </EmbedHTML>
+      )}
     </ItemStyled>
   );
 };


### PR DESCRIPTION
## What does this do?
Replicates the HTML Embed functionality from DC v1.

![image](https://user-images.githubusercontent.com/3020266/195653722-505f89a8-42f0-495a-b11b-ad19d3f6959b.png)


## How to test
1. Open any work in DC v2 and click the "Download and share" button.
2. Click "Embed HTML"
3. Verify the width and color selections change in the UI.
4. Verify the copy functionality works
