### PR TITLE
Update search results count to match agg counts in the Filter modal. …

### DIFF
--- a/components/Facets/Facet/GenericFacet.test.tsx
+++ b/components/Facets/Facet/GenericFacet.test.tsx
@@ -1,6 +1,10 @@
 import { render, screen } from "@/test-utils";
 import GenericFacet from "./GenericFacet";
+import mockRouter from "next-router-mock";
 import { response } from "@/mocks/use-fetch-api-response";
+
+jest.mock("next/router", () => require("next-router-mock"));
+mockRouter.setCurrentUrl("/search");
 
 jest.mock("@/hooks/useFetchApiData", () => {
   return jest.fn(() => response);

--- a/components/Facets/Facet/Options.tsx
+++ b/components/Facets/Facet/Options.tsx
@@ -4,7 +4,7 @@ import { Options } from "./GenericFacet.styled";
 import { SpinLoader } from "@/components/Shared/Loader.styled";
 import useFetchApiData from "@/hooks/useFetchApiData";
 import { useFilterState } from "@/context/filter-context";
-import { useSearchState } from "@/context/search-context";
+import useQueryParams from "@/hooks/useQueryParams";
 
 interface FacetOptionsProps {
   aggsFilterValue: string;
@@ -16,9 +16,7 @@ const FacetOptions: React.FC<FacetOptionsProps> = ({
   facet,
 }) => {
   const facetInstance = facet ? [facet] : undefined;
-  const {
-    searchState: { q },
-  } = useSearchState();
+  const { searchTerm } = useQueryParams();
 
   const {
     filterState: { userFacetsUnsubmitted },
@@ -27,7 +25,7 @@ const FacetOptions: React.FC<FacetOptionsProps> = ({
   const { data, error, loading } = useFetchApiData({
     activeFacets: facetInstance,
     aggsFilterValue,
-    searchTerm: q,
+    searchTerm,
     size: 0,
     urlFacets: userFacetsUnsubmitted,
   });

--- a/components/Facets/Facets.tsx
+++ b/components/Facets/Facets.tsx
@@ -7,8 +7,9 @@ import WorkType from "@/components/Facets/WorkType/WorkType";
 import { useSearchState } from "@/context/search-context";
 
 const Facets: React.FC = () => {
-  const { searchState } = useSearchState();
-  const { searchFixed } = searchState;
+  const {
+    searchState: { searchFixed },
+  } = useSearchState();
 
   const facetsRef = useRef<HTMLDivElement>(null);
 

--- a/components/Facets/Filter/Filter.tsx
+++ b/components/Facets/Filter/Filter.tsx
@@ -12,14 +12,11 @@ import FilterModal from "@/components/Facets/Filter/Modal";
 import Icon from "@/components/Shared/Icon";
 import { IconFilter } from "@/components/Shared/SVG/Icons";
 import useQueryParams from "@/hooks/useQueryParams";
-import { useSearchState } from "@/context/search-context";
 
 const DialogWrapper: React.FC = () => {
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const { filterDispatch } = useFilterState();
-  const { searchState } = useSearchState();
-  const { q } = searchState;
-  const { urlFacets } = useQueryParams();
+  const { searchTerm, urlFacets } = useQueryParams();
 
   const handleDialogChange = () => {
     /**
@@ -49,7 +46,7 @@ const DialogWrapper: React.FC = () => {
       <Dialog.Portal>
         <DialogOverlay />
         <FilterContent data-testid="modal-content">
-          <FilterModal q={q} setIsModalOpen={setIsModalOpen} />
+          <FilterModal q={searchTerm} setIsModalOpen={setIsModalOpen} />
         </FilterContent>
       </Dialog.Portal>
     </Dialog.Root>

--- a/components/Facets/Filter/GroupList.test.tsx
+++ b/components/Facets/Filter/GroupList.test.tsx
@@ -2,7 +2,11 @@ import { render, screen, within } from "@/test-utils";
 import { FACETS } from "@/lib/constants/facets-model";
 import FacetsGroupList from "./GroupList";
 import { FilterProvider } from "@/context/filter-context";
+import mockRouter from "next-router-mock";
 import userEvent from "@testing-library/user-event";
+
+jest.mock("next/router", () => require("next-router-mock"));
+mockRouter.setCurrentUrl("/search");
 
 jest.mock("@/hooks/useFetchApiData", () => {
   return jest.fn(() => ({

--- a/components/Header/Primary.tsx
+++ b/components/Header/Primary.tsx
@@ -16,8 +16,10 @@ const HeaderPrimary: React.FC = () => {
 
   const [searchActive, setSearchActive] = useState<boolean>(false);
 
-  const { searchDispatch, searchState } = useSearchState();
-  const { searchFixed } = searchState;
+  const {
+    searchDispatch,
+    searchState: { searchFixed },
+  } = useSearchState();
 
   const primaryRef = useRef<HTMLDivElement>(null);
   const scrollPosition = useElementPosition(primaryRef);

--- a/context/search-context.tsx
+++ b/context/search-context.tsx
@@ -19,7 +19,6 @@ type SearchProviderProps = {
 
 const defaultState: SearchContextStore = {
   aggregations: {},
-  q: "",
   searchFixed: false,
 };
 

--- a/hooks/useQueryParams.test.ts
+++ b/hooks/useQueryParams.test.ts
@@ -1,0 +1,16 @@
+import mockRouter from "next-router-mock";
+import { renderHook } from "@testing-library/react";
+import useQueryParams from "./useQueryParams";
+
+jest.mock("next/router", () => require("next-router-mock"));
+
+mockRouter.setCurrentUrl("/search?q=foo&subject=baz&genre=Film");
+
+it("should return proper query param values", () => {
+  const { result } = renderHook(() => useQueryParams());
+  expect(result.current.searchTerm).toEqual("foo");
+  expect(result.current.urlFacets).toMatchObject({
+    genre: ["Film"],
+    subject: ["baz"],
+  });
+});

--- a/hooks/useQueryParams.ts
+++ b/hooks/useQueryParams.ts
@@ -4,13 +4,19 @@ import { parseUrlFacets } from "@/lib/utils/facet-helpers";
 import { useRouter } from "next/router";
 
 export default function useQueryParams() {
-  const router = useRouter();
+  const { isReady, query } = useRouter();
   const [urlFacets, setUrlFacets] = React.useState<UrlFacets>({});
+  const [searchTerm, setSearchTerm] = React.useState<string>("");
 
   React.useEffect(() => {
-    const obj = parseUrlFacets(router.query);
-    setUrlFacets(obj);
-  }, [router.query]);
+    if (!isReady) return;
 
-  return { urlFacets };
+    const obj = parseUrlFacets(query);
+    const q = (query.q ? query.q : "") as string;
+
+    setUrlFacets(obj);
+    setSearchTerm(q);
+  }, [isReady, query]);
+
+  return { searchTerm, urlFacets };
 }

--- a/types/context/search-context.ts
+++ b/types/context/search-context.ts
@@ -2,7 +2,6 @@ import { ApiResponseAggregation } from "@/types/api/response";
 
 export interface SearchContextStore {
   aggregations?: ApiResponseAggregation;
-  q: string;
   searchFixed: boolean;
 }
 


### PR DESCRIPTION
## What does this do?
Primarily, this PR fixes a bug where the Search results count wasn't matching the metadata value counts in the Filter modal.

![image](https://user-images.githubusercontent.com/3020266/210441010-c46344e5-2aa6-4fad-9bcb-dd115dc16b17.png)

In addition the PR also does the following:
- Enhances the `useQueryParams` custom hook to return the search term (`q`) value in addition to `userFacets`
- Removes any reliance on `q` value from `context/search-context.tsx` (original source of this Issue's bug)

## How to test
1. Go to the Search page
2. Open the Filter modal and select any facet value checkbox, noticing the results count next to facet value.
3. Apply the facet, then notice the count in Search results and it should match