### PR TITLE
More Like This on Work.

### DIFF
--- a/lib/iiif/collection-helpers.test.js
+++ b/lib/iiif/collection-helpers.test.js
@@ -1,4 +1,4 @@
-import { DC_API_SEARCH_URL } from "@/lib/constants/endpoints";
+import { DCAPI_ENDPOINT, DC_API_SEARCH_URL } from "@/lib/constants/endpoints";
 import { getRelatedCollections } from "@/lib/iiif/collection-helpers";
 import { sampleWork2 } from "@/mocks/sample-work2";
 
@@ -6,13 +6,11 @@ describe("Function to generate IIIF collection URIs", () => {
   it("successfully builds an array of IIIF collection endpoints", () => {
     const related = getRelatedCollections(sampleWork2);
     expect(related[0]).toBe(
-      `${DC_API_SEARCH_URL}?query=collection.title.keyword:"Jim Roberts Photographs, 1968-1972" AND NOT id:"c16029ff-d027-496a-98b7-6f259395a8f7"&collectionLabel=Jim Roberts Photographs, 1968-1972&collectionSummary=Collection&as=iiif`
+      `${DCAPI_ENDPOINT}/works/c16029ff-d027-496a-98b7-6f259395a8f7/similar?collectionLabel=More Like This&collectionSummary=Similar to Hawking dental products in outdoor market, Cuernavaca, Mexico&as=iiif`
     );
-    expect(related).toEqual(
-      expect.arrayContaining([
-        `${DC_API_SEARCH_URL}?query=workType.label.keyword:\"Image\" AND NOT id:\"c16029ff-d027-496a-98b7-6f259395a8f7\"&collectionLabel=Image&collectionSummary=Work Type&as=iiif`,
-      ])
+    expect(related[1]).toBe(
+      `${DC_API_SEARCH_URL}?query=collection.title.keyword:"Jim Roberts Photographs, 1968-1972"&collectionLabel=Jim Roberts Photographs, 1968-1972&collectionSummary=Collection&as=iiif`
     );
-    expect(related.length).toBe(4);
+    expect(related.length).toBe(5);
   });
 });


### PR DESCRIPTION
## What does this do?

This work adds "More Like This" Bloom slider with a collection response from the /similar endpoint of a work. The actual integration of this was absolutely easy. In the process I also cleaned up the search query URIs for the genre and subject collections. Somewhere along the way, these began failing.

![image](https://user-images.githubusercontent.com/7376450/199801348-0521e71f-b9b3-468f-8ba4-8afdc2b52754.png)

This work should be exclusive of any bug fixes or enhancements we make to Bloom itself. 