### PR TITLE
Add support for View All Public works Switch on Search page

### DIFF
--- a/components/Facets/Facets.styled.ts
+++ b/components/Facets/Facets.styled.ts
@@ -1,3 +1,4 @@
+import { StyledToggle } from "@/components/Shared/Switch.styled";
 import { Wrapper as WorkTypeWrapper } from "@/components/Facets/WorkType/WorkType.styled";
 import { styled } from "@/stitches.config";
 
@@ -9,6 +10,18 @@ const StyledFacets = styled("div", {
   margin: "1.618rem 0",
   position: "relative",
   zIndex: "1",
+
+  [`& ${WorkTypeWrapper}`]: {
+    borderRight: "1px solid $black10",
+    paddingRight: "$gr2",
+  },
+
+  "@sm": {
+    [`& ${WorkTypeWrapper}`]: {
+      width: "0",
+      opacity: "0",
+    },
+  },
 });
 
 const Width = styled("span", {
@@ -35,7 +48,16 @@ const Wrapper = styled("div", {
       top: "50px",
       zIndex: "1",
     },
+
+    [`& ${StyledToggle}`]: {
+      width: "0",
+      opacity: "0",
+    },
   },
 });
 
-export { StyledFacets, Width, Wrapper };
+const FacetExtras = styled("div", {
+  display: "flex",
+});
+
+export { FacetExtras, StyledFacets, Width, Wrapper };

--- a/components/Facets/Facets.tsx
+++ b/components/Facets/Facets.tsx
@@ -1,7 +1,8 @@
+import { FacetExtras, StyledFacets, Width, Wrapper } from "./Facets.styled";
 import React, { useRef } from "react";
-import { StyledFacets, Width, Wrapper } from "./Facets.styled";
 import Container from "@/components/Shared/Container";
 import FacetsFilter from "@/components/Facets/Filter/Filter";
+import SearchPublicOnlyWorks from "@/components/Search/PublicOnlyWorks";
 import WorkType from "@/components/Facets/WorkType/WorkType";
 import { useSearchState } from "@/context/search-context";
 
@@ -20,7 +21,10 @@ const Facets: React.FC = () => {
         <StyledFacets data-testid="facets-ui-wrapper" ref={facetsRef}>
           <Width ref={facetsRef} />
           <FacetsFilter />
-          <WorkType />
+          <FacetExtras>
+            <WorkType />
+            <SearchPublicOnlyWorks />
+          </FacetExtras>
         </StyledFacets>
       </Container>
     </Wrapper>

--- a/components/Search/PublicOnlyWorks.tsx
+++ b/components/Search/PublicOnlyWorks.tsx
@@ -1,0 +1,49 @@
+import {
+  Label,
+  StyledSwitch,
+  StyledThumb,
+  StyledToggle,
+  Wrapper,
+} from "@/components/Shared/Switch.styled";
+import React from "react";
+import useQueryParams from "@/hooks/useQueryParams";
+import { useRouter } from "next/router";
+
+const SearchPublicOnlyWorks = () => {
+  const router = useRouter();
+  const { urlFacets } = useQueryParams();
+  const { query: q } = router;
+
+  const switchId = `public-works-toggle`;
+  const checked =
+    urlFacets?.visibility && urlFacets?.visibility[0] === "Public";
+
+  const handleCheckedChange = (value: boolean) => {
+    const newObj = { ...urlFacets };
+    newObj["visibility"] = value ? ["Public"] : [];
+
+    router.push({
+      pathname: "/search",
+      query: { ...(q && q), ...newObj },
+    });
+  };
+
+  return (
+    <StyledToggle>
+      <Wrapper>
+        <Label htmlFor={switchId} css={checked ? { opacity: "1" } : {}}>
+          Public works only
+        </Label>
+        <StyledSwitch
+          checked={checked}
+          id={switchId}
+          onCheckedChange={handleCheckedChange}
+        >
+          <StyledThumb />
+        </StyledSwitch>
+      </Wrapper>
+    </StyledToggle>
+  );
+};
+
+export default SearchPublicOnlyWorks;

--- a/components/Shared/Switch.styled.ts
+++ b/components/Shared/Switch.styled.ts
@@ -1,0 +1,59 @@
+import * as Switch from "@radix-ui/react-switch";
+import { styled } from "stitches.config";
+
+/* eslint sort-keys: 0 */
+
+const StyledSwitch = styled(Switch.Root, {
+  all: "unset",
+  height: "2rem",
+  width: "3.236rem",
+  backgroundColor: "$black10",
+  borderRadius: "9999px",
+  position: "relative",
+  WebkitTapHighlightColor: "transparent",
+  cursor: "pointer",
+
+  "&:focus": {
+    boxShadow: `0 0 0 2px $secondaryAlt`,
+  },
+
+  '&[data-state="checked"]': {
+    backgroundColor: "$darkBlueA",
+    boxShadow: `inset 2px 2px 5px #0003`,
+  },
+});
+
+const StyledThumb = styled(Switch.Thumb, {
+  display: "block",
+  height: "calc(2rem - 12px)",
+  width: "calc(2rem - 12px)",
+  backgroundColor: "$white",
+  borderRadius: "100%",
+  boxShadow: `2px 2px 5px #0001`,
+  transition: "$all",
+  transform: "translateX(6px)",
+  willChange: "transform",
+
+  '&[data-state="checked"]': {
+    transform: "translateX(calc(1.236rem + 6px))",
+  },
+});
+
+const Wrapper = styled("div", {
+  display: "flex",
+  alignItems: "center",
+  paddingLeft: "1.618rem",
+});
+
+const Label = styled("label", {
+  fontSize: "$gr3",
+  lineHeight: "1em",
+  userSelect: "none",
+  cursor: "pointer",
+  color: "$black50",
+  paddingRight: "$gr2",
+});
+
+const StyledToggle = styled("form", {});
+
+export { Label, StyledSwitch, StyledThumb, StyledToggle, Wrapper };

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@radix-ui/react-icons": "^1.1.1",
         "@radix-ui/react-radio-group": "^0.1.6-rc.20",
         "@radix-ui/react-select": "^1.0.0",
+        "@radix-ui/react-switch": "^1.0.1",
         "@radix-ui/react-tabs": "^0.1.6-rc.13",
         "@samvera/bloom-iiif": "^0.3.4",
         "@samvera/clover-iiif": "^1.12.3",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@radix-ui/react-icons": "^1.1.1",
     "@radix-ui/react-radio-group": "^0.1.6-rc.20",
     "@radix-ui/react-select": "^1.0.0",
+    "@radix-ui/react-switch": "^1.0.1",
     "@radix-ui/react-tabs": "^0.1.6-rc.13",
     "@samvera/bloom-iiif": "^0.3.4",
     "@samvera/clover-iiif": "^1.12.3",


### PR DESCRIPTION
## What does this do?
Adds easy access UI support for viewing all public works on the Search page via a Switch/Toggle component.

<img width="1209" alt="image" src="https://user-images.githubusercontent.com/3020266/202553117-eff6417a-4877-417f-b07c-faf4948f35f6.png">

<img width="1310" alt="image" src="https://user-images.githubusercontent.com/3020266/202553269-33359a14-6424-42c4-a19a-8a22c12d86f2.png">

## How to test
Toggle the switch on/off from the Search page and notice the `visibility` facet is applied.