### PR TITLE
Search within Collection

### DIFF
--- a/components/Header/Primary.test.tsx
+++ b/components/Header/Primary.test.tsx
@@ -1,7 +1,14 @@
 import { render, screen } from "@/test-utils";
 import HeaderPrimary from "./Primary";
 
+import mockRouter from "next-router-mock";
+jest.mock("next/router", () => require("next-router-mock"));
+
 describe("HeaderPrimary", () => {
+  beforeEach(() => {
+    mockRouter.setCurrentUrl("/search");
+  });
+
   it("renders the header-primary ui component", () => {
     render(<HeaderPrimary />);
     const wrapper = screen.getByTestId("header-primary-ui-component");

--- a/components/Header/Primary.tsx
+++ b/components/Header/Primary.tsx
@@ -6,9 +6,11 @@ import Link from "next/link";
 import Nav from "@/components/Nav/Nav";
 import Search from "@/components/Search/Search";
 import useElementPosition from "@/hooks/useElementPosition";
+import { useRouter } from "next/router";
 import { useSearchState } from "@/context/search-context";
 
 const HeaderPrimary: React.FC = () => {
+  const router = useRouter();
   const [searchActive, setSearchActive] = useState<boolean>(false);
 
   const { searchDispatch, searchState } = useSearchState();
@@ -43,7 +45,12 @@ const HeaderPrimary: React.FC = () => {
             <strong>N</strong>
           </Heading>
           <PrimaryInner>
-            <Search isSearchActive={handleIsSearchActive} />
+            <Search
+              isSearchActive={handleIsSearchActive}
+              {...(router.pathname.includes("collection")
+                ? { jumpTo: "collection" }
+                : undefined)}
+            />
             <Nav>
               <Link href="/collections">Browse Collections</Link>
             </Nav>

--- a/components/Search/JumpTo.styled.ts
+++ b/components/Search/JumpTo.styled.ts
@@ -1,0 +1,55 @@
+import { styled } from "@/stitches.config";
+
+/* eslint sort-keys: 0 */
+
+const SearchJumpToStyled = styled("ul", {
+  position: "absolute",
+  left: "0px",
+  display: "block",
+  margin: "0",
+  padding: "0",
+  background: "white",
+  width: "calc(100% - $gr5)",
+  fontSize: "$gr3",
+  listStyle: "none",
+  top: "50px",
+});
+
+const JumpItem = styled("li", {
+  position: "relative",
+
+  "& a": {
+    display: "block",
+    padding: "$gr3",
+    borderTopWidth: "1px",
+    borderTopColor: "$black20",
+    borderTopStyle: "solid",
+    cursor: "pointer",
+
+    "&:hover": {
+      background: "$black10",
+    },
+  },
+});
+
+const HelperStyled = styled("div", {
+  position: "absolute",
+  top: "$gr2",
+  right: "$gr2",
+  padding: "0 $gr2",
+  background: "$black50",
+  color: "$white",
+  display: "flex",
+  alignItems: "center",
+
+  "& svg": {
+    position: "relative",
+    display: "inline-block",
+    padding: "0",
+    marginLeft: "$gr1",
+    height: "$gr4",
+    width: "auto",
+  },
+});
+
+export { HelperStyled, JumpItem, SearchJumpToStyled };

--- a/components/Search/JumpTo.test.tsx
+++ b/components/Search/JumpTo.test.tsx
@@ -1,0 +1,40 @@
+import SearchJumpTo from "@/components/Search/JumpTo";
+import { render } from "@/test-utils";
+import { screen } from "@testing-library/react";
+import singletonRouter from "next/router";
+
+jest.mock("next/router", () => require("next-router-mock"));
+// This is needed for mocking 'next/link':
+jest.mock("next/dist/client/router", () => require("next-router-mock"));
+
+describe("SearchJumpTo component", () => {
+  it("renders search value in listbox items", () => {
+    render(<SearchJumpTo searchValue="Dylan" />);
+    expect(screen.getByTestId("jump-to-wrapper"));
+    expect(screen.getAllByText("Dylan")).toHaveLength(2);
+  });
+
+  it("renders Helper components in each JumpTo item", () => {
+    render(<SearchJumpTo searchValue="foo" />);
+    const helpers = screen.getAllByTestId("helper");
+    expect(helpers[0]).toHaveTextContent(/in this collection/i);
+    expect(helpers[1]).toHaveTextContent(/all digital collections/i);
+  });
+
+  it("renders route query params in JumpTo items", async () => {
+    singletonRouter.push({
+      pathname: "/collection/[id]",
+      query: { id: "abc123" },
+    });
+    render(<SearchJumpTo searchValue="foo" />);
+
+    expect(screen.getByTestId("helper-anchor-collection")).toHaveAttribute(
+      "href",
+      "/search?collection=abc123&q=foo"
+    );
+    expect(screen.getByTestId("helper-anchor-all")).toHaveAttribute(
+      "href",
+      "/search?q=foo"
+    );
+  });
+});

--- a/components/Search/JumpTo.tsx
+++ b/components/Search/JumpTo.tsx
@@ -1,0 +1,56 @@
+import {
+  HelperStyled,
+  JumpItem,
+  SearchJumpToStyled,
+} from "@/components/Search/JumpTo.styled";
+import { IconReturnDownBack } from "@/components/Shared/SVG/Icons";
+import Link from "next/link";
+import { useRouter } from "next/router";
+
+const SearchJumpTo = ({ searchValue }: { searchValue: string }) => {
+  const router = useRouter();
+
+  return (
+    <SearchJumpToStyled data-testid="jump-to-wrapper" role="listbox">
+      <JumpItem role="option">
+        <Link
+          href={{
+            pathname: "/search",
+            query: {
+              collection: router.query.id,
+              q: searchValue,
+            },
+          }}
+        >
+          <a tabIndex={0} data-testid="helper-anchor-collection">
+            {searchValue} <Helper label="In this Collection" />
+          </a>
+        </Link>
+      </JumpItem>
+      <JumpItem role="option">
+        <Link
+          href={{
+            pathname: "/search",
+            query: {
+              q: searchValue,
+            },
+          }}
+        >
+          <a tabIndex={0} data-testid="helper-anchor-all">
+            {searchValue} <Helper label="All Digital Collections" />
+          </a>
+        </Link>
+      </JumpItem>
+    </SearchJumpToStyled>
+  );
+};
+
+const Helper: React.FC<{ label: string }> = ({ label }) => {
+  return (
+    <HelperStyled data-testid="helper">
+      <span>{label}</span> <IconReturnDownBack />
+    </HelperStyled>
+  );
+};
+
+export default SearchJumpTo;

--- a/components/Search/Search.test.tsx
+++ b/components/Search/Search.test.tsx
@@ -1,10 +1,56 @@
 import { render, screen } from "@/test-utils";
 import Search from "./Search";
+import userEvent from "@testing-library/user-event";
 
-describe("Search", () => {
+const mockIsSearchActive = jest.fn();
+
+jest.mock("next/router", () => require("next-router-mock"));
+
+describe("Search component", () => {
   it("renders the search ui component", () => {
     render(<Search isSearchActive={() => ({})} />);
     const wrapper = screen.getByTestId("search-ui-component");
     expect(wrapper).toBeInTheDocument();
+  });
+
+  it("does not render the SearchJumpTo component on Search page", async () => {
+    const user = userEvent.setup();
+    render(<Search isSearchActive={mockIsSearchActive} />);
+    const form = screen.getByTestId("search-ui-component");
+
+    await user.type(screen.getByRole("search"), "foo");
+
+    expect(form).toHaveFormValues({ search: "foo" });
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
+  it("conditionally renders the SearchJumpTo component", async () => {
+    const user = userEvent.setup();
+    render(
+      <div data-testid="page">
+        <span>Outside search form</span>
+        <Search isSearchActive={mockIsSearchActive} jumpTo="collection" />
+      </div>
+    );
+    const form = screen.getByTestId("search-ui-component");
+
+    await user.type(screen.getByRole("search"), "foo");
+
+    // JumpTo should be visible
+    expect(form).toHaveFormValues({ search: "foo" });
+    expect(screen.getByRole("listbox"));
+
+    // Click outside Search form, it should close JumpTo
+    await user.click(screen.getByText("Outside search form"));
+
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+
+    // Type back in main search input, it should re-open JumpTo
+    await user.type(screen.getByRole("search"), "baz");
+
+    expect(form).toHaveFormValues({
+      search: "foobaz",
+    });
+    expect(screen.getByRole("listbox"));
   });
 });

--- a/components/Search/Search.tsx
+++ b/components/Search/Search.tsx
@@ -8,19 +8,39 @@ import {
   useState,
 } from "react";
 import { IconClear, IconSearch } from "../Shared/SVG/Icons";
+import SearchJumpTo from "@/components/Search/JumpTo";
+import useEventListener from "@/hooks/useEventListener";
 import { useRouter } from "next/router";
 import { useSearchState } from "@/context/search-context";
+
 interface SearchProps {
   isSearchActive: (value: boolean) => void;
+  jumpTo?: "collection"; // In the future maybe we extend a jumpTo enum? ie. "collection" | "work" | ?
 }
 
-const Search: React.FC<SearchProps> = ({ isSearchActive }) => {
+const Search: React.FC<SearchProps> = ({ isSearchActive, jumpTo }) => {
   const router = useRouter();
   const { searchDispatch } = useSearchState();
   const search = useRef<HTMLInputElement>(null);
+  const formRef = useRef<HTMLFormElement>(null);
   const [searchValue, setSearchValue] = useState<string>("");
   const [searchFocus, setSearchFocus] = useState<boolean>(false);
   const [isLoaded, setIsLoaded] = useState<boolean>(false);
+  const [showJumpTo, setShowJumpTo] = useState<boolean>(false);
+
+  // @ts-ignore
+  const handleMouseDown = (e) => {
+    if (
+      jumpTo &&
+      showJumpTo &&
+      formRef.current &&
+      !formRef.current.contains(e.target)
+    ) {
+      if (jumpTo) setShowJumpTo(false);
+    }
+  };
+
+  useEventListener("mousedown", handleMouseDown);
 
   const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -36,11 +56,20 @@ const Search: React.FC<SearchProps> = ({ isSearchActive }) => {
     });
   };
 
-  const handleSearchFocus = (e: FocusEvent) =>
-    e.type === "focus" ? setSearchFocus(true) : setSearchFocus(false);
+  const handleSearchFocus = (e: FocusEvent) => {
+    if (e.type === "focus") {
+      setSearchFocus(true);
+      setShowJumpTo(Boolean(jumpTo && searchValue));
+    } else {
+      setSearchFocus(false);
+    }
+  };
 
-  const handleSearchChange = (e: ChangeEvent<HTMLInputElement>) =>
-    setSearchValue(e.target.value);
+  const handleSearchChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setSearchValue(value);
+    setShowJumpTo(Boolean(value && jumpTo));
+  };
 
   const clearSearchResults = () => {
     router.push(`/search`);
@@ -65,13 +94,19 @@ const Search: React.FC<SearchProps> = ({ isSearchActive }) => {
   }, [searchFocus, searchValue, isSearchActive]);
 
   return (
-    <SearchStyled onSubmit={handleSubmit} data-testid="search-ui-component">
+    <SearchStyled
+      ref={formRef}
+      onSubmit={handleSubmit}
+      data-testid="search-ui-component"
+    >
       <Input
         placeholder="Search by keyword or phrase, ex: Berkeley Music Festival"
         onChange={handleSearchChange}
         onFocus={handleSearchFocus}
         onBlur={handleSearchFocus}
         ref={search}
+        name="search"
+        role="search"
       />
       {searchValue && (
         <Clear onClick={clearSearchResults} type="reset">
@@ -80,6 +115,7 @@ const Search: React.FC<SearchProps> = ({ isSearchActive }) => {
       )}
       <Button type="submit">Search</Button>
       {isLoaded && <IconSearch />}
+      {jumpTo && showJumpTo && <SearchJumpTo searchValue={searchValue} />}
     </SearchStyled>
   );
 };

--- a/components/Shared/SVG/Icons.tsx
+++ b/components/Shared/SVG/Icons.tsx
@@ -101,6 +101,28 @@ const IconLock: React.FC = () => (
   </svg>
 );
 
+const IconReturnDownBack: React.FC = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+    <title>Return Down Back</title>
+    <path
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="32"
+      d="M112 352l-64-64 64-64"
+    />
+    <path
+      d="M64 288h294c58.76 0 106-49.33 106-108v-20"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="32"
+    />
+  </svg>
+);
+
 const IconSearch: React.FC = () => (
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
     <title>Search</title>
@@ -153,6 +175,7 @@ export {
   IconFilter,
   IconImage,
   IconLock,
+  IconReturnDownBack,
   IconSearch,
   IconSocialFacebook,
   IconSocialPinterest,

--- a/lib/constants/facets-model.ts
+++ b/lib/constants/facets-model.ts
@@ -8,7 +8,7 @@ import {
 export const ALL_FACETS: FacetsList = {
   facets: [
     {
-      field: "collection.title",
+      field: "collection.id",
       id: "collection",
       label: "Collection",
     },

--- a/lib/iiif/collection-helpers.ts
+++ b/lib/iiif/collection-helpers.ts
@@ -74,7 +74,7 @@ export const getHeroCollection = (collection: CollectionShape) => {
     const seeAlso = [
       {
         id: search,
-        label: { none: ["Search this Collection"] },
+        label: { none: ["View this Collection"] },
         type: "Text",
       },
     ];

--- a/mocks/sample-work1.ts
+++ b/mocks/sample-work1.ts
@@ -13,6 +13,7 @@ export const sampleWork1: WorkShape = {
   caption: [],
   catalog_key: [],
   collection: {
+    description: "Something",
     id: "51d4475f-5a0a-42a4-8901-bde73a1fae99",
     title: "Jim Roberts Photographs, 1968-1972",
   },

--- a/mocks/sample-work2.ts
+++ b/mocks/sample-work2.ts
@@ -13,6 +13,7 @@ export const sampleWork2: WorkShape = {
   caption: [],
   catalog_key: [],
   collection: {
+    description: null,
     id: "51d4475f-5a0a-42a4-8901-bde73a1fae99",
     title: "Jim Roberts Photographs, 1968-1972",
   },

--- a/types/components/works.ts
+++ b/types/components/works.ts
@@ -72,6 +72,7 @@ export interface WorkShape {
   caption: Array<string>;
   catalog_key: Array<string>;
   collection: {
+    description: string | null;
     id: string;
     title: string;
   };


### PR DESCRIPTION
## What does this do?
This supports an option for the user to search either within a Collection, or within All Digital Collections.  Inspired by Github's "Search or jump to..." (look above).

Adds some extra tests around the `<Search />` component.

Even though it's currently just used for expanding a search on the Collection page, it's set up for a `prop` to be passed into the `<Search />` component which could leave room for future implementations outside of the Collection page itself.

![image](https://user-images.githubusercontent.com/3020266/206763826-041c6e1e-a5eb-4f08-961d-38cc0af5e92d.png)
 
## How to test
- Go to a Collection, and test searching within Collection, or within all the whole site
- Try clicking in/out of the search box to see visibility behavior.
- Go to Home page or main search and notice it doesn't appear.