### PR TITLE
Update link to Collection works from Collection page

### DIFF
--- a/lib/iiif/collection-helpers.ts
+++ b/lib/iiif/collection-helpers.ts
@@ -89,7 +89,7 @@ export const getHeroCollection = (collection: CollectionShape) => {
     return seeAlso;
   };
 
-  const searchUrl = `${DC_URL}/search?q=${id}`;
+  const searchUrl = `${DC_URL}/search?collection=${title}`;
 
   return {
     "@context": "http://iiif.io/api/presentation/3/context.json",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3335,9 +3335,9 @@
       "dev": true
     },
     "node_modules/@types/prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ri0UmynRRvZiiUJdiz38MmIblKK+oH30MztdBVR95dv/Ubw6neWSb8u1XpRb72L4qsZOhz+L+z9JD40SJmfWow==",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.2.tgz",
+      "integrity": "sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg==",
       "dev": true
     },
     "node_modules/@types/prop-types": {
@@ -4414,9 +4414,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001439",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001439.tgz",
-      "integrity": "sha512-1MgUzEkoMO6gKfXflStpYgZDlFM7M/ck/bgfVCACO5vnAf0fXoNVHdWtqGU+MYca+4bL9Z5bpOVmR33cWW9G2A==",
+      "version": "1.0.30001441",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001441.tgz",
+      "integrity": "sha512-OyxRR4Vof59I3yGWXws6i908EtGbMzVUi3ganaZQHmydk1iwDhRnvaPG2WaR0KcqrDFKrxVZHULT396LEPhXfg==",
       "funding": [
         {
           "type": "opencollective",
@@ -6436,9 +6436,9 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "7.10.2",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-7.10.2.tgz",
-      "integrity": "sha512-2OAII9hjpMNz2Nbl2w09uKo7A0bD6xRtGnCZbPzuGGueucWgmSBLjAwzPhXwzCQWMpL3LU8jmXHjxAwIyjslxg==",
+      "version": "7.10.3",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-7.10.3.tgz",
+      "integrity": "sha512-k2ccYeZNSpPg//HTaqrU+4pRq9f9ZpaaN7rr0+Rx5zA4wZLbk547wtDzge2db1sB+1mnJ6r59P4xb+aEIi/W+w==",
       "dependencies": {
         "@motionone/dom": "^10.15.3",
         "hey-listen": "^1.0.8",
@@ -11350,9 +11350,9 @@
       "dev": true
     },
     "node_modules/sanitize-html": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.8.0.tgz",
-      "integrity": "sha512-ZsGyc6avnqgvEm3eMKrcy8xa7WM1MrGrfkGsUgQee2CU+vg3PCfNCexXwBDF/6dEPvaQ4k/QqRjnYKHL8xgNjg==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.8.1.tgz",
+      "integrity": "sha512-qK5neD0SaMxGwVv5txOYv05huC3o6ZAA4h5+7nJJgWMNFUNRjcjLO6FpwAtKzfKCZ0jrG6xTk6eVFskbvOGblg==",
       "dependencies": {
         "deepmerge": "^4.2.2",
         "escape-string-regexp": "^4.0.0",
@@ -15079,9 +15079,9 @@
       "dev": true
     },
     "@types/prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ri0UmynRRvZiiUJdiz38MmIblKK+oH30MztdBVR95dv/Ubw6neWSb8u1XpRb72L4qsZOhz+L+z9JD40SJmfWow==",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.2.tgz",
+      "integrity": "sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg==",
       "dev": true
     },
     "@types/prop-types": {
@@ -15848,9 +15848,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001439",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001439.tgz",
-      "integrity": "sha512-1MgUzEkoMO6gKfXflStpYgZDlFM7M/ck/bgfVCACO5vnAf0fXoNVHdWtqGU+MYca+4bL9Z5bpOVmR33cWW9G2A=="
+      "version": "1.0.30001441",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001441.tgz",
+      "integrity": "sha512-OyxRR4Vof59I3yGWXws6i908EtGbMzVUi3ganaZQHmydk1iwDhRnvaPG2WaR0KcqrDFKrxVZHULT396LEPhXfg=="
     },
     "caseless": {
       "version": "0.12.0",
@@ -17368,9 +17368,9 @@
       }
     },
     "framer-motion": {
-      "version": "7.10.2",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-7.10.2.tgz",
-      "integrity": "sha512-2OAII9hjpMNz2Nbl2w09uKo7A0bD6xRtGnCZbPzuGGueucWgmSBLjAwzPhXwzCQWMpL3LU8jmXHjxAwIyjslxg==",
+      "version": "7.10.3",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-7.10.3.tgz",
+      "integrity": "sha512-k2ccYeZNSpPg//HTaqrU+4pRq9f9ZpaaN7rr0+Rx5zA4wZLbk547wtDzge2db1sB+1mnJ6r59P4xb+aEIi/W+w==",
       "requires": {
         "@emotion/is-prop-valid": "^0.8.2",
         "@motionone/dom": "^10.15.3",
@@ -20915,9 +20915,9 @@
       "dev": true
     },
     "sanitize-html": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.8.0.tgz",
-      "integrity": "sha512-ZsGyc6avnqgvEm3eMKrcy8xa7WM1MrGrfkGsUgQee2CU+vg3PCfNCexXwBDF/6dEPvaQ4k/QqRjnYKHL8xgNjg==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.8.1.tgz",
+      "integrity": "sha512-qK5neD0SaMxGwVv5txOYv05huC3o6ZAA4h5+7nJJgWMNFUNRjcjLO6FpwAtKzfKCZ0jrG6xTk6eVFskbvOGblg==",
       "requires": {
         "deepmerge": "^4.2.2",
         "escape-string-regexp": "^4.0.0",


### PR DESCRIPTION
## What does this do?
Fixes the Collection page link to view Collection Works.

## How to test
Clicking this link should take you to staging (or production) Search page with the Collection facet activated.

<img width="758" alt="image" src="https://user-images.githubusercontent.com/3020266/208993182-7efd119b-fc70-4443-a434-a83026b29027.png">
