### PR TITLE
Collection Organization, and collection revamp

### DIFF
--- a/components/Collection/Collection.styled.ts
+++ b/components/Collection/Collection.styled.ts
@@ -3,15 +3,22 @@ import { styled } from "@/stitches.config";
 /* eslint sort-keys: 0 */
 
 const Description = styled("p", {
-  fontSize: "$gr4",
+  fontSize: "$gr5",
   fontFamily: "$sansLight",
   lineHeight: "1.55em",
-  margin: "0 0 $gr5",
+  margin: "$gr2 0 $gr5",
+  color: "$black50",
 });
 
 const HeroWrapper = styled("div", {
-  height: "350px",
+  height: "375px",
   position: "relative",
 });
 
-export { Description, HeroWrapper };
+const Interstitial = styled("div", {
+  backgroundColor: "#f6f6f6",
+  marginBottom: "$gr4",
+  padding: "$gr3 0",
+});
+
+export { Description, Interstitial, HeroWrapper };

--- a/components/Collection/Item/Item.styled.ts
+++ b/components/Collection/Item/Item.styled.ts
@@ -21,14 +21,6 @@ const ItemContent = styled("div", {
   paddingLeft: "$gr4",
   lineHeight: "1.55",
 
-  h2: {
-    fontSize: "$gr5",
-    fontFamily: "$displayBold",
-    fontWeight: "400",
-    marginBottom: "$gr2",
-    color: "$purple",
-  },
-
   p: {
     fontSize: "$gr3",
     fontFamily: "$sansLight",

--- a/components/Collection/Item/Item.tsx
+++ b/components/Collection/Item/Item.tsx
@@ -40,7 +40,7 @@ const CollectionItem: React.FC<CollectionShape> = (props) => {
       </ItemImageWrapper>
       <ItemContent>
         <a href={`/collections/${id}`}>
-          <Heading as="h2">{title}</Heading>
+          <Heading as="h3">{title}</Heading>
         </a>
         {description && (
           <p>

--- a/components/Collection/Tabs/Explore.test.tsx
+++ b/components/Collection/Tabs/Explore.test.tsx
@@ -24,6 +24,5 @@ describe("CollectionTabsExplore", () => {
       />
     );
     expect(screen.getByTestId("explore-wrapper"));
-    expect(screen.getByTestId("description"));
   });
 });

--- a/components/Collection/Tabs/Explore.tsx
+++ b/components/Collection/Tabs/Explore.tsx
@@ -1,7 +1,5 @@
 import { useEffect, useState } from "react";
-import { Description } from "@/components/Collection/Collection.styled";
 import type { GetTopMetadataAggsReturn } from "@/lib/collection-helpers";
-import ReadMore from "@/components/Shared/ReadMore";
 import RelatedItems from "@/components/Shared/RelatedItems";
 
 interface CollectionTabsExploreProps {
@@ -14,7 +12,6 @@ const url = process.env.NEXT_PUBLIC_DCAPI_ENDPOINT;
 
 const CollectionTabsExplore: React.FC<CollectionTabsExploreProps> = ({
   collectionId,
-  description,
   topMetadata,
 }) => {
   const [urls, setUrls] = useState<string[]>([]);
@@ -38,14 +35,8 @@ const CollectionTabsExplore: React.FC<CollectionTabsExploreProps> = ({
 
   return (
     <div data-testid="explore-wrapper">
-      {description && (
-        <Description data-testid="description">
-          <ReadMore text={description} words={55} />
-        </Description>
-      )}
-
       {urls.length > 0 && (
-        <RelatedItems collectionUris={urls} title="Explore Collection" />
+        <RelatedItems collectionUris={urls} title="Top Subjects" />
       )}
     </div>
   );

--- a/components/Collection/Tabs/Metadata.styled.ts
+++ b/components/Collection/Tabs/Metadata.styled.ts
@@ -13,7 +13,8 @@ const GroupedList = styled("ul", {
   padding: 0,
 
   "& li": {
-    paddingBottom: "$1",
+    paddingBottom: "$gr2",
+    fontSize: "$gr4",
   },
 });
 

--- a/components/Collection/Tabs/Metadata.tsx
+++ b/components/Collection/Tabs/Metadata.tsx
@@ -1,8 +1,6 @@
-import {
-  ActionHeader,
-  GroupedList,
-} from "@/components/Collection/Tabs/Metadata.styled";
 import { ApiResponseBucket } from "@/types/api/response";
+import { GroupedList } from "@/components/Collection/Tabs/Metadata.styled";
+import Heading from "@/components/Heading/Heading";
 import React from "react";
 import { useRouter } from "next/router";
 
@@ -34,13 +32,11 @@ const CollectionTabsMetadata: React.FC<CollectionTabsMetadataProps> = ({
 
   return (
     <div>
-      <ActionHeader>
-        <h2>Subjects</h2>
-      </ActionHeader>
+      <Heading as="h2">All Subjects</Heading>
       <GroupedList>
         {Object.keys(grouped).map((letter) => (
           <li key={letter}>
-            <h3>{letter}</h3>
+            <Heading as="h3">{letter}</Heading>
             <GroupedList>
               {grouped[letter].map(({ doc_count, key }) => (
                 <li key={key}>

--- a/components/Collection/Tabs/Organization.tsx
+++ b/components/Collection/Tabs/Organization.tsx
@@ -1,0 +1,50 @@
+import { BloomIIIF } from "@/components/Shared/RelatedItems";
+import ExpandableList from "@/components/Shared/ExpandableList";
+import { GenericAggsReturn } from "@/lib/collection-helpers";
+import Heading from "@/components/Heading/Heading";
+
+interface CollectionTabsOrganizationProps {
+  series: GenericAggsReturn[];
+}
+
+const url = process.env.NEXT_PUBLIC_DCAPI_ENDPOINT;
+
+const CollectionTabsOrganization: React.FC<CollectionTabsOrganizationProps> = ({
+  series,
+}) => {
+  return (
+    <div data-testid="organization-wrapper">
+      <section>
+        <Heading as="h2">Explore Series</Heading>
+        <ExpandableList>
+          {series.map((entry, index) => {
+            const { key, doc_count } = entry;
+            const summary =
+              doc_count > 1 ? `${doc_count} Items` : `${doc_count}  Item`;
+            const collectionId = encodeURI(
+              `${url}/search?query=series:"${key}"
+            &collectionLabel=${key}&collectionSummary=${summary}&as=iiif`
+            );
+
+            const value = `series-${index}`;
+            const title = entry.key;
+            const indicator = `${entry.doc_count} Items`;
+
+            return (
+              <ExpandableList.Item
+                indicator={indicator}
+                title={title}
+                value={value}
+                key={value}
+              >
+                <BloomIIIF collectionId={collectionId} />
+              </ExpandableList.Item>
+            );
+          })}
+        </ExpandableList>
+      </section>
+    </div>
+  );
+};
+
+export default CollectionTabsOrganization;

--- a/components/Header/Header.styled.ts
+++ b/components/Header/Header.styled.ts
@@ -181,6 +181,11 @@ const HeaderStyled = styled("header", {
 
             ".swiper-slide": {
               figure: {
+                "&::before": {
+                  background:
+                    "linear-gradient(7deg, #000a 0%, #000a 20%, #0000 61.8%)",
+                },
+
                 "img, video": {
                   opacity: "1 !important",
                 },

--- a/components/Heading/Heading.styled.ts
+++ b/components/Heading/Heading.styled.ts
@@ -29,6 +29,20 @@ const StyledHeading = styled("h2", {
       top: "-$gr4",
     },
   },
+
+  "&[data-level=h2]": {
+    fontFamily: "$displayBold",
+    fontSize: "$gr6",
+    fontWeight: "400",
+    marginBottom: "$gr5",
+  },
+
+  "&[data-level=h3]": {
+    fontFamily: "$displayBook",
+    fontSize: "$gr6",
+    fontWeight: "400",
+    marginBottom: "$gr3",
+  },
 });
 
 export { StyledHeading };

--- a/components/Hero/Hero.styled.ts
+++ b/components/Hero/Hero.styled.ts
@@ -2,6 +2,19 @@ import { styled } from "@/stitches.config";
 
 /* eslint sort-keys: 0 */
 
+const HeroActions = styled("div", {
+  paddingTop: "$gr3",
+
+  a: {
+    textTransform: "uppercase",
+    padding: "calc($gr2 + 3px) $gr3 $gr2",
+    marginRight: "$gr3",
+    fontSize: "$gr3",
+    textShadow: "none",
+    backgroundColor: "$purple",
+  },
+});
+
 const HeroStyled = styled("div", {
   position: "absolute",
   width: "100%",
@@ -68,7 +81,8 @@ const HeroStyled = styled("div", {
           display: "flex",
           width: "100%",
           height: "100%",
-          background: "linear-gradient(7deg, #000e 0%, #0000 61.8%)",
+          background:
+            "linear-gradient(7deg, #401F68cc 0%, #000a 20%, #0000 61.8%)",
           position: "absolute",
           zIndex: "1",
           bottom: "0",
@@ -88,7 +102,7 @@ const HeroStyled = styled("div", {
         figcaption: {
           position: "absolute",
           zIndex: "1",
-          bottom: "$gr5",
+          bottom: "$gr6",
           color: "$white",
           display: "flex",
           flexDirection: "column",
@@ -104,9 +118,9 @@ const HeroStyled = styled("div", {
 
           ".slide-label": {
             fontFamily: "$displayBold",
-            fontSize: "$gr7",
+            fontSize: "$gr8",
             display: "block",
-            margin: "0 0 $gr1",
+            margin: "0 0 $gr2",
             lineHeight: "1em",
           },
 
@@ -117,16 +131,10 @@ const HeroStyled = styled("div", {
             color: "$black20",
             lineHeight: "1.15em",
           },
-
-          ".slide-see-also": {
-            marginTop: "$gr2",
-            fontSize: "$gr4",
-            textShadow: "none",
-            textTransform: "none",
-          },
         },
       },
     },
   },
 });
-export { HeroStyled };
+
+export { HeroActions, HeroStyled };

--- a/components/Hero/Hero.tsx
+++ b/components/Hero/Hero.tsx
@@ -3,12 +3,11 @@ import "swiper/css/effect-fade";
 import "swiper/css/navigation";
 import "swiper/css/pagination";
 import { Autoplay, EffectFade, Keyboard, Navigation, Pagination } from "swiper";
+import { HeroActions, HeroStyled } from "@/components/Hero/Hero.styled";
 import { Label, Summary, Thumbnail } from "@samvera/nectar-iiif";
 import { Swiper, SwiperSlide } from "swiper/react";
-import { Button } from "@nulib/design-system";
 import Container from "@/components/Shared/Container";
 import { HeroCollection } from "@/lib/constants/homepage";
-import { HeroStyled } from "@/components/Hero/Hero.styled";
 import Link from "next/link";
 import React from "react";
 
@@ -62,18 +61,22 @@ const Hero: React.FC<HeroProps> = ({ collection }) => {
                       className="slide-summary"
                     />
                   )}
-                  {item.seeAlso &&
-                    item.seeAlso.map((entry) => (
-                      <Link href={entry.id} key={entry.id}>
-                        <Button isPrimary as="a" className="slide-see-also">
-                          {entry.label ? (
-                            <Label label={entry.label} />
-                          ) : (
-                            <span>Search Collection</span>
-                          )}
-                        </Button>
-                      </Link>
-                    ))}
+
+                  {item.seeAlso && (
+                    <HeroActions>
+                      {item.seeAlso.map((entry) => (
+                        <Link href={entry.id} key={entry.id}>
+                          <a>
+                            {entry.label ? (
+                              <Label label={entry.label} />
+                            ) : (
+                              <span>Search Collection</span>
+                            )}
+                          </a>
+                        </Link>
+                      ))}
+                    </HeroActions>
+                  )}
                 </figcaption>
               </Container>
             </figure>

--- a/components/Shared/ExpandableList.styled.ts
+++ b/components/Shared/ExpandableList.styled.ts
@@ -1,0 +1,77 @@
+import * as Accordion from "@radix-ui/react-accordion";
+import { styled } from "@/stitches.config";
+
+/* eslint sort-keys: 0 */
+
+const ExpandableListItemIndicator = styled("span", {
+  display: "flex",
+  backgroundColor: "transparent",
+  color: "$black50",
+  fontSize: "$gr1",
+  fontFamily: "$sansRegular",
+  borderRadius: "3px",
+  height: "$gr3",
+  padding: "3px",
+  marginLeft: "$gr2",
+  marginTop: "3px",
+  whiteSpace: "nowrap",
+  border: "1px solid $black10",
+});
+
+const ExpandableListItemHeading = styled("span", {
+  color: "$purple",
+  fontFamily: "$sansRegular",
+  fontSize: "$gr4",
+  lineHeight: "1.55em",
+});
+
+const ExpandableListItemTrigger = styled(Accordion.Trigger, {
+  display: "flex",
+  textAlign: "left",
+  background: "transparent",
+  border: "none",
+  padding: "$gr2 0",
+  cursor: "pointer",
+
+  svg: {
+    display: "flex",
+    fill: "$purple",
+    color: "$purple",
+    height: "$gr3",
+    width: "$gr3",
+    marginRight: "$gr1",
+    marginTop: "2px",
+    transform: "rotate(-90deg)",
+    transition: "$all",
+    flexShrink: "0",
+    flexGrow: "1",
+  },
+
+  "&:hover, &:focus": {
+    [`& ${ExpandableListItemHeading}`]: {
+      textDecoration: "underline",
+    },
+  },
+
+  [`&[data-state=open]`]: {
+    svg: {
+      transform: "rotate(0)",
+    },
+  },
+});
+
+const ExpandableListItemStyled = styled(Accordion.Item, {
+  background: "transparent",
+  borderTop: "1px solid #f0f0f0",
+
+  "&:last-child": {
+    borderBottom: "1px solid #f0f0f0",
+  },
+});
+
+export {
+  ExpandableListItemHeading,
+  ExpandableListItemIndicator,
+  ExpandableListItemStyled,
+  ExpandableListItemTrigger,
+};

--- a/components/Shared/ExpandableList.tsx
+++ b/components/Shared/ExpandableList.tsx
@@ -1,0 +1,61 @@
+import * as Accordion from "@radix-ui/react-accordion";
+import {
+  ExpandableListItemHeading,
+  ExpandableListItemIndicator,
+  ExpandableListItemStyled,
+  ExpandableListItemTrigger,
+} from "@/components/Shared/ExpandableList.styled";
+import React, { ReactNode } from "react";
+import { IconChevronDown } from "@/components/Shared/SVG/Icons";
+
+interface ExpandableListItemProps {
+  children: ReactNode | ReactNode[];
+  indicator?: string;
+  title: string;
+  value: string;
+}
+
+export const ExpandableListItem: React.FC<ExpandableListItemProps> = ({
+  children,
+  indicator,
+  title,
+  value,
+}) => {
+  return (
+    <ExpandableListItemStyled value={value} key={value}>
+      <Accordion.Header asChild>
+        <ExpandableListItemTrigger>
+          <IconChevronDown />
+          <ExpandableListItemHeading>{title}</ExpandableListItemHeading>
+          {indicator && (
+            <ExpandableListItemIndicator>
+              {indicator}
+            </ExpandableListItemIndicator>
+          )}
+        </ExpandableListItemTrigger>
+      </Accordion.Header>
+      <Accordion.Content>{children}</Accordion.Content>
+    </ExpandableListItemStyled>
+  );
+};
+
+interface ExpandableListComposition {
+  Item: React.FC<ExpandableListItemProps>;
+}
+
+interface ExpandableListProps {
+  children: ReactNode | ReactNode[];
+}
+
+const ExpandableList: ExpandableListComposition &
+  React.FC<ExpandableListProps> = ({ children }) => {
+  return (
+    <Accordion.Root type="single" collapsible={true}>
+      {children}
+    </Accordion.Root>
+  );
+};
+
+ExpandableList.Item = ExpandableListItem;
+
+export default ExpandableList;

--- a/components/Shared/Facts.styled.ts
+++ b/components/Shared/Facts.styled.ts
@@ -1,0 +1,31 @@
+import { styled } from "@/stitches.config";
+
+/* eslint sort-keys: 0 */
+
+const FactsItemBig = styled("span", {
+  fontSize: "$gr7",
+  fontFamily: "$displayExtraBold",
+});
+
+const FactsItemSmall = styled("span", {
+  fontSize: "$gr4",
+  fontFamily: "$displayExtraLight",
+});
+
+const FactsItemStyled = styled("div", {
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "center",
+  alignItems: "center",
+  alignContent: "center",
+  flexGrow: "1",
+  padding: "$gr3",
+  color: "$purple",
+});
+
+const FactsStyled = styled("div", {
+  display: "flex",
+  justifyContent: "space-between",
+});
+
+export { FactsItemBig, FactsItemSmall, FactsItemStyled, FactsStyled };

--- a/components/Shared/Facts.tsx
+++ b/components/Shared/Facts.tsx
@@ -1,0 +1,37 @@
+import {
+  FactsItemBig,
+  FactsItemSmall,
+  FactsItemStyled,
+  FactsStyled,
+} from "@/components/Shared/Facts.styled";
+import React, { ReactNode } from "react";
+
+interface FactsItemProps {
+  big: string;
+  small: string;
+}
+
+const FactsItem: React.FC<FactsItemProps> = ({ big, small }) => {
+  return (
+    <FactsItemStyled>
+      <FactsItemBig>{big}</FactsItemBig>
+      <FactsItemSmall>{small}</FactsItemSmall>
+    </FactsItemStyled>
+  );
+};
+
+interface FactsComposition {
+  Item: React.FC<FactsItemProps>;
+}
+
+interface FactsProps {
+  children: ReactNode | ReactNode[];
+}
+
+const Facts: FactsComposition & React.FC<FactsProps> = ({ children }) => {
+  return <FactsStyled>{children}</FactsStyled>;
+};
+
+Facts.Item = FactsItem;
+
+export default Facts;

--- a/components/Shared/RelatedItems.styled.ts
+++ b/components/Shared/RelatedItems.styled.ts
@@ -6,9 +6,9 @@ const RelatedItemsStyled = styled("section", {
   marginBottom: "$gr5",
 
   "> h2": {
-    color: "$black50",
-    fontSize: "$gr4",
-    fontFamily: "$displayExtraLight",
+    color: "$black",
+    fontFamily: "$displayBold",
+    fontSize: "$gr6",
     fontWeight: "400",
     marginBottom: "$gr5",
   },
@@ -20,7 +20,7 @@ const RelatedItemsStyled = styled("section", {
   [`& .bloom-header-label`]: {
     display: "block",
     color: "$purple",
-    fontFamily: "$displayBold !important",
+    fontFamily: "$sansRegular !important",
     fontSize: "$gr5 !important",
   },
 

--- a/components/Shared/RelatedItems.tsx
+++ b/components/Shared/RelatedItems.tsx
@@ -1,11 +1,12 @@
 import { ErrorBoundary } from "react-error-boundary";
 import ErrorFallback from "@/components/Shared/ErrorFallback";
+import Heading from "@/components/Heading/Heading";
 import { RelatedItemsStyled } from "@/components/Shared/RelatedItems.styled";
 import dynamic from "next/dynamic";
 
 export interface RelatedItemsProps {
   collectionUris?: string[];
-  title: string;
+  title?: string;
 }
 
 export const BloomIIIF: React.ComponentType<{
@@ -21,7 +22,7 @@ const RelatedItems: React.FC<RelatedItemsProps> = ({
   if (collectionUris?.length === 0) return <></>;
   return (
     <RelatedItemsStyled data-testid="related-items">
-      <h2>{title}</h2>
+      {title && <Heading as="h2">{title}</Heading>}
       <ErrorBoundary FallbackComponent={ErrorFallback}>
         {collectionUris?.map((collectionId) => (
           <BloomIIIF collectionId={collectionId} key={collectionId} />

--- a/lib/collection-helpers.ts
+++ b/lib/collection-helpers.ts
@@ -87,7 +87,7 @@ export async function getMetadataAggs(collectionId: string, field: string) {
   const body = {
     _source: ["id"],
     aggs: {
-      collectionSubjects: {
+      collectionMetadata: {
         terms: {
           field: field,
           order: {
@@ -118,7 +118,7 @@ export async function getMetadataAggs(collectionId: string, field: string) {
     });
 
     if (response?.aggregations) {
-      return response.aggregations.collectionSubjects.buckets;
+      return response.aggregations.collectionMetadata.buckets;
     }
     return null;
   } catch (err) {
@@ -126,10 +126,16 @@ export async function getMetadataAggs(collectionId: string, field: string) {
   }
 }
 
+export type GenericAggsReturn = {
+  key: string;
+  doc_count: number;
+};
+
 type GetTopMetadataAggsParams = {
   collectionId: string;
   metadataFields: string[];
 };
+
 export type GetTopMetadataAggsReturn = {
   field: string;
   value: string[] | [];

--- a/lib/iiif/collection-helpers.ts
+++ b/lib/iiif/collection-helpers.ts
@@ -64,11 +64,32 @@ export const getRelatedCollections = (work: WorkShape) => {
 };
 
 export const getHeroCollection = (collection: CollectionShape) => {
-  const { id, representative_image, title } = collection;
+  const { id, finding_aid_url, representative_image, title } = collection;
 
   const thumbnailId = representative_image.url
     ? `${representative_image.url}/full/1200,/0/default.jpg`
     : "";
+
+  const appendSeeAlso = (search: string, findingAid: string | null) => {
+    const seeAlso = [
+      {
+        id: search,
+        label: { none: ["Search this Collection"] },
+        type: "Text",
+      },
+    ];
+
+    if (findingAid)
+      seeAlso.push({
+        id: findingAid,
+        label: { none: ["View Finding Aid"] },
+        type: "Text",
+      });
+
+    return seeAlso;
+  };
+
+  const searchUrl = `${DC_URL}/search?q=${id}`;
 
   return {
     "@context": "http://iiif.io/api/presentation/3/context.json",
@@ -83,12 +104,7 @@ export const getHeroCollection = (collection: CollectionShape) => {
         ],
         id: `${DCAPI_ENDPOINT}`,
         label: { none: [title] },
-        seeAlso: [
-          {
-            id: `${DC_URL}/search?q=${id}`,
-            type: "Text",
-          },
-        ],
+        seeAlso: appendSeeAlso(searchUrl, finding_aid_url),
         thumbnail: [
           {
             format: "image/jpeg",

--- a/pages/collections/[id].tsx
+++ b/pages/collections/[id].tsx
@@ -1,3 +1,12 @@
+import {
+  Description,
+  HeroWrapper,
+  Interstitial,
+} from "@/components/Collection/Collection.styled";
+import type {
+  GenericAggsReturn,
+  GetTopMetadataAggsReturn,
+} from "@/lib/collection-helpers";
 import { GetStaticPropsContext, NextPage } from "next";
 import {
   Tabs,
@@ -15,12 +24,13 @@ import { ApiResponseBucket } from "@/types/api/response";
 import { CollectionShape } from "@/types/components/collections";
 import CollectionTabsExplore from "@/components/Collection/Tabs/Explore";
 import CollectionTabsMetadata from "@/components/Collection/Tabs/Metadata";
+import CollectionTabsOrganization from "@/components/Collection/Tabs/Organization";
 import Container from "@/components/Shared/Container";
-import type { GetTopMetadataAggsReturn } from "@/lib/collection-helpers";
+import Facts from "@/components/Shared/Facts";
 import Head from "next/head";
 import Hero from "@/components/Hero/Hero";
-import { HeroWrapper } from "@/components/Collection/Collection.styled";
 import Layout from "components/layout";
+import ReadMore from "@/components/Shared/ReadMore";
 import { buildDataLayer } from "@/lib/ga/data-layer";
 import { getHeroCollection } from "@/lib/iiif/collection-helpers";
 import { loadCollectionStructuredData } from "@/lib/json-ld";
@@ -29,12 +39,14 @@ interface CollectionProps {
   collection: CollectionShape | null;
   metadata: ApiResponseBucket[];
   topMetadata: GetTopMetadataAggsReturn[] | [];
+  series: GenericAggsReturn[];
 }
 
 const Collection: NextPage<CollectionProps> = ({
   collection,
   metadata,
   topMetadata,
+  series,
 }) => {
   if (!collection) return null;
 
@@ -59,26 +71,44 @@ const Collection: NextPage<CollectionProps> = ({
         <HeroWrapper>
           <Hero collection={getHeroCollection(collection)} />
         </HeroWrapper>
+        <Interstitial>
+          <Container>
+            <Facts>
+              <Facts.Item big="30000" small="Total Works" />
+              <Facts.Item big="29000" small="Image Works" />
+              <Facts.Item big="300" small="Video Works" />
+              <Facts.Item big="30" small="Audio Works" />
+              <Facts.Item big="Across" small="47 Boxes" />
+            </Facts>
+          </Container>
+        </Interstitial>
         <Container>
           <Tabs defaultValue="explore">
             <TabsList aria-label="Explore">
               <TabsTrigger value="explore">About</TabsTrigger>
-              <TabsTrigger value="metadata">Subjects</TabsTrigger>
               <TabsTrigger value="organization">
                 Collection Organization
               </TabsTrigger>
+              <TabsTrigger value="metadata">All Subjects</TabsTrigger>
             </TabsList>
             <TabsContent value="explore">
+              {description && (
+                <Description data-testid="description">
+                  <ReadMore text={description} words={55} />
+                </Description>
+              )}
               <CollectionTabsExplore
                 collectionId={id}
                 description={description}
                 topMetadata={topMetadata}
               />
             </TabsContent>
+            <TabsContent value="organization">
+              <CollectionTabsOrganization series={series} />
+            </TabsContent>
             <TabsContent value="metadata">
               <CollectionTabsMetadata metadata={metadata} />
             </TabsContent>
-            <TabsContent value="organization"></TabsContent>
           </Tabs>
         </Container>
       </Layout>
@@ -113,6 +143,9 @@ export async function getStaticProps({ params }: GetStaticPropsContext) {
         })
       : null;
 
+  const series =
+    id && collection ? await getMetadataAggs(id as string, "series") : null;
+
   /** Add values to GTM's dataLayer object */
   const dataLayer = buildDataLayer({
     adminset: "",
@@ -145,6 +178,7 @@ export async function getStaticProps({ params }: GetStaticPropsContext) {
       dataLayer,
       metadata,
       openGraphData,
+      series,
       topMetadata,
     },
   };


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7376450/201717646-d72484e1-b8d8-49d2-bf27-1257627b959d.png)

## What does this do?

This work incorporates Radix UI Accordion components (as an `<ExpandableList>`) to order a collection by Series. On expand each series will render a Bloom slider. 

- No item will be open by default.
- Only one list item may be open at any time. 
- The user can also choose collapse a list item that is open.

Also incorporated into this work is `<Facts>` component that will render a Big/Small text in combination. These values are currently hardcoded placeholders but should be mapped from aggs in a future issue.

A collection's `finding_aid_url` will be rendered to a Button in the hero if it is not null.

