### PR TITLE
Add embedded viewer route for iFrame viewer

### DIFF
--- a/components/Work/ActionsDialog/DownloadAndShare.tsx
+++ b/components/Work/ActionsDialog/DownloadAndShare.tsx
@@ -27,7 +27,13 @@ const DownloadAndShare: React.FC = () => {
   const { workState } = useWorkState();
   const { manifest, work } = workState;
 
-  const embedViewerHTML = `<iframe src=“https://dc.library.northwestern.edu/embedded-viewer/${manifest?.id}” title=“${work?.title}” width=“100%” height=“800”></iframe>`;
+  const embedViewerHTML = manifest?.id
+    ? `<iframe src="${
+        window.location.origin
+      }/embedded-viewer/${encodeURIComponent(manifest.id)}" title="${
+        work?.title
+      }" width="100%" height="800"></iframe>`
+    : "";
 
   if (!manifest || !work) return <></>;
 
@@ -50,7 +56,7 @@ const DownloadAndShare: React.FC = () => {
 
         <h3>Embed Viewer</h3>
         <EmbedViewer>
-          <pre>{embedViewerHTML}</pre>
+          <pre>{embedViewerHTML || "Error creating embed viewer HTML"}</pre>
           <CopyText textPrompt="Copy" textToCopy={embedViewerHTML} />
         </EmbedViewer>
 

--- a/pages/embedded-viewer/[manifestId].tsx
+++ b/pages/embedded-viewer/[manifestId].tsx
@@ -1,0 +1,27 @@
+import { GetServerSidePropsContext, NextPage } from "next";
+import React from "react";
+import WorkViewerWrapper from "@/components/Work/ViewerWrapper";
+
+interface WorkPageProps {
+  manifestId: string;
+}
+
+const WorkPage: NextPage<WorkPageProps> = ({ manifestId }) => {
+  return (
+    <>
+      <WorkViewerWrapper manifestId={decodeURIComponent(manifestId)} />
+    </>
+  );
+};
+
+export async function getServerSideProps({
+  params,
+}: GetServerSidePropsContext) {
+  const manifestId = params?.manifestId || null;
+
+  return {
+    props: { manifestId },
+  };
+}
+
+export default WorkPage;


### PR DESCRIPTION
## What does this do?
- Creates the app route `/embedded-viewer/[MANIFEST_ID]` to host the iFrame viewer
- URI Encodes the link in the Download and Share window

<img width="1390" alt="image" src="https://user-images.githubusercontent.com/3020266/195939816-6d670e63-44a8-49a4-b111-e7523220e697.png">

<img width="1508" alt="image" src="https://user-images.githubusercontent.com/3020266/195939905-a46743a6-e770-4ffc-a6d9-62741917b2fa.png">

## How to test
1. Go to a Work page
2. Click Download and Share button
3. Copy the `iFrame` code, and on the same domain (Cors...), in your browser console "Elements" tab, click on some HTML tag and edit the HTML.  Paste in your iFrame code and it should display.
4. Copy the `src` value of the `iframe` tag  (ie this part: `https://devbox.library.northwestern.edu:3000/embedded-viewer/https%3A%2F%2Fiiif.stack.rdc-staging.library.northwestern.edu%2Fpublic%2Fc1%2F92%2Fa8%2F4c%2F-c%2F64%2F1-%2F4f%2Ff3%2F-8%2Fc1%2F5-%2F26%2F76%2Fce%2F9e%2F1e%2F8e-manifest.json`), and paste that value into a new browser window.  You should see only the viewer display in the browser.
