### PR TITLE
Update DC_URL env var.

### DIFF
--- a/components/Work/Metadata.test.tsx
+++ b/components/Work/Metadata.test.tsx
@@ -1,6 +1,5 @@
 import WorkMetadata, { ValueAsSearchLink } from "@/components/Work/Metadata";
 import { render, screen, within } from "@/test-utils";
-import { DC_URL } from "@/lib/constants/endpoints";
 import { FACETS_WORK_LINK } from "@/lib/constants/works";
 import { MetadataItem } from "@iiif/presentation-3";
 import { manifest } from "@/mocks/sample-work-image";
@@ -30,6 +29,6 @@ describe("WorkMetadata component", () => {
   it("renders metadata value as custom link pattern", () => {
     render(<ValueAsSearchLink param="foo" value="bar" />);
     const link = screen.getByRole("link");
-    expect(link.getAttribute("href")).toBe(`${DC_URL}/search?foo=bar`);
+    expect(link.getAttribute("href")).toContain(`/search?foo=bar`);
   });
 });

--- a/lib/constants/endpoints.ts
+++ b/lib/constants/endpoints.ts
@@ -1,8 +1,6 @@
 const DCAPI_ENDPOINT = process.env.NEXT_PUBLIC_DCAPI_ENDPOINT;
 const DC_API_SEARCH_URL = `${DCAPI_ENDPOINT}/search`;
-const DC_URL = process.env.DC_URL
-  ? process.env.DC_URL
-  : "https://devbox.library.northwestern.edu:3000";
+const DC_URL = process.env.NEXT_PUBLIC_DC_URL;
 const PRODUCTION_URL = "https://digitalcollections.library.northwestern.edu";
 
 export { DC_URL, DCAPI_ENDPOINT, DC_API_SEARCH_URL, PRODUCTION_URL };


### PR DESCRIPTION
This update the `DC_URL` constant to use `NEXT_PUBLIC_DC_URL`.

Relates to @davidschober feedback on https://github.com/nulib/repodev_planning_and_docs/issues/3075 and work completed on https://github.com/nulib/repodev_planning_and_docs/issues/3243