### PR TITLE
3405 collection search bugfixes

### DIFF
--- a/components/Collection/Collection.styled.ts
+++ b/components/Collection/Collection.styled.ts
@@ -13,6 +13,7 @@ const Description = styled("p", {
 const HeroWrapper = styled("div", {
   height: "375px",
   position: "relative",
+  pointerEvents: "none",
 });
 
 const Interstitial = styled("div", {

--- a/components/Header/Primary.tsx
+++ b/components/Header/Primary.tsx
@@ -5,12 +5,15 @@ import Heading from "@/components/Heading/Heading";
 import Link from "next/link";
 import Nav from "@/components/Nav/Nav";
 import Search from "@/components/Search/Search";
+import SearchJumpTo from "@/components/Search/JumpTo";
 import useElementPosition from "@/hooks/useElementPosition";
 import { useRouter } from "next/router";
 import { useSearchState } from "@/context/search-context";
 
 const HeaderPrimary: React.FC = () => {
   const router = useRouter();
+  const isCollectionPage = router.pathname.includes("collection");
+
   const [searchActive, setSearchActive] = useState<boolean>(false);
 
   const { searchDispatch, searchState } = useSearchState();
@@ -45,12 +48,12 @@ const HeaderPrimary: React.FC = () => {
             <strong>N</strong>
           </Heading>
           <PrimaryInner>
-            <Search
-              isSearchActive={handleIsSearchActive}
-              {...(router.pathname.includes("collection")
-                ? { jumpTo: "collection" }
-                : undefined)}
-            />
+            {!isCollectionPage && (
+              <Search isSearchActive={handleIsSearchActive} />
+            )}
+            {isCollectionPage && (
+              <SearchJumpTo isSearchActive={handleIsSearchActive} />
+            )}
             <Nav>
               <Link href="/collections">Browse Collections</Link>
             </Nav>

--- a/components/Search/JumpTo.styled.ts
+++ b/components/Search/JumpTo.styled.ts
@@ -2,17 +2,18 @@ import { styled } from "@/stitches.config";
 
 /* eslint sort-keys: 0 */
 
-const SearchJumpToStyled = styled("ul", {
+const JumpToListStyled = styled("ul", {
   position: "absolute",
   left: "0px",
   display: "block",
   margin: "0",
   padding: "0",
   background: "white",
-  width: "calc(100% - $gr5)",
+  width: "100%",
   fontSize: "$gr3",
   listStyle: "none",
   top: "50px",
+  border: "1px solid $black10",
 });
 
 const JumpItem = styled("li", {
@@ -25,10 +26,10 @@ const JumpItem = styled("li", {
     borderTopColor: "$black20",
     borderTopStyle: "solid",
     cursor: "pointer",
+  },
 
-    "&:hover": {
-      background: "$black10",
-    },
+  "&[aria-selected='true']": {
+    background: "$purple10",
   },
 });
 
@@ -37,12 +38,12 @@ const HelperStyled = styled("div", {
   top: "$gr2",
   right: "$gr2",
   padding: "0 $gr2",
-  background: "$black50",
+  background: "$purple60",
   color: "$white",
   display: "flex",
   alignItems: "center",
 
-  "& svg": {
+  "& > svg": {
     position: "relative",
     display: "inline-block",
     padding: "0",
@@ -52,4 +53,4 @@ const HelperStyled = styled("div", {
   },
 });
 
-export { HelperStyled, JumpItem, SearchJumpToStyled };
+export { HelperStyled, JumpItem, JumpToListStyled };

--- a/components/Search/JumpTo.tsx
+++ b/components/Search/JumpTo.tsx
@@ -1,75 +1,113 @@
-import {
-  HelperStyled,
-  JumpItem,
-  SearchJumpToStyled,
-} from "@/components/Search/JumpTo.styled";
-import { useEffect, useState } from "react";
-import { IconReturnDownBack } from "@/components/Shared/SVG/Icons";
-import Link from "next/link";
-import { getCollection } from "@/lib/collection-helpers";
-import { useRouter } from "next/router";
+import { Input, SearchStyled } from "./Search.styled";
+import React, {
+  ChangeEvent,
+  FocusEvent,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { IconSearch } from "@/components/Shared/SVG/Icons";
+import SearchJumpToList from "@/components/Search/JumpToList";
+import Swiper from "swiper";
 
-const SearchJumpTo = ({ searchValue }: { searchValue: string }) => {
-  const router = useRouter();
-  const [collectionTitle, setCollectionTitle] = useState<string>("");
+interface SearchProps {
+  isSearchActive: (value: boolean) => void;
+}
+
+const SearchJumpTo: React.FC<SearchProps> = ({ isSearchActive }) => {
+  const search = useRef<HTMLInputElement>(null);
+  const formRef = useRef<HTMLFormElement>(null);
+  const [searchValue, setSearchValue] = useState<string>("");
+  const [searchFocus, setSearchFocus] = useState<boolean>(false);
+  const [isLoaded, setIsLoaded] = useState<boolean>(false);
+  const [showJumpTo, setShowJumpTo] = useState<boolean>(false);
+
+  React.useEffect(() => {
+    // @ts-ignore
+    const handleMouseDown = (e) => {
+      if (
+        showJumpTo &&
+        formRef.current &&
+        !formRef.current.contains(e.target)
+      ) {
+        setShowJumpTo(false);
+      }
+    };
+
+    const handleSwiperTouch = () => {
+      if (showJumpTo) {
+        setShowJumpTo(false);
+      }
+    };
+
+    window.addEventListener("mousedown", handleMouseDown);
+
+    /**
+     * SwiperJS swallows mouse/touch events on window, so if a Swiper
+     * is on the same page as this component, grab an instance of Swiper
+     * and specifically listen for touch events. This seems to be the only
+     * way to grab mousedown events on the Swiper hero.
+     */
+    interface SwiperEl extends Element {
+      swiper?: Swiper;
+    }
+    const swiperEl: SwiperEl | null = document?.querySelector(".swiper");
+    const swiper = swiperEl ? swiperEl.swiper : undefined;
+
+    if (swiper) {
+      swiper.on("touchStart", handleSwiperTouch);
+    }
+
+    return () => {
+      window.removeEventListener("mousedown", handleMouseDown);
+      if (swiper) {
+        swiper?.off("touchStart", handleSwiperTouch);
+      }
+    };
+  }, [showJumpTo]);
+
+  const handleSearchFocus = (e: FocusEvent) => {
+    if (e.type === "focus") {
+      setSearchFocus(true);
+      setShowJumpTo(Boolean(searchValue));
+    } else {
+      setSearchFocus(false);
+    }
+  };
+
+  const handleSearchChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    setSearchValue(value);
+    setShowJumpTo(Boolean(value));
+  };
 
   useEffect(() => {
-    if (!router?.query?.id) return;
+    setIsLoaded(true);
+  }, []);
 
-    async function getCollectionTitle() {
-      try {
-        const data = await getCollection(router.query.id as string);
-        setCollectionTitle(data?.title || "");
-      } catch (err) {
-        console.error(
-          "Error getting Collection title in JumpTo component",
-          err
-        );
-      }
-    }
-    getCollectionTitle();
-  }, [router.query.id]);
+  useEffect(() => {
+    !searchFocus && !searchValue ? isSearchActive(false) : isSearchActive(true);
+  }, [searchFocus, searchValue, isSearchActive]);
 
   return (
-    <SearchJumpToStyled data-testid="jump-to-wrapper" role="listbox">
-      <JumpItem role="option">
-        <Link
-          href={{
-            pathname: "/search",
-            query: {
-              collection: collectionTitle,
-              q: searchValue,
-            },
-          }}
-        >
-          <a tabIndex={0} data-testid="helper-anchor-collection">
-            {searchValue} <Helper label="In this Collection" />
-          </a>
-        </Link>
-      </JumpItem>
-      <JumpItem role="option">
-        <Link
-          href={{
-            pathname: "/search",
-            query: {
-              q: searchValue,
-            },
-          }}
-        >
-          <a tabIndex={0} data-testid="helper-anchor-all">
-            {searchValue} <Helper label="All Digital Collections" />
-          </a>
-        </Link>
-      </JumpItem>
-    </SearchJumpToStyled>
-  );
-};
-
-const Helper: React.FC<{ label: string }> = ({ label }) => {
-  return (
-    <HelperStyled data-testid="helper">
-      <span>{label}</span> <IconReturnDownBack />
-    </HelperStyled>
+    <SearchStyled ref={formRef} data-testid="search-jump-to-form">
+      <Input
+        placeholder="Search by keyword or phrase, ex: Berkeley Music Festival"
+        onChange={handleSearchChange}
+        onFocus={handleSearchFocus}
+        onBlur={handleSearchFocus}
+        ref={search}
+        name="search"
+        role="search"
+      />
+      {isLoaded && <IconSearch />}
+      {showJumpTo && (
+        <SearchJumpToList
+          searchValue={searchValue}
+          setShowJumpTo={setShowJumpTo}
+        />
+      )}
+    </SearchStyled>
   );
 };
 

--- a/components/Search/JumpToList.test.tsx
+++ b/components/Search/JumpToList.test.tsx
@@ -1,0 +1,96 @@
+import SearchJumpToList from "@/components/Search/JumpToList";
+import { act } from "@testing-library/react";
+import { render } from "@/test-utils";
+import { screen } from "@testing-library/react";
+import singletonRouter from "next/router";
+import userEvent from "@testing-library/user-event";
+
+jest.mock("next/router", () => require("next-router-mock"));
+// This is needed for mocking 'next/link':
+jest.mock("next/dist/client/router", () => require("next-router-mock"));
+
+/** Mock getCollection() to return a Collection title for tests */
+jest.mock("../../lib/collection-helpers", () => ({
+  getCollection: jest.fn().mockResolvedValue({
+    title: "Best Collection Ever",
+  }),
+}));
+
+const mockSetShowJumpTo = jest.fn();
+
+describe("SearchJumpToList component", () => {
+  it("renders search value in list items", () => {
+    render(
+      <SearchJumpToList searchValue="Dylan" setShowJumpTo={mockSetShowJumpTo} />
+    );
+    expect(screen.getByTestId("jump-to-wrapper"));
+    expect(screen.getAllByText("Dylan")).toHaveLength(2);
+  });
+
+  it("renders Helper components in each JumpTo item", () => {
+    render(
+      <SearchJumpToList searchValue="foo" setShowJumpTo={mockSetShowJumpTo} />
+    );
+    const helpers = screen.getAllByTestId("helper");
+    expect(helpers[0]).toHaveTextContent(/in this collection/i);
+    expect(helpers[1]).toHaveTextContent(/all digital collections/i);
+  });
+
+  it("renders route query params in JumpTo items", async () => {
+    render(
+      <SearchJumpToList searchValue="foo" setShowJumpTo={mockSetShowJumpTo} />
+    );
+
+    await act(async () => {
+      await singletonRouter.push({
+        pathname: "/collections/[id]",
+        query: { id: "abc123" },
+      });
+    });
+
+    expect(
+      await screen.findByTestId("helper-anchor-collection")
+    ).toHaveAttribute("href", `/search?collection=Best+Collection+Ever&q=foo`);
+
+    expect(screen.getByTestId("helper-anchor-all")).toHaveAttribute(
+      "href",
+      "/search?q=foo"
+    );
+  });
+
+  it("selects items correctly on arrow key presses", async () => {
+    const user = userEvent.setup();
+    render(
+      <SearchJumpToList searchValue="foo" setShowJumpTo={mockSetShowJumpTo} />
+    );
+    const listItems = await screen.findAllByRole("option");
+
+    expect(listItems[0]).toHaveAttribute("aria-selected", "true");
+
+    await user.keyboard("{ArrowDown}");
+
+    expect(listItems[0]).toHaveAttribute("aria-selected", "false");
+    expect(listItems[1]).toHaveAttribute("aria-selected", "true");
+
+    // Can't select any other lower options (only 2 exist)
+    await user.keyboard("{ArrowDown}");
+
+    expect(listItems[0]).toHaveAttribute("aria-selected", "false");
+    expect(listItems[1]).toHaveAttribute("aria-selected", "true");
+
+    // Go back up (even more than allowed)
+    await user.keyboard("{ArrowUp}{ArrowUp}{ArrowUp}");
+    expect(listItems[0]).toHaveAttribute("aria-selected", "true");
+    expect(listItems[1]).toHaveAttribute("aria-selected", "false");
+  });
+
+  it("handles the Escape key press", async () => {
+    const user = userEvent.setup();
+    render(
+      <SearchJumpToList searchValue="foo" setShowJumpTo={mockSetShowJumpTo} />
+    );
+
+    await user.keyboard("{Escape}");
+    expect(mockSetShowJumpTo).toHaveBeenCalled();
+  });
+});

--- a/components/Search/JumpToList.tsx
+++ b/components/Search/JumpToList.tsx
@@ -1,0 +1,131 @@
+import { Dispatch, KeyboardEvent, useEffect, useState } from "react";
+import {
+  HelperStyled,
+  JumpItem,
+  JumpToListStyled,
+} from "@/components/Search/JumpTo.styled";
+import { IconReturnDownBack } from "@/components/Shared/SVG/Icons";
+import Link from "next/link";
+import { getCollection } from "@/lib/collection-helpers";
+import useEventListener from "@/hooks/useEventListener";
+import { useRouter } from "next/router";
+
+interface SearchJumpToListProps {
+  searchValue: string;
+  setShowJumpTo: Dispatch<React.SetStateAction<boolean>>;
+}
+
+const SearchJumpToList: React.FC<SearchJumpToListProps> = ({
+  searchValue,
+  setShowJumpTo,
+}) => {
+  const router = useRouter();
+  const [collectionTitle, setCollectionTitle] = useState<string>("");
+  const [activeIndex, setActiveIndex] = useState<number>(0);
+
+  const jumpToItems = [
+    {
+      dataTestId: "helper-anchor-collection",
+      helperLabel: "In this Collection",
+      pathName: "/search",
+      query: {
+        collection: collectionTitle,
+        q: searchValue,
+      },
+    },
+    {
+      dataTestId: "helper-anchor-all",
+      helperLabel: "All Digital Collections",
+      pathName: "/search",
+      query: {
+        q: searchValue,
+      },
+    },
+  ];
+
+  const handleItemHover = (index: number): void => {
+    setActiveIndex(index);
+  };
+
+  const handleKeyEvent = (e: KeyboardEvent) => {
+    switch (e.key) {
+      case "ArrowUp":
+        if (activeIndex > 0) {
+          setActiveIndex(activeIndex - 1);
+        }
+        break;
+      case "ArrowDown":
+        if (activeIndex < jumpToItems.length - 1) {
+          setActiveIndex(activeIndex + 1);
+        }
+        break;
+      case "Enter":
+        e.preventDefault();
+        const activeItem = jumpToItems[activeIndex];
+        router.push({
+          pathname: activeItem.pathName,
+          query: activeItem.query,
+        });
+        break;
+      case "Escape":
+        setShowJumpTo(false);
+        break;
+      default:
+        break;
+    }
+  };
+
+  // @ts-ignore
+  useEventListener("keydown", handleKeyEvent);
+
+  useEffect(() => {
+    if (!router?.query?.id) return;
+
+    async function getCollectionTitle() {
+      try {
+        const data = await getCollection(router.query.id as string);
+        setCollectionTitle(data?.title || "");
+      } catch (err) {
+        console.error(
+          "Error getting Collection title in JumpTo component",
+          err
+        );
+      }
+    }
+    getCollectionTitle();
+  }, [router.query.id]);
+
+  return (
+    <JumpToListStyled data-testid="jump-to-wrapper" role="listbox">
+      {jumpToItems.map((item, index) => (
+        <JumpItem
+          key={item.dataTestId}
+          role="option"
+          aria-selected={index === activeIndex}
+          onMouseEnter={() => handleItemHover(index)}
+        >
+          <Link
+            href={{
+              pathname: item.pathName,
+              query: item.query,
+            }}
+          >
+            <a tabIndex={0} data-testid={item.dataTestId}>
+              {searchValue} <Helper label={item.helperLabel} />
+            </a>
+          </Link>
+        </JumpItem>
+      ))}
+    </JumpToListStyled>
+  );
+};
+
+const Helper: React.FC<{ label: string }> = ({ label }) => {
+  return (
+    <HelperStyled data-testid="helper">
+      <span>{label}</span> <IconReturnDownBack />
+    </HelperStyled>
+  );
+};
+
+export default SearchJumpToList;

--- a/components/Search/Search.test.tsx
+++ b/components/Search/Search.test.tsx
@@ -13,7 +13,7 @@ describe("Search component", () => {
     expect(wrapper).toBeInTheDocument();
   });
 
-  it("does not render the SearchJumpTo component on Search page", async () => {
+  it("accepts text input as a form value", async () => {
     const user = userEvent.setup();
     render(<Search isSearchActive={mockIsSearchActive} />);
     const form = screen.getByTestId("search-ui-component");
@@ -21,36 +21,5 @@ describe("Search component", () => {
     await user.type(screen.getByRole("search"), "foo");
 
     expect(form).toHaveFormValues({ search: "foo" });
-    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
-  });
-
-  it("conditionally renders the SearchJumpTo component", async () => {
-    const user = userEvent.setup();
-    render(
-      <div data-testid="page">
-        <span>Outside search form</span>
-        <Search isSearchActive={mockIsSearchActive} jumpTo="collection" />
-      </div>
-    );
-    const form = screen.getByTestId("search-ui-component");
-
-    await user.type(screen.getByRole("search"), "foo");
-
-    // JumpTo should be visible
-    expect(form).toHaveFormValues({ search: "foo" });
-    expect(screen.getByRole("listbox"));
-
-    // Click outside Search form, it should close JumpTo
-    await user.click(screen.getByText("Outside search form"));
-
-    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
-
-    // Type back in main search input, it should re-open JumpTo
-    await user.type(screen.getByRole("search"), "baz");
-
-    expect(form).toHaveFormValues({
-      search: "foobaz",
-    });
-    expect(screen.getByRole("listbox"));
   });
 });

--- a/components/Search/Search.tsx
+++ b/components/Search/Search.tsx
@@ -1,5 +1,6 @@
 import { Button, Clear, Input, SearchStyled } from "./Search.styled";
-import {
+import { IconClear, IconSearch } from "@/components/Shared/SVG/Icons";
+import React, {
   ChangeEvent,
   FocusEvent,
   SyntheticEvent,
@@ -7,47 +8,23 @@ import {
   useRef,
   useState,
 } from "react";
-import { IconClear, IconSearch } from "../Shared/SVG/Icons";
-import SearchJumpTo from "@/components/Search/JumpTo";
-import useEventListener from "@/hooks/useEventListener";
 import { useRouter } from "next/router";
-import { useSearchState } from "@/context/search-context";
 
 interface SearchProps {
   isSearchActive: (value: boolean) => void;
-  jumpTo?: "collection"; // In the future maybe we extend a jumpTo enum? ie. "collection" | "work" | ?
 }
 
-const Search: React.FC<SearchProps> = ({ isSearchActive, jumpTo }) => {
+const Search: React.FC<SearchProps> = ({ isSearchActive }) => {
   const router = useRouter();
-  const { searchDispatch } = useSearchState();
   const search = useRef<HTMLInputElement>(null);
   const formRef = useRef<HTMLFormElement>(null);
   const [searchValue, setSearchValue] = useState<string>("");
   const [searchFocus, setSearchFocus] = useState<boolean>(false);
   const [isLoaded, setIsLoaded] = useState<boolean>(false);
-  const [showJumpTo, setShowJumpTo] = useState<boolean>(false);
-
-  // @ts-ignore
-  const handleMouseDown = (e) => {
-    if (
-      jumpTo &&
-      showJumpTo &&
-      formRef.current &&
-      !formRef.current.contains(e.target)
-    ) {
-      if (jumpTo) setShowJumpTo(false);
-    }
-  };
-
-  useEventListener("mousedown", handleMouseDown);
 
   const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
     e.preventDefault();
-    searchDispatch({
-      q: searchValue,
-      type: "updateSearch",
-    });
+
     router.push({
       pathname: "/search",
       query: {
@@ -57,24 +34,18 @@ const Search: React.FC<SearchProps> = ({ isSearchActive, jumpTo }) => {
   };
 
   const handleSearchFocus = (e: FocusEvent) => {
-    if (e.type === "focus") {
-      setSearchFocus(true);
-      setShowJumpTo(Boolean(jumpTo && searchValue));
-    } else {
-      setSearchFocus(false);
-    }
+    setSearchFocus(e.type === "focus");
   };
 
   const handleSearchChange = (e: ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value;
     setSearchValue(value);
-    setShowJumpTo(Boolean(value && jumpTo));
   };
 
   const clearSearchResults = () => {
-    router.push(`/search`);
     setSearchValue("");
     if (search.current) search.current.value = "";
+    router.push("/search");
   };
 
   useEffect(() => {
@@ -115,7 +86,6 @@ const Search: React.FC<SearchProps> = ({ isSearchActive, jumpTo }) => {
       )}
       <Button type="submit">Search</Button>
       {isLoaded && <IconSearch />}
-      {jumpTo && showJumpTo && <SearchJumpTo searchValue={searchValue} />}
     </SearchStyled>
   );
 };

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -144,7 +144,7 @@ export async function getStaticProps() {
   });
 
   const openGraphData = {
-    "og:url": `${PRODUCTION_URL}/contact`,
+    "og:url": `${PRODUCTION_URL}/search`,
   };
 
   return {


### PR DESCRIPTION
## What does this do?
- Fixes some buggy behavior in the Search Within Collections feature (layout, not closing properly, etc)
- Introduces `keydown` mouse event handling (Arrow up, Arrow down, Enter, Escape)
- Breaks the `SearchJumpTo` component out of `Search` to be its own independent component

![image](https://user-images.githubusercontent.com/3020266/208767489-86c4a674-c4c8-42d7-ad75-6b3285f8bd78.png)


## How to test
- Search within a Collection, experiment and try to break it.