### PR TITLE
Case insensitive facet filtering

### DIFF
--- a/components/Facets/Facet/Options.tsx
+++ b/components/Facets/Facet/Options.tsx
@@ -33,7 +33,13 @@ const FacetOptions: React.FC<FacetOptionsProps> = ({
   });
 
   if (loading) return <SpinLoader />;
-  if (error || !data || !data.aggregations) return <>friendly user error...</>;
+  if (error) return <p>Error fetching data</p>;
+  if (
+    !data ||
+    !data.aggregations ||
+    data.aggregations[facet.id].buckets.length === 0
+  )
+    return <p>No data returned</p>;
 
   /**
    * return facet aggregation data for this facet instance

--- a/hooks/useFetchApiData.ts
+++ b/hooks/useFetchApiData.ts
@@ -38,10 +38,11 @@ const useFetchApiData = (obj: HookArguments): UseFetchApiDataResponse => {
   useEffect(() => {
     async function doRequest() {
       try {
-        setRequest({
+        setRequest((request) => ({
           ...request,
+          error: null,
           loading: true,
-        });
+        }));
 
         const body: ApiSearchRequest = buildQuery({
           aggs: activeFacets,
@@ -52,22 +53,23 @@ const useFetchApiData = (obj: HookArguments): UseFetchApiDataResponse => {
         });
 
         const response = await axios.post(DC_API_SEARCH_URL, body);
-        setRequest({
+        setRequest((request) => ({
           ...request,
           data: response.data,
           loading: false,
-        });
+        }));
       } catch (err) {
-        setRequest({
+        setRequest((request) => ({
           ...request,
           error: "Error loading data from useFetchApi",
-        });
+          loading: false,
+        }));
         console.error("error fetching API data", err);
       }
     }
 
     doRequest();
-  }, [aggsFilterValue, searchTerm, size, urlFacets]);
+  }, [aggsFilterValue, searchTerm, setRequest, size, urlFacets]);
 
   return { ...request };
 };

--- a/lib/queries/aggs.test.ts
+++ b/lib/queries/aggs.test.ts
@@ -1,0 +1,109 @@
+import * as aggs from "@/lib/queries/aggs";
+
+describe("buildAggs function", () => {
+  it("returns expected aggs with default values", () => {
+    const facets = [
+      {
+        field: "genre.label",
+        id: "genre",
+        label: "Genre",
+      },
+    ];
+    const facetFilterValue = "";
+    const userFacets = {
+      genre: ["paintings (visual works)"],
+      subject: ["Painting", "19th century"],
+    };
+
+    const response = aggs.buildAggs(facets, facetFilterValue, userFacets);
+
+    expect(response).toEqual({
+      genre: {
+        terms: {
+          field: "genre.label",
+          order: {
+            _count: "desc",
+          },
+          size: 20,
+        },
+      },
+      userFacets: {
+        terms: {
+          field: "genre.label",
+          include: ["paintings (visual works)"],
+          order: {
+            _count: "desc",
+          },
+          size: 20,
+        },
+      },
+    });
+  });
+
+  it("returns a case insensitive facet filter value by default on user filter text input", () => {
+    const facets = [
+      {
+        field: "subject.label",
+        id: "subject",
+        label: "Subject",
+      },
+    ];
+    const facetFilterValue = `Architec`;
+    const userFacets = {};
+
+    const response = aggs.buildAggs(facets, facetFilterValue, userFacets);
+    expect(response).toEqual({
+      subject: {
+        terms: {
+          field: "subject.label",
+          include: ".*(A|a)(R|r)(C|c)(H|h)(I|i)(T|t)(E|e)(C|c).*",
+          order: {
+            _count: "desc",
+          },
+          size: 20,
+        },
+      },
+    });
+  });
+
+  it("handles exact quote matching in facet filter text input", () => {
+    const facets = [
+      {
+        field: "subject.label",
+        id: "subject",
+        label: "Subject",
+      },
+    ];
+    const facetFilterValue = `"Art"`;
+    const userFacets = {};
+
+    const response = aggs.buildAggs(facets, facetFilterValue, userFacets);
+    expect(response).toEqual({
+      subject: {
+        terms: {
+          field: "subject.label",
+          include: '.*"Art".*',
+          order: {
+            _count: "desc",
+          },
+          size: 20,
+        },
+      },
+    });
+
+    /** Handles case of only one quote entered */
+    const singleQuoteResponse = aggs.buildAggs(facets, `"`, userFacets);
+    expect(singleQuoteResponse).toEqual({
+      subject: {
+        terms: {
+          field: "subject.label",
+          include: " ",
+          order: {
+            _count: "desc",
+          },
+          size: 20,
+        },
+      },
+    });
+  });
+});

