### PR TITLE
Update logout to use API logout route

### DIFF
--- a/components/Header/Super.tsx
+++ b/components/Header/Super.tsx
@@ -52,7 +52,7 @@ export default function HeaderSuper() {
             <>
               <User>{userAuthContext.user.displayName}</User>
               <a
-                onClick={userAuthContext.logout}
+                href={`${DCAPI_ENDPOINT}/auth/logout`}
                 style={{
                   cursor: "pointer",
                   paddingLeft: "8px",

--- a/lib/constants/auth.ts
+++ b/lib/constants/auth.ts
@@ -1,4 +1,1 @@
 export const API_TOKEN_COOKIE = "dcApiV2Token";
-export const AUTH_DOMAIN = ".library.northwestern.edu";
-export const NUSSO_COOKIE = "nusso";
-export const NUSSO_REDIRECT_URL = "nussoRedirectUrl";

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,6 @@
-import { API_TOKEN_COOKIE, AUTH_DOMAIN } from "@/lib/constants/auth";
 import { User, UserContextInterface } from "@/types/context/user";
-import { deleteCookie, getCookie } from "cookies-next";
+
+import { API_TOKEN_COOKIE } from "@/lib/constants/auth";
 import type { AppProps } from "next/app";
 import { DCAPI_ENDPOINT } from "@/lib/constants/endpoints";
 import Head from "next/head";
@@ -11,6 +11,7 @@ import { SearchProvider } from "@/context/search-context";
 import Transition from "@/components/Transition";
 import axios from "axios";
 import { defaultOpenGraphData } from "@/lib/open-graph";
+import { getCookie } from "cookies-next";
 import globalStyles from "@/styles/global";
 
 export const UserContext = React.createContext<UserContextInterface | null>(
@@ -65,12 +66,6 @@ function MyApp({ Component, pageProps }: MyAppProps) {
     }
   }, [pageProps]);
 
-  const logout = () => {
-    setUser(null);
-    // Delete cookie - Maybe move to new /logout API route if we want to delete NUSSO cookie
-    deleteCookie(API_TOKEN_COOKIE, { domain: AUTH_DOMAIN });
-  };
-
   return (
     <>
       <Head>
@@ -81,7 +76,7 @@ function MyApp({ Component, pageProps }: MyAppProps) {
         ))}
       </Head>
 
-      <UserContext.Provider value={{ logout, user }}>
+      <UserContext.Provider value={{ user }}>
         <Transition>
           <SearchProvider>
             <Script id="google-tag-manager" strategy="afterInteractive">

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -75,8 +75,6 @@ resource "aws_amplify_app" "dc-next" {
     JWT_TOKEN_SECRET           = var.jwt_token_secret
     NEXT_PUBLIC_DCAPI_ENDPOINT = var.next_public_dcapi_endpoint
     NEXT_PUBLIC_DC_URL         = var.next_public_dc_url
-    NUSSO_API_KEY              = var.nusso_api_key
-    NUSSO_BASE_URL             = var.nusso_base_url
     _LIVE_UPDATES              = "[{ \"name\" : \"Next.js version\", \"pkg\" : \"next-version\", \"type\" : \"internal\", \"version\" : \"latest\" }]"
   }
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -37,13 +37,6 @@ variable "next_public_dc_url" {
   type = string
 }
 
-variable "nusso_base_url" {
-  type = string
-}
-
-variable "nusso_api_key" {
-  type = string
-}
 
 variable "production_branch" {
   type = string

--- a/types/context/user.ts
+++ b/types/context/user.ts
@@ -4,7 +4,6 @@ export interface User {
 }
 
 export interface UserContextInterface {
-  logout: () => void;
   user: User | null;
 }
 


### PR DESCRIPTION
### Summary

- Use DC API V2's `/auth/logout` route which will take you to the NUSSO logout form

### How to Test

- New browser/cookies get rid of any current DC session
- Run DC next in your dev environment (*with https and either using devbox locally or your dev prefix in remote dev)
- Login
- Click logout and see that you are presented with the NUSSO logout screen. 
- Logout


** I will apply the Terraform changes after this is merged.