### PR TITLE
Add Copy functionality to Citation tab on Work page

### DIFF
--- a/components/Shared/CopyText.styled.ts
+++ b/components/Shared/CopyText.styled.ts
@@ -15,6 +15,19 @@ const StyledStatus = styled("span", {
   textTransform: "uppercase",
 });
 
-const StyledCopyText = styled("button", {});
+const StyledCopyText = styled("button", {
+  display: "inline-flex",
+  alignItems: "center",
+  backgroundColor: "transparent",
+  border: "none",
+  cursor: "pointer",
+  color: "$purple",
+  fontWeight: "700",
+  fontSize: "$3",
+
+  "&:hover": {
+    textDecoration: "underline",
+  },
+});
 
 export { StyledCopyText, StyledStatus };

--- a/components/Work/ActionsDialog/Cite.test.tsx
+++ b/components/Work/ActionsDialog/Cite.test.tsx
@@ -27,18 +27,27 @@ describe("WorkDialogCite", () => {
     const div = screen.getByTestId("metadata");
 
     // <dt>s
-    expect(within(div).getByText(/IDENTIFIER/i));
-    expect(within(div).getAllByText(/title/i));
-    expect(within(div).getByText(/USE STATEMENT/i));
-    expect(within(div).getAllByText(/ark/i));
-    expect(within(div).getByText(/apa format/i));
-    expect(within(div).getByText(/chicago\/turabian format/i));
-    expect(within(div).getByText(/mla format/i));
-    expect(within(div).getByText(/wiki citation/i));
+    expect(within(div).getByText(/IDENTIFIER/i, { exact: false }));
+    expect(within(div).getAllByText(/title/i, { exact: false }));
+    expect(within(div).getByText(/USE STATEMENT/i, { exact: false }));
+    expect(within(div).getAllByText(/ark/i, { exact: false }));
+    expect(within(div).getByText(/apa format/i, { exact: false }));
+    expect(
+      within(div).getByText(/chicago\/turabian format/i, { exact: false })
+    );
+    expect(within(div).getByText(/mla format/i, { exact: false }));
+    expect(within(div).getByText(/wiki citation/i, { exact: false }));
 
-    // <dl>s
+    // <dd>s
     metadataValues.forEach((value) => {
-      expect(within(div).getByText(value));
+      expect(
+        within(div).getAllByText(value, { exact: false }).length
+      ).toBeGreaterThan(0);
     });
+  });
+
+  it("renders copy links for all metadata", () => {
+    setup();
+    expect(screen.getAllByText(/copy/i).length).toEqual(8);
   });
 });

--- a/components/Work/ActionsDialog/Cite.tsx
+++ b/components/Work/ActionsDialog/Cite.tsx
@@ -3,6 +3,7 @@ import {
   Content,
 } from "@/components/Work/ActionsDialog/ActionsDialog.styled";
 import ActionsDialogAside from "@/components/Work/ActionsDialog/Aside";
+import CopyText from "@/components/Shared/CopyText";
 import { DefinitionListWrapper } from "@/components/Shared/DefinitionList.styled";
 import React from "react";
 import { useWorkState } from "@/context/work-context";
@@ -52,12 +53,24 @@ const WorkDialogCite: React.FC = () => {
             {metadata.map((item) => (
               <React.Fragment key={item[0]}>
                 <dt>{item[0]}</dt>
-                <dd>{item[1]}</dd>
+                <dd>
+                  {item[1]}{" "}
+                  {item[1] && (
+                    <>
+                      {" |"}
+                      <CopyText textPrompt="Copy" textToCopy={item[1]} />
+                    </>
+                  )}
+                </dd>
               </React.Fragment>
             ))}
             <dt>Wiki Citation</dt>
             <dd>
               <code>{wikiCitation}</code>
+              <>
+                {" |"}
+                <CopyText textPrompt="Copy" textToCopy={wikiCitation} />
+              </>
             </dd>
           </dl>
         </DefinitionListWrapper>

--- a/components/Work/ActionsDialog/DownloadAndShare.styled.ts
+++ b/components/Work/ActionsDialog/DownloadAndShare.styled.ts
@@ -1,4 +1,3 @@
-import { StyledCopyText } from "@/components/Shared/CopyText.styled";
 import { styled } from "@/stitches.config";
 
 /* eslint sort-keys: 0 */
@@ -7,16 +6,6 @@ const EmbedViewer = styled("div", {
   border: "2px dashed $black10",
   width: "calc(100% - $4)",
   padding: "$3 $4",
-
-  [`& ${StyledCopyText}`]: {
-    display: "flex",
-    backgroundColor: "transparent",
-    border: "none",
-    cursor: "pointer",
-    color: "$purple",
-    fontWeight: "700",
-    fontSize: "$3",
-  },
 
   pre: {
     margin: "$3 0",


### PR DESCRIPTION
## What does this do?
Add `CopyText` component to Cite modal.

<img width="1465" alt="image" src="https://user-images.githubusercontent.com/3020266/200663251-4bfb5886-27aa-4a72-83eb-8cd5c7f96517.png">