--- a/lib/utils/facet-helpers.test.ts
+++ b/lib/utils/facet-helpers.test.ts
@@ -1,0 +1,19 @@
+import { facetRegex } from "./facet-helpers";
+
+describe("Case insensitive regex function", () => {
+  it("returns expected pattern", () => {
+    const response = facetRegex("21st century Boy");
+    expect(response).toBe(
+      ".*21(S|s)(T|t) (C|c)(E|e)(N|n)(T|t)(U|u)(R|r)(Y|y) (B|b)(O|o)(Y|y).*"
+    );
+    const response2 = facetRegex("Architecture");
+    expect(response2).toBe(
+      ".*(A|a)(R|r)(C|c)(H|h)(I|i)(T|t)(E|e)(C|c)(T|t)(U|u)(R|r)(E|e).*"
+    );
+  });
+
+  it("returns empty string if passed no value", () => {
+    const response = facetRegex("");
+    expect(response).toBe("");
+  });
+});

--- a/lib/utils/facet-helpers.ts
+++ b/lib/utils/facet-helpers.ts
@@ -2,6 +2,30 @@ import { ALL_FACETS, FACETS } from "@/lib/constants/facets-model";
 import { FacetsGroup, FacetsInstance } from "@/types/components/facets";
 import { UrlFacets } from "@/types/context/filter-context";
 
+/**
+ * Helper function which returns a regex pattern which
+ * OpenSearch will make case insensitive queries against
+ *
+ * ie facetRegex("Berk") returns '.*(B|b)(E|e)(R|r)(K|k).*'
+ */
+export function facetRegex(str?: string) {
+  if (!str) return "";
+
+  const upper = str.toUpperCase().split("");
+  const lower = str.toLowerCase().split("");
+  const pattern = upper
+    .map((char: string, index: number) => {
+      const unique = [...new Set([char, lower[index]])];
+      if (unique.length == 1) {
+        return unique[0];
+      } else {
+        return `(${unique.join("|")})`;
+      }
+    })
+    .join("");
+  return `.*${pattern}.*`;
+}
+
 export const getFacetById = (id: string): FacetsInstance | undefined => {
   return ALL_FACETS.facets.find((facet) => facet.id === id);
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -725,9 +725,9 @@
       "dev": true
     },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
-      "version": "13.17.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
-      "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
+      "version": "13.18.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.18.0.tgz",
+      "integrity": "sha512-/mR4KI8Ps2spmoc0Ulu9L7agOF0du1CZNQ3dke8yItYlyKNmGrkONemBbd6V8UTc1Wgcqn21t3WYB7dbRmh6/A==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -4606,14 +4606,14 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.43.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.43.0.tgz",
-      "integrity": "sha512-wNPzG+eDR6+hhW4yobEmpR36jrqqQv1vxBq5LJO3fBAktjkvekfr4BRl+3Fn1CM/A+s8/EiGUbOMDoYqWdbtXA==",
+      "version": "5.44.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.44.0.tgz",
+      "integrity": "sha512-j5ULd7FmmekcyWeArx+i8x7sdRHzAtXTkmDPthE4amxZOWKFK7bomoJ4r7PJ8K7PoMzD16U8MmuZFAonr1ERvw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.43.0",
-        "@typescript-eslint/type-utils": "5.43.0",
-        "@typescript-eslint/utils": "5.43.0",
+        "@typescript-eslint/scope-manager": "5.44.0",
+        "@typescript-eslint/type-utils": "5.44.0",
+        "@typescript-eslint/utils": "5.44.0",
         "debug": "^4.3.4",
         "ignore": "^5.2.0",
         "natural-compare-lite": "^1.4.0",
