### PR TITLE
Consolidate swiper/css imports.

### DIFF
--- a/components/Hero/Hero.tsx
+++ b/components/Hero/Hero.tsx
@@ -1,7 +1,3 @@
-import "swiper/css";
-import "swiper/css/effect-fade";
-import "swiper/css/navigation";
-import "swiper/css/pagination";
 import { Autoplay, EffectFade, Keyboard, Navigation, Pagination } from "swiper";
 import { HeroActions, HeroStyled } from "@/components/Hero/Hero.styled";
 import { Label, Summary, Thumbnail } from "@samvera/nectar-iiif";

--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -1,3 +1,8 @@
+import "swiper/css";
+import "swiper/css/effect-fade";
+import "swiper/css/lazy";
+import "swiper/css/navigation";
+import "swiper/css/pagination";
 import Footer from "@/components/Footer/Footer";
 import Head from "next/head";
 import Header from "@/components/Header/Header";


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/7376450/210846254-00bd4066-9bf6-4258-95c2-0a5ee0fba68a.png)


## What does this do?
This fixes the orientation issue of Bloom sliders by importing the `swiper/css` files in a common location of **layout.tsx**. The orientation issue was caused be a reworking of the Hero component to not be embedded in the Header. When this changed, the `swiper/css` files were no longer available on every page as they had been. Note that the orientation issue needs to be reviewed in a built/deployed Next environment and isn't an issue in dev.

See:
https://preview-3440-bloom-orientation.d1g4r4p7fos4jz.amplifyapp.com/items/8e2d6bc5-3f00-45d1-880b-a458cddf0c1c

## Thoughts?
 I did attempt to also import the necessary CSS files in the `components/BloomWrapper.tsx` file, however jest testing on RelatedItems and SharedLinks components were not fairing well with these CSS files being imported here. Thoughts on this?