### PR TITLE
Page transitions slightly smoother and less flashy white

### DIFF
--- a/components/Transition.tsx
+++ b/components/Transition.tsx
@@ -1,21 +1,23 @@
-import { AnimatePresence, motion } from "framer-motion";
+import { AnimatePresence, type Variants, motion } from "framer-motion";
 import { useRouter } from "next/router";
 
-const variants = {
-  in: {
+const variants: Variants = {
+  animate: {
     opacity: 1,
     transition: {
-      delay: 0.25,
-      duration: 0.25,
+      duration: 0.5,
+      ease: "easeInOut",
     },
-    y: 0,
   },
-  out: {
-    opacity: 0,
+  exit: {
+    opacity: 0.9,
     transition: {
-      duration: 0.25,
+      duration: 0.5,
+      ease: "easeInOut",
     },
-    y: 0,
+  },
+  initial: {
+    opacity: 0.9,
   },
 };
 
@@ -28,13 +30,13 @@ const Transition: React.FC<Props> = ({ children }) => {
 
   return (
     <div style={{ overflow: "hidden" }}>
-      <AnimatePresence initial={false} exitBeforeEnter>
+      <AnimatePresence>
         <motion.div
           key={asPath}
           variants={variants}
-          animate="in"
-          initial="out"
-          exit="out"
+          initial="initial"
+          animate="animate"
+          exit="exit"
         >
           {children}
         </motion.div>


### PR DESCRIPTION
## What does this do?
Uses the Framer Motion package to attempt handling smooth page transitions.  I can't seem to configure it to do a perfect fade from one page to the next...still get a little bit of the white background feeling, but this is less jarring (I think).

If we don't like this, we can remove the transition altogether and just run with default browser behavior.

## To Test
Click around the site from page to page and bask in its glory.