@@ -4654,14 +4654,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.43.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.43.0.tgz",
-      "integrity": "sha512-2iHUK2Lh7PwNUlhFxxLI2haSDNyXvebBO9izhjhMoDC+S3XI9qt2DGFUsiJ89m2k7gGYch2aEpYqV5F/+nwZug==",
+      "version": "5.44.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.44.0.tgz",
+      "integrity": "sha512-H7LCqbZnKqkkgQHaKLGC6KUjt3pjJDx8ETDqmwncyb6PuoigYajyAwBGz08VU/l86dZWZgI4zm5k2VaKqayYyA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.43.0",
-        "@typescript-eslint/types": "5.43.0",
-        "@typescript-eslint/typescript-estree": "5.43.0",
+        "@typescript-eslint/scope-manager": "5.44.0",
+        "@typescript-eslint/types": "5.44.0",
+        "@typescript-eslint/typescript-estree": "5.44.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -4681,13 +4681,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.43.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.43.0.tgz",
-      "integrity": "sha512-XNWnGaqAtTJsUiZaoiGIrdJYHsUOd3BZ3Qj5zKp9w6km6HsrjPk/TGZv0qMTWyWj0+1QOqpHQ2gZOLXaGA9Ekw==",
+      "version": "5.44.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.44.0.tgz",
+      "integrity": "sha512-2pKml57KusI0LAhgLKae9kwWeITZ7IsZs77YxyNyIVOwQ1kToyXRaJLl+uDEXzMN5hnobKUOo2gKntK9H1YL8g==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.43.0",
-        "@typescript-eslint/visitor-keys": "5.43.0"
+        "@typescript-eslint/types": "5.44.0",
+        "@typescript-eslint/visitor-keys": "5.44.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -4698,13 +4698,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.43.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.43.0.tgz",
-      "integrity": "sha512-K21f+KY2/VvYggLf5Pk4tgBOPs2otTaIHy2zjclo7UZGLyFH86VfUOm5iq+OtDtxq/Zwu2I3ujDBykVW4Xtmtg==",
+      "version": "5.44.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.44.0.tgz",
+      "integrity": "sha512-A1u0Yo5wZxkXPQ7/noGkRhV4J9opcymcr31XQtOzcc5nO/IHN2E2TPMECKWYpM3e6olWEM63fq/BaL1wEYnt/w==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "5.43.0",
-        "@typescript-eslint/utils": "5.43.0",
+        "@typescript-eslint/typescript-estree": "5.44.0",
+        "@typescript-eslint/utils": "5.44.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
@@ -4725,9 +4725,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.43.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.43.0.tgz",
-      "integrity": "sha512-jpsbcD0x6AUvV7tyOlyvon0aUsQpF8W+7TpJntfCUWU1qaIKu2K34pMwQKSzQH8ORgUrGYY6pVIh1Pi8TNeteg==",
+      "version": "5.44.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.44.0.tgz",
+      "integrity": "sha512-Tp+zDnHmGk4qKR1l+Y1rBvpjpm5tGXX339eAlRBDg+kgZkz9Bw+pqi4dyseOZMsGuSH69fYfPJCBKBrbPCxYFQ==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -4738,13 +4738,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.43.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.43.0.tgz",
-      "integrity": "sha512-BZ1WVe+QQ+igWal2tDbNg1j2HWUkAa+CVqdU79L4HP9izQY6CNhXfkNwd1SS4+sSZAP/EthI1uiCSY/+H0pROg==",
+      "version": "5.44.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.44.0.tgz",
+      "integrity": "sha512-M6Jr+RM7M5zeRj2maSfsZK2660HKAJawv4Ud0xT+yauyvgrsHu276VtXlKDFnEmhG+nVEd0fYZNXGoAgxwDWJw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.43.0",
-        "@typescript-eslint/visitor-keys": "5.43.0",
+        "@typescript-eslint/types": "5.44.0",
+        "@typescript-eslint/visitor-keys": "5.44.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -4780,16 +4780,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.43.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.43.0.tgz",
-      "integrity": "sha512-8nVpA6yX0sCjf7v/NDfeaOlyaIIqL7OaIGOWSPFqUKK59Gnumd3Wa+2l8oAaYO2lk0sO+SbWFWRSvhu8gLGv4A==",
+      "version": "5.44.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.44.0.tgz",
+      "integrity": "sha512-fMzA8LLQ189gaBjS0MZszw5HBdZgVwxVFShCO3QN+ws3GlPkcy9YuS3U4wkT6su0w+Byjq3mS3uamy9HE4Yfjw==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.43.0",
-        "@typescript-eslint/types": "5.43.0",
-        "@typescript-eslint/typescript-estree": "5.43.0",
+        "@typescript-eslint/scope-manager": "5.44.0",
+        "@typescript-eslint/types": "5.44.0",
+        "@typescript-eslint/typescript-estree": "5.44.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0",
         "semver": "^7.3.7"
