### PR TITLE
Retain metadata filters when re-submitting search values

### DIFF
--- a/components/Search/Search.tsx
+++ b/components/Search/Search.tsx
@@ -8,6 +8,7 @@ import React, {
   useRef,
   useState,
 } from "react";
+import useQueryParams from "@/hooks/useQueryParams";
 import { useRouter } from "next/router";
 
 interface SearchProps {
@@ -21,15 +22,14 @@ const Search: React.FC<SearchProps> = ({ isSearchActive }) => {
   const [searchValue, setSearchValue] = useState<string>("");
   const [searchFocus, setSearchFocus] = useState<boolean>(false);
   const [isLoaded, setIsLoaded] = useState<boolean>(false);
+  const { urlFacets } = useQueryParams();
 
   const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
     e.preventDefault();
 
     router.push({
       pathname: "/search",
-      query: {
-        q: searchValue,
-      },
+      query: { q: searchValue, ...urlFacets },
     });
   };
 
@@ -45,7 +45,10 @@ const Search: React.FC<SearchProps> = ({ isSearchActive }) => {
   const clearSearchResults = () => {
     setSearchValue("");
     if (search.current) search.current.value = "";
-    router.push("/search");
+    router.push({
+      pathname: "/search",
+      query: { ...urlFacets },
+    });
   };
 
   useEffect(() => {
@@ -84,7 +87,9 @@ const Search: React.FC<SearchProps> = ({ isSearchActive }) => {
           <IconClear />
         </Clear>
       )}
-      <Button type="submit">Search</Button>
+      <Button type="submit" data-testid="submit-button">
+        Search
+      </Button>
       {isLoaded && <IconSearch />}
     </SearchStyled>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "@iiif/presentation-3": "^2.0.5",
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.0.0",
+        "@testing-library/react-hooks": "^8.0.1",
         "@testing-library/user-event": "^14.0.4",
         "@types/node": "^18.11.18",
         "@types/openseadragon": "^3.0.4",
@@ -3148,6 +3149,36 @@
       "peerDependencies": {
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
+      }
+    },
+    "node_modules/@testing-library/react-hooks": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz",
+      "integrity": "sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "react-error-boundary": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "@types/react": "^16.9.0 || ^17.0.0",
+        "react": "^16.9.0 || ^17.0.0",
+        "react-dom": "^16.9.0 || ^17.0.0",
+        "react-test-renderer": "^16.9.0 || ^17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-test-renderer": {
+          "optional": true
+        }
       }
     },
     "node_modules/@testing-library/user-event": {
@@ -15096,6 +15127,16 @@
         "@babel/runtime": "^7.12.5",
         "@testing-library/dom": "^8.5.0",
         "@types/react-dom": "^18.0.0"
+      }
+    },
+    "@testing-library/react-hooks": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz",
+      "integrity": "sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "react-error-boundary": "^3.1.0"
       }
     },
     "@testing-library/user-event": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@iiif/presentation-3": "^2.0.5",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.0.0",
+    "@testing-library/react-hooks": "^8.0.1",
     "@testing-library/user-event": "^14.0.4",
     "@types/node": "^18.11.18",
     "@types/openseadragon": "^3.0.4",


### PR DESCRIPTION
## What does this do?
Changes user search behavior slightly, so that metadata filters are retained when updating a search query via `/search?q=something`.  Previously the filters were wiped away on a new search.

## How to test
1. Go to the Search page
2. Apply some Filters
3. Enter a search term
4. Verify that the filters are retained