### PR TITLE
Handling display of a Work when in Reading Room

### DIFF
--- a/components/Shared/SVG/Icons.tsx
+++ b/components/Shared/SVG/Icons.tsx
@@ -1,3 +1,10 @@
+const IconAlertCircleIcon: React.FC = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+    <title>Alert Circle</title>
+    <path d="M256 48C141.31 48 48 141.31 48 256s93.31 208 208 208 208-93.31 208-208S370.69 48 256 48zm0 319.91a20 20 0 1120-20 20 20 0 01-20 20zm21.72-201.15l-5.74 122a16 16 0 01-32 0l-5.74-121.94v-.05a21.74 21.74 0 1143.44 0z" />
+  </svg>
+);
+
 const IconArrowBack: React.FC = () => (
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
     <title>Arrow Back</title>
@@ -90,6 +97,13 @@ const IconImage: React.FC = () => (
   </svg>
 );
 
+const IconInfo: React.FC = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+    <title>Information Circle</title>
+    <path d="M256 56C145.72 56 56 145.72 56 256s89.72 200 200 200 200-89.72 200-200S366.28 56 256 56zm0 82a26 26 0 11-26 26 26 26 0 0126-26zm48 226h-88a16 16 0 010-32h28v-88h-16a16 16 0 010-32h32a16 16 0 0116 16v104h28a16 16 0 010 32z" />
+  </svg>
+);
+
 const IconLock: React.FC = () => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