@@ -4821,12 +4821,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.43.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.43.0.tgz",
-      "integrity": "sha512-icl1jNH/d18OVHLfcwdL3bWUKsBeIiKYTGxMJCoGe7xFht+E4QgzOqoWYrU8XSLJWhVw8nTacbm03v23J/hFTg==",
+      "version": "5.44.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.44.0.tgz",
+      "integrity": "sha512-a48tLG8/4m62gPFbJ27FxwCOqPKxsb8KC3HkmYoq2As/4YyjQl1jDbRr1s63+g4FS/iIehjmN3L5UjmKva1HzQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.43.0",
+        "@typescript-eslint/types": "5.44.0",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -4970,9 +4970,9 @@
       }
     },
     "node_modules/anymatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "dev": true,
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -5102,6 +5102,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.tosorted": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.1.tgz",
+      "integrity": "sha512-pZYPXPRl2PqWcsUs6LOMn+1f1532nEoPTYowBtqLwAW+W8vSVhkIGnmOX1t/UQjD6YGI0vcD2B1U7ZFGQH9jnQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "es-shim-unscopables": "^1.0.0",
+        "get-intrinsic": "^1.1.3"
       }
     },
     "node_modules/asn1": {
@@ -5560,9 +5573,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001431",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001431.tgz",
-      "integrity": "sha512-zBUoFU0ZcxpvSt9IU66dXVT/3ctO1cy4y9cscs1szkPlcWb6pasYM144GqrUygUbT+k7cmUCW61cvskjcv0enQ==",
+      "version": "1.0.30001434",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001434.tgz",
+      "integrity": "sha512-aOBHrLmTQw//WFa2rcF1If9fa3ypkC1wzqqiKHgfdrXTWcU8C4gKVZT77eQAPWN1APys3+uQ0Df07rKauXGEYA==",
       "funding": [
         {
           "type": "opencollective",
@@ -6553,9 +6566,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.27.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.27.0.tgz",
-      "integrity": "sha512-0y1bfG2ho7mty+SiILVf9PfuRA49ek4Nc60Wmmu62QlobNR+CeXa4xXIJgcuwSQgZiWaPH+5BDsctpIW0PR/wQ==",
+      "version": "8.28.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.28.0.tgz",
+      "integrity": "sha512-S27Di+EVyMxcHiwDrFzk8dJYAaD+/5SoWKxL1ri/71CRHsnJnRDPNt2Kzj24+MT9FDupf4aqqyqPrvI8MvQ4VQ==",
       "dev": true,
       "dependencies": {
         "@eslint/eslintrc": "^1.3.3",
@@ -6838,25 +6851,26 @@
       }
     },
     "node_modules/eslint-plugin-react": {
-      "version": "7.31.10",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.31.10.tgz",
-      "integrity": "sha512-e4N/nc6AAlg4UKW/mXeYWd3R++qUano5/o+t+wnWxIf+bLsOaH3a4q74kX3nDjYym3VBN4HyO9nEn1GcAqgQOA==",
+      "version": "7.31.11",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.31.11.tgz",
+      "integrity": "sha512-TTvq5JsT5v56wPa9OYHzsrOlHzKZKjV+aLgS+55NJP/cuzdiQPC7PfYoUjMoxlffKtvijpk7vA/jmuqRb9nohw==",
       "dev": true,
       "dependencies": {
-        "array-includes": "^3.1.5",
-        "array.prototype.flatmap": "^1.3.0",
+        "array-includes": "^3.1.6",
+        "array.prototype.flatmap": "^1.3.1",
+        "array.prototype.tosorted": "^1.1.1",
         "doctrine": "^2.1.0",
         "estraverse": "^5.3.0",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "minimatch": "^3.1.2",
-        "object.entries": "^1.1.5",
-        "object.fromentries": "^2.0.5",
-        "object.hasown": "^1.1.1",
-        "object.values": "^1.1.5",
+        "object.entries": "^1.1.6",
+        "object.fromentries": "^2.0.6",
+        "object.hasown": "^1.1.2",
+        "object.values": "^1.1.6",
         "prop-types": "^15.8.1",
         "resolve": "^2.0.0-next.3",
         "semver": "^6.3.0",
-        "string.prototype.matchall": "^4.0.7"
+        "string.prototype.matchall": "^4.0.8"
       },
       "engines": {
         "node": ">=4"
@@ -7077,9 +7091,9 @@
       }
     },
     "node_modules/eslint/node_modules/globals": {
-      "version": "13.17.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
-      "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
+      "version": "13.18.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.18.0.tgz",
+      "integrity": "sha512-/mR4KI8Ps2spmoc0Ulu9L7agOF0du1CZNQ3dke8yItYlyKNmGrkONemBbd6V8UTc1Wgcqn21t3WYB7dbRmh6/A==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -7802,9 +7816,9 @@
       }
     },
     "node_modules/global-dirs": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.0.tgz",
-      "integrity": "sha512-v8ho2DS5RiCjftj1nD9NmnfaOzTdud7RRnVd9kFNOjqZbISlx5DQ+OrTkywgd0dIt7oFCvKetZSHoHcP3sDdiA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.1.tgz",
+      "integrity": "sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==",
       "dev": true,
       "dependencies": {
         "ini": "2.0.0"
@@ -10608,10 +10622,14 @@
       }
     },
     "node_modules/js-sdsl": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.5.tgz",
