### PR TITLE
Clean up collection card on a Work.

### DIFF
--- a/components/Figure/Figure.styled.ts
+++ b/components/Figure/Figure.styled.ts
@@ -102,13 +102,15 @@ const FigureStyled = styled("figure", {
   variants: {
     isPromoted: {
       true: {
+        paddingBottom: "$gr3",
+
         [`& ${FigureTitle}`]: {
           fontSize: "$5",
-          fontFamily: "$northwesternDisplayBold",
+          fontFamily: "$northwesternDisplayBook",
         },
 
         [`& ${FigureSupplementalInfo}`]: {
-          fontSize: "$3",
+          fontSize: "$2",
         },
       },
     },

--- a/components/Shared/Card.styled.ts
+++ b/components/Shared/Card.styled.ts
@@ -14,10 +14,14 @@ const LinkedAnchor = styled("a", {
 
 const CardStyled = styled("div", {
   p: {
-    margin: "0 0 $gr4",
+    margin: "0 0 $gr3",
     fontFamily: "$northwesternSansRegular",
     fontSize: "$gr3",
     lineHeight: "1.47em",
+
+    a: {
+      cursor: "pointer",
+    },
   },
 });
 

--- a/components/Shared/Card.tsx
+++ b/components/Shared/Card.tsx
@@ -3,9 +3,10 @@ import Figure from "@/components/Figure/Figure";
 import Link from "next/link";
 import { LinkStyled } from "@/components/Shared/LinkStyled";
 import React from "react";
+import ReadMore from "./ReadMore";
 
 export interface CardProps {
-  description?: string;
+  description?: string | null;
   href?: string;
   imageUrl: string;
   supplementalInfo?: string;
@@ -38,7 +39,11 @@ const Card: React.FC<CardProps> = ({
         <Figure data={data} isPromoted />
       )}
 
-      {description && <p data-testid="card-description">{description}</p>}
+      {description && (
+        <p data-testid="card-description">
+          <ReadMore text={description} words={30} />
+        </p>
+      )}
     </CardStyled>
   );
 };

--- a/components/Work/TopInfo.tsx
+++ b/components/Work/TopInfo.tsx
@@ -126,7 +126,7 @@ const WorkTopInfo: React.FC<TopInfoProps> = ({
             {/* <Heading as="h2">Part of {work.collection?.title}</Heading> */}
             <Card
               title={work.collection?.title}
-              description="Cras mollis lorem sed nisi consequat aliquet. Mauris fringilla pretium nibh, ut laoreet mi luctus nec. Integer luctus urna sed nisi rhoncus mollis."
+              description={work.collection?.description}
               href={`/collections/${work.collection?.id}`}
               imageUrl={`${process.env.NEXT_PUBLIC_DCAPI_ENDPOINT}/collections/${work.collection?.id}/thumbnail?aspect=square `}
               supplementalInfo={buildWorkCountsText()}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7376450/210604460-30becefd-47b8-4586-a3e8-bcd3d59560da.png)

## What does this do?

This cleans up the Collection card on a work.

- Renders a real description from `work.collection.description`.
- Adds a read more component to limit long descriptions.
- Tidy up card styling.

## How should we review?

Visit any work. Should be pretty consistent -- though some work/collections might have very short descriptions.