@@ -166,6 +180,7 @@ const IconVideo: React.FC = () => (
 );
 
 export {
+  IconAlertCircleIcon,
   IconArrowBack,
   IconArrowForward,
   IconAudio,
@@ -174,6 +189,7 @@ export {
   IconClear,
   IconFilter,
   IconImage,
+  IconInfo,
   IconLock,
   IconReturnDownBack,
   IconSearch,

--- a/components/Work/ViewerWrapper.styled.ts
+++ b/components/Work/ViewerWrapper.styled.ts
@@ -7,4 +7,16 @@ const ViewerWrapperStyled = styled("section", {
   zIndex: "0",
 });
 
-export { ViewerWrapperStyled };
+const AnnouncementContent = styled("div", {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+
+  "& svg": {
+    height: "$gr4",
+    fill: "$black80",
+    marginRight: "$gr1",
+  },
+});
+
+export { AnnouncementContent, ViewerWrapperStyled };

--- a/components/Work/ViewerWrapper.test.tsx
+++ b/components/Work/ViewerWrapper.test.tsx
@@ -1,13 +1,50 @@
 import { render, screen, waitFor } from "@/test-utils";
+import { UserContext } from "@/pages/_app";
 import WorkViewerWrapper from "@/components/Work/ViewerWrapper";
 
-// TODO: Why is this throwing an async warning?
-xdescribe("WorkViewerWrapper", () => {
+const userContextValue = {
+  user: {
+    email: "joan.doe@northwestern.edu",
+    isLoggedIn: true,
+    isReadingRoom: false,
+    name: "Joan Doe",
+    sub: "jdoe2399",
+  },
+};
+const readingRoomMessage =
+  /You have access to Work because you are in the reading room/i;
+
+describe("WorkViewerWrapper", () => {
   it("renders a wrapping element for Clover", async () => {
-    render(<WorkViewerWrapper manifestId="http:testing.com" />);
+    render(<WorkViewerWrapper manifestId="http://testing.com" />);
     await waitFor(() => {
       const el = screen.getByTestId("work-viewer-wrapper");
       expect(el).toBeInTheDocument();
     });
+  });
+
+  it("renders an announcement when in the Reading Room", async () => {
+    render(
+      <UserContext.Provider value={userContextValue}>
+        <WorkViewerWrapper manifestId="http://testing.com" />
+      </UserContext.Provider>
+    );
+
+    expect(screen.queryByText(readingRoomMessage)).not.toBeInTheDocument();
+
+    const readingUserContext = { ...userContextValue };
+    readingUserContext.user.isReadingRoom = true;
+
+    render(
+      <UserContext.Provider value={readingUserContext}>
+        <WorkViewerWrapper manifestId="http://testing.com" />
+      </UserContext.Provider>
+    );
+
+    expect(
+      await screen.findByText(
+        /You have access to Work because you are in the reading room/i
+      )
+    ).toBeInTheDocument();
   });
 });

--- a/components/Work/ViewerWrapper.tsx
+++ b/components/Work/ViewerWrapper.tsx
@@ -1,6 +1,12 @@
+import {
+  AnnouncementContent,
+  ViewerWrapperStyled,
+} from "@/components/Work/ViewerWrapper.styled";
+import Announcement from "@/components/Shared/Announcement";
+import { IconInfo } from "@/components/Shared/SVG/Icons";
 import { Options as OpenSeadragonOptions } from "openseadragon";
 import React from "react";
-import { ViewerWrapperStyled } from "@/components/Work/ViewerWrapper.styled";
+import { UserContext } from "@/pages/_app";
 import dynamic from "next/dynamic";
 
 export const CloverIIIF: React.ComponentType<{
@@ -21,6 +27,8 @@ interface WrapperProps {
 }
 
 const WorkViewerWrapper: React.FC<WrapperProps> = ({ manifestId }) => {
+  const userAuth = React.useContext(UserContext);
+
   const customTheme = {
     colors: {
       accent: "$purple",
@@ -57,6 +65,14 @@ const WorkViewerWrapper: React.FC<WrapperProps> = ({ manifestId }) => {
           id={manifestId}
           options={options}
         />
+      )}
+      {userAuth?.user?.isReadingRoom && (
+        <Announcement>
+          <AnnouncementContent>
+            <IconInfo />
+            <p>You have access to Work because you are in the reading room</p>
+          </AnnouncementContent>
+        </Announcement>
       )}
     </ViewerWrapperStyled>
   );

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -29,9 +29,7 @@ function MyApp({ Component, pageProps }: MyAppProps) {
   const [user, setUser] = React.useState<User | null>(null);
 
   React.useEffect(() => {
-    /**
-     * Determine if user is authenticated via cookie
-     */
+    /* Determine if user is authenticated via cookie */
     axios
       .get(`${DCAPI_ENDPOINT}/auth/whoami`, {
         withCredentials: true,

--- a/pages/items/[id].tsx
+++ b/pages/items/[id].tsx
@@ -49,6 +49,7 @@ const WorkPage: NextPage<WorkPageProps> = ({
     (!userAuthContext?.user?.isLoggedIn && work.visibility !== "Public");
   const collectionWorkTypeCounts =
     collectionWorkCounts && collectionWorkCounts[work.collection?.id];
+  const isReadingRoom = userAuthContext?.user?.isReadingRoom;
 
   return (
     <>
@@ -71,11 +72,10 @@ const WorkPage: NextPage<WorkPageProps> = ({
       <Layout title={work.title}>
         <WorkProvider initialState={{ manifest: manifest, work: work }}>
           <ErrorBoundary FallbackComponent={ErrorFallback}>
-            {isRestricted && (
-              <WorkRestrictedDisplay thumbnail={work.thumbnail} />
-            )}
-            {!isRestricted && (
+            {!isRestricted || isReadingRoom ? (
               <WorkViewerWrapper manifestId={work.iiif_manifest} />
+            ) : (
+              <WorkRestrictedDisplay thumbnail={work.thumbnail} />
             )}
             <Container>
               <WorkTopInfo


### PR DESCRIPTION
## What does this do?
Handles display of a Work when in the Reading Room.

#### Authenticated view
![image](https://user-images.githubusercontent.com/3020266/208457261-af343556-412e-4796-b2c4-b6b94d338a65.png)

#### Reading Room view
![image](https://user-images.githubusercontent.com/3020266/208457484-b45e82ef-e8d7-439b-9f4f-3a349d890d32.png)

### How to Test
- Run the local dev environment
- In `pages/_app.tsx`, on line 49, set the value of `isReadingRoom` to `true` to mock what the Reading Room auth request response would look like.
```jsx
...
setUser({
  email,
  isLoggedIn,
  isReadingRoom: true,
  name,
  sub,
});
```