-      "integrity": "sha512-08bOAKweV2NUC1wqTtf3qZlnpOX/R2DU9ikpjOHs0H+ibQv3zpncVQg6um4uYtRtrwIX8M4Nh3ytK4HGlYAq7Q==",
-      "dev": true
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.2.0.tgz",
+      "integrity": "sha512-dyBIzQBDkCqCu+0upx25Y2jGdbTGxE9fshMsCdK0ViOongpV+n5tXRcZY9v7CaVQ79AGS9KA1KHtojxiM7aXSQ==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -10638,18 +10656,18 @@
       "dev": true
     },
     "node_modules/jsdom": {
-      "version": "20.0.2",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.2.tgz",
-      "integrity": "sha512-AHWa+QO/cgRg4N+DsmHg1Y7xnz+8KU3EflM0LVDTdmrYOc1WWTSkOjtpUveQH+1Bqd5rtcVnb/DuxV/UjDO4rA==",
+      "version": "20.0.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
+      "integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
       "dev": true,
       "dependencies": {
         "abab": "^2.0.6",
-        "acorn": "^8.8.0",
+        "acorn": "^8.8.1",
         "acorn-globals": "^7.0.0",
         "cssom": "^0.5.0",
         "cssstyle": "^2.3.0",
         "data-urls": "^3.0.2",
-        "decimal.js": "^10.4.1",
+        "decimal.js": "^10.4.2",
         "domexception": "^4.0.0",
         "escodegen": "^2.0.0",
         "form-data": "^4.0.0",
@@ -10662,12 +10680,12 @@
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
         "tough-cookie": "^4.1.2",
-        "w3c-xmlserializer": "^3.0.0",
+        "w3c-xmlserializer": "^4.0.0",
         "webidl-conversions": "^7.0.0",
         "whatwg-encoding": "^2.0.0",
         "whatwg-mimetype": "^3.0.0",
         "whatwg-url": "^11.0.0",
-        "ws": "^8.9.0",
+        "ws": "^8.11.0",
         "xml-name-validator": "^4.0.0"
       },
       "engines": {
@@ -11775,9 +11793,9 @@
       "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q=="
     },
     "node_modules/parse5": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.1.tgz",
-      "integrity": "sha512-kwpuwzB+px5WUg9pyK0IcK/shltJN5/OVhQagxhCQNtT9Y9QRZqNY2e1cmbu/paRh5LMnz/oVTVLBpjFmMZhSg==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
       "dev": true,
       "dependencies": {
         "entities": "^4.4.0"
@@ -12236,9 +12254,9 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.13.10",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz",
-      "integrity": "sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw=="
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.4.3",
@@ -12887,9 +12905,9 @@
       }
     },
     "node_modules/swiper": {
-      "version": "8.4.4",
-      "resolved": "https://registry.npmjs.org/swiper/-/swiper-8.4.4.tgz",
-      "integrity": "sha512-jA/8BfOZwT8PqPSnMX0TENZYitXEhNa7ZSNj1Diqh5LZyUJoBQaZcqAiPQ/PIg1+IPaRn/V8ZYVb0nxHMh51yw==",
+      "version": "8.4.5",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-8.4.5.tgz",
+      "integrity": "sha512-zveyEFBBv4q1sVkbJHnuH4xCtarKieavJ4SxP0QEHvdpPLJRuD7j/Xg38IVVLbp7Db6qrPsLUePvxohYx39Agw==",
       "funding": [
         {
           "type": "patreon",
@@ -13135,9 +13153,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
+      "integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -13324,15 +13342,15 @@
       }
     },
     "node_modules/w3c-xmlserializer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-3.0.0.tgz",
-      "integrity": "sha512-3WFqGEgSXIyGhOmAFtlicJNMjEps8b1MG31NCA0/vOF9+nKMUW1ckhi9cnNHmf88Rzw5V+dwIwsm2C7X8k9aQg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
+      "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
       "dev": true,
       "dependencies": {
         "xml-name-validator": "^4.0.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       }
     },
     "node_modules/walker": {
@@ -14153,9 +14171,9 @@
           "dev": true
         },
         "globals": {
-          "version": "13.17.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
-          "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
+          "version": "13.18.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.18.0.tgz",
+          "integrity": "sha512-/mR4KI8Ps2spmoc0Ulu9L7agOF0du1CZNQ3dke8yItYlyKNmGrkONemBbd6V8UTc1Wgcqn21t3WYB7dbRmh6/A==",
           "dev": true,
           "requires": {
             "type-fest": "^0.20.2"
@@ -17204,14 +17222,14 @@
       }
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.43.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.43.0.tgz",
-      "integrity": "sha512-wNPzG+eDR6+hhW4yobEmpR36jrqqQv1vxBq5LJO3fBAktjkvekfr4BRl+3Fn1CM/A+s8/EiGUbOMDoYqWdbtXA==",
+      "version": "5.44.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.44.0.tgz",
+      "integrity": "sha512-j5ULd7FmmekcyWeArx+i8x7sdRHzAtXTkmDPthE4amxZOWKFK7bomoJ4r7PJ8K7PoMzD16U8MmuZFAonr1ERvw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.43.0",
-        "@typescript-eslint/type-utils": "5.43.0",
-        "@typescript-eslint/utils": "5.43.0",
+        "@typescript-eslint/scope-manager": "5.44.0",
+        "@typescript-eslint/type-utils": "5.44.0",
+        "@typescript-eslint/utils": "5.44.0",
         "debug": "^4.3.4",
         "ignore": "^5.2.0",
         "natural-compare-lite": "^1.4.0",
@@ -17232,53 +17250,53 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.43.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.43.0.tgz",
-      "integrity": "sha512-2iHUK2Lh7PwNUlhFxxLI2haSDNyXvebBO9izhjhMoDC+S3XI9qt2DGFUsiJ89m2k7gGYch2aEpYqV5F/+nwZug==",
+      "version": "5.44.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.44.0.tgz",
+      "integrity": "sha512-H7LCqbZnKqkkgQHaKLGC6KUjt3pjJDx8ETDqmwncyb6PuoigYajyAwBGz08VU/l86dZWZgI4zm5k2VaKqayYyA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.43.0",
-        "@typescript-eslint/types": "5.43.0",
-        "@typescript-eslint/typescript-estree": "5.43.0",
+        "@typescript-eslint/scope-manager": "5.44.0",
+        "@typescript-eslint/types": "5.44.0",
+        "@typescript-eslint/typescript-estree": "5.44.0",
         "debug": "^4.3.4"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.43.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.43.0.tgz",
-      "integrity": "sha512-XNWnGaqAtTJsUiZaoiGIrdJYHsUOd3BZ3Qj5zKp9w6km6HsrjPk/TGZv0qMTWyWj0+1QOqpHQ2gZOLXaGA9Ekw==",
+      "version": "5.44.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.44.0.tgz",
+      "integrity": "sha512-2pKml57KusI0LAhgLKae9kwWeITZ7IsZs77YxyNyIVOwQ1kToyXRaJLl+uDEXzMN5hnobKUOo2gKntK9H1YL8g==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.43.0",
-        "@typescript-eslint/visitor-keys": "5.43.0"
+        "@typescript-eslint/types": "5.44.0",
+        "@typescript-eslint/visitor-keys": "5.44.0"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.43.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.43.0.tgz",
-      "integrity": "sha512-K21f+KY2/VvYggLf5Pk4tgBOPs2otTaIHy2zjclo7UZGLyFH86VfUOm5iq+OtDtxq/Zwu2I3ujDBykVW4Xtmtg==",
+      "version": "5.44.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.44.0.tgz",
+      "integrity": "sha512-A1u0Yo5wZxkXPQ7/noGkRhV4J9opcymcr31XQtOzcc5nO/IHN2E2TPMECKWYpM3e6olWEM63fq/BaL1wEYnt/w==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/typescript-estree": "5.43.0",
-        "@typescript-eslint/utils": "5.43.0",
+        "@typescript-eslint/typescript-estree": "5.44.0",
+        "@typescript-eslint/utils": "5.44.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.43.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.43.0.tgz",
-      "integrity": "sha512-jpsbcD0x6AUvV7tyOlyvon0aUsQpF8W+7TpJntfCUWU1qaIKu2K34pMwQKSzQH8ORgUrGYY6pVIh1Pi8TNeteg==",
+      "version": "5.44.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.44.0.tgz",
+      "integrity": "sha512-Tp+zDnHmGk4qKR1l+Y1rBvpjpm5tGXX339eAlRBDg+kgZkz9Bw+pqi4dyseOZMsGuSH69fYfPJCBKBrbPCxYFQ==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.43.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.43.0.tgz",
-      "integrity": "sha512-BZ1WVe+QQ+igWal2tDbNg1j2HWUkAa+CVqdU79L4HP9izQY6CNhXfkNwd1SS4+sSZAP/EthI1uiCSY/+H0pROg==",
+      "version": "5.44.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.44.0.tgz",
+      "integrity": "sha512-M6Jr+RM7M5zeRj2maSfsZK2660HKAJawv4Ud0xT+yauyvgrsHu276VtXlKDFnEmhG+nVEd0fYZNXGoAgxwDWJw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.43.0",
-        "@typescript-eslint/visitor-keys": "5.43.0",
+        "@typescript-eslint/types": "5.44.0",
+        "@typescript-eslint/visitor-keys": "5.44.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -17298,16 +17316,16 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.43.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.43.0.tgz",
-      "integrity": "sha512-8nVpA6yX0sCjf7v/NDfeaOlyaIIqL7OaIGOWSPFqUKK59Gnumd3Wa+2l8oAaYO2lk0sO+SbWFWRSvhu8gLGv4A==",
+      "version": "5.44.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.44.0.tgz",
+      "integrity": "sha512-fMzA8LLQ189gaBjS0MZszw5HBdZgVwxVFShCO3QN+ws3GlPkcy9YuS3U4wkT6su0w+Byjq3mS3uamy9HE4Yfjw==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.43.0",
-        "@typescript-eslint/types": "5.43.0",
-        "@typescript-eslint/typescript-estree": "5.43.0",
+        "@typescript-eslint/scope-manager": "5.44.0",
+        "@typescript-eslint/types": "5.44.0",
+        "@typescript-eslint/typescript-estree": "5.44.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0",
         "semver": "^7.3.7"
@@ -17325,12 +17343,12 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.43.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.43.0.tgz",
-      "integrity": "sha512-icl1jNH/d18OVHLfcwdL3bWUKsBeIiKYTGxMJCoGe7xFht+E4QgzOqoWYrU8XSLJWhVw8nTacbm03v23J/hFTg==",
+      "version": "5.44.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.44.0.tgz",
+      "integrity": "sha512-a48tLG8/4m62gPFbJ27FxwCOqPKxsb8KC3HkmYoq2As/4YyjQl1jDbRr1s63+g4FS/iIehjmN3L5UjmKva1HzQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.43.0",
+        "@typescript-eslint/types": "5.44.0",
         "eslint-visitor-keys": "^3.3.0"
       }
     },
@@ -17431,9 +17449,9 @@
       }
     },
     "anymatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "dev": true,
       "requires": {
         "normalize-path": "^3.0.0",
@@ -17513,6 +17531,19 @@
         "define-properties": "^1.1.4",
         "es-abstract": "^1.20.4",
         "es-shim-unscopables": "^1.0.0"
+      }
+    },
+    "array.prototype.tosorted": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.1.tgz",
+      "integrity": "sha512-pZYPXPRl2PqWcsUs6LOMn+1f1532nEoPTYowBtqLwAW+W8vSVhkIGnmOX1t/UQjD6YGI0vcD2B1U7ZFGQH9jnQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "es-shim-unscopables": "^1.0.0",
+        "get-intrinsic": "^1.1.3"
       }
     },
     "asn1": {
@@ -17848,9 +17879,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001431",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001431.tgz",
-      "integrity": "sha512-zBUoFU0ZcxpvSt9IU66dXVT/3ctO1cy4y9cscs1szkPlcWb6pasYM144GqrUygUbT+k7cmUCW61cvskjcv0enQ=="
+      "version": "1.0.30001434",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001434.tgz",
+      "integrity": "sha512-aOBHrLmTQw//WFa2rcF1If9fa3ypkC1wzqqiKHgfdrXTWcU8C4gKVZT77eQAPWN1APys3+uQ0Df07rKauXGEYA=="
     },
     "caseless": {
       "version": "0.12.0",
@@ -18619,9 +18650,9 @@
       }
     },
     "eslint": {
-      "version": "8.27.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.27.0.tgz",
-      "integrity": "sha512-0y1bfG2ho7mty+SiILVf9PfuRA49ek4Nc60Wmmu62QlobNR+CeXa4xXIJgcuwSQgZiWaPH+5BDsctpIW0PR/wQ==",
+      "version": "8.28.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.28.0.tgz",
+      "integrity": "sha512-S27Di+EVyMxcHiwDrFzk8dJYAaD+/5SoWKxL1ri/71CRHsnJnRDPNt2Kzj24+MT9FDupf4aqqyqPrvI8MvQ4VQ==",
       "dev": true,
       "requires": {
         "@eslint/eslintrc": "^1.3.3",
@@ -18732,9 +18763,9 @@
           }
         },
         "globals": {
-          "version": "13.17.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
-          "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
+          "version": "13.18.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.18.0.tgz",
+          "integrity": "sha512-/mR4KI8Ps2spmoc0Ulu9L7agOF0du1CZNQ3dke8yItYlyKNmGrkONemBbd6V8UTc1Wgcqn21t3WYB7dbRmh6/A==",
           "dev": true,
           "requires": {
             "type-fest": "^0.20.2"
@@ -18974,25 +19005,26 @@
       }
     },
     "eslint-plugin-react": {
-      "version": "7.31.10",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.31.10.tgz",
-      "integrity": "sha512-e4N/nc6AAlg4UKW/mXeYWd3R++qUano5/o+t+wnWxIf+bLsOaH3a4q74kX3nDjYym3VBN4HyO9nEn1GcAqgQOA==",
+      "version": "7.31.11",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.31.11.tgz",
+      "integrity": "sha512-TTvq5JsT5v56wPa9OYHzsrOlHzKZKjV+aLgS+55NJP/cuzdiQPC7PfYoUjMoxlffKtvijpk7vA/jmuqRb9nohw==",
       "dev": true,
       "requires": {
-        "array-includes": "^3.1.5",
-        "array.prototype.flatmap": "^1.3.0",
+        "array-includes": "^3.1.6",
+        "array.prototype.flatmap": "^1.3.1",
+        "array.prototype.tosorted": "^1.1.1",
         "doctrine": "^2.1.0",
         "estraverse": "^5.3.0",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "minimatch": "^3.1.2",
-        "object.entries": "^1.1.5",
-        "object.fromentries": "^2.0.5",
-        "object.hasown": "^1.1.1",
-        "object.values": "^1.1.5",
+        "object.entries": "^1.1.6",
+        "object.fromentries": "^2.0.6",
+        "object.hasown": "^1.1.2",
+        "object.values": "^1.1.6",
         "prop-types": "^15.8.1",
         "resolve": "^2.0.0-next.3",
         "semver": "^6.3.0",
-        "string.prototype.matchall": "^4.0.7"
+        "string.prototype.matchall": "^4.0.8"
       },
       "dependencies": {
         "doctrine": {
@@ -19544,9 +19576,9 @@
       }
     },
     "global-dirs": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.0.tgz",
-      "integrity": "sha512-v8ho2DS5RiCjftj1nD9NmnfaOzTdud7RRnVd9kFNOjqZbISlx5DQ+OrTkywgd0dIt7oFCvKetZSHoHcP3sDdiA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.1.tgz",
+      "integrity": "sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==",
       "dev": true,
       "requires": {
         "ini": "2.0.0"
@@ -21590,9 +21622,9 @@
       }
     },
     "js-sdsl": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.1.5.tgz",
-      "integrity": "sha512-08bOAKweV2NUC1wqTtf3qZlnpOX/R2DU9ikpjOHs0H+ibQv3zpncVQg6um4uYtRtrwIX8M4Nh3ytK4HGlYAq7Q==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.2.0.tgz",
+      "integrity": "sha512-dyBIzQBDkCqCu+0upx25Y2jGdbTGxE9fshMsCdK0ViOongpV+n5tXRcZY9v7CaVQ79AGS9KA1KHtojxiM7aXSQ==",
       "dev": true
     },
     "js-tokens": {
@@ -21617,18 +21649,18 @@
       "dev": true
     },
     "jsdom": {
-      "version": "20.0.2",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.2.tgz",
-      "integrity": "sha512-AHWa+QO/cgRg4N+DsmHg1Y7xnz+8KU3EflM0LVDTdmrYOc1WWTSkOjtpUveQH+1Bqd5rtcVnb/DuxV/UjDO4rA==",
+      "version": "20.0.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
+      "integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
       "dev": true,
       "requires": {
         "abab": "^2.0.6",
-        "acorn": "^8.8.0",
+        "acorn": "^8.8.1",
         "acorn-globals": "^7.0.0",
         "cssom": "^0.5.0",
         "cssstyle": "^2.3.0",
         "data-urls": "^3.0.2",
-        "decimal.js": "^10.4.1",
+        "decimal.js": "^10.4.2",
         "domexception": "^4.0.0",
         "escodegen": "^2.0.0",
         "form-data": "^4.0.0",
@@ -21641,12 +21673,12 @@
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
         "tough-cookie": "^4.1.2",
-        "w3c-xmlserializer": "^3.0.0",
+        "w3c-xmlserializer": "^4.0.0",
         "webidl-conversions": "^7.0.0",
         "whatwg-encoding": "^2.0.0",
         "whatwg-mimetype": "^3.0.0",
         "whatwg-url": "^11.0.0",
-        "ws": "^8.9.0",
+        "ws": "^8.11.0",
         "xml-name-validator": "^4.0.0"
       },
       "dependencies": {
@@ -22452,9 +22484,9 @@
       "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q=="
     },
     "parse5": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.1.tgz",
-      "integrity": "sha512-kwpuwzB+px5WUg9pyK0IcK/shltJN5/OVhQagxhCQNtT9Y9QRZqNY2e1cmbu/paRh5LMnz/oVTVLBpjFmMZhSg==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
       "dev": true,
       "requires": {
         "entities": "^4.4.0"
@@ -22767,9 +22799,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.10",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz",
-      "integrity": "sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw=="
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "regexp.prototype.flags": {
       "version": "1.4.3",
@@ -23243,9 +23275,9 @@
       "dev": true
     },
     "swiper": {
-      "version": "8.4.4",
-      "resolved": "https://registry.npmjs.org/swiper/-/swiper-8.4.4.tgz",
-      "integrity": "sha512-jA/8BfOZwT8PqPSnMX0TENZYitXEhNa7ZSNj1Diqh5LZyUJoBQaZcqAiPQ/PIg1+IPaRn/V8ZYVb0nxHMh51yw==",
+      "version": "8.4.5",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-8.4.5.tgz",
+      "integrity": "sha512-zveyEFBBv4q1sVkbJHnuH4xCtarKieavJ4SxP0QEHvdpPLJRuD7j/Xg38IVVLbp7Db6qrPsLUePvxohYx39Agw==",
       "requires": {
         "dom7": "^4.0.4",
         "ssr-window": "^4.0.2"
@@ -23433,9 +23465,9 @@
       "integrity": "sha512-bna6Yi1pRznoo6Bz1cE6btB/Yy8Xywytyfrzu/wc+NFW3ZF0I+2iCGImhBsoYYCOWuICtRO4yHcnDlzgo1AdNg=="
     },
     "typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.3.tgz",
+      "integrity": "sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==",
       "dev": true
     },
     "unbox-primitive": {
@@ -23548,9 +23580,9 @@
       }
     },
     "w3c-xmlserializer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-3.0.0.tgz",
-      "integrity": "sha512-3WFqGEgSXIyGhOmAFtlicJNMjEps8b1MG31NCA0/vOF9+nKMUW1ckhi9cnNHmf88Rzw5V+dwIwsm2C7X8k9aQg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
+      "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
       "dev": true,
       "requires": {
         "xml-name-validator": "^4.0.0"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "ES6",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## What does this do?
In the Filter modal window, facet filtering is now case insensitive thanks for a helper function provided by @mbklein @kdid and @bmquinn 

<img width="697" alt="image" src="https://user-images.githubusercontent.com/3020266/203352068-87f064ba-e927-4cb8-850d-6404c3f6083a.png">


## How to test
1. From the screen shot above, go to a Work, and open the Filter modal
2. Type facet filter values, and notice case insensitivity in results