### PR TITLE
Address Bloom zIndexing and control colors.

### DIFF
--- a/components/BloomWrapper.tsx
+++ b/components/BloomWrapper.tsx
@@ -1,9 +1,21 @@
 import dynamic from "next/dynamic";
+import { styled } from "@/stitches.config";
 
-export const BloomIIIFWrapper: React.ComponentType<{
+const StyledBloomIIIFWrapper = styled("div", {
+  position: "relative",
+  zIndex: "0",
+});
+
+const BloomIIIF: React.ComponentType<{
   collectionId: string;
 }> = dynamic(() => import("@samvera/bloom-iiif"), {
   ssr: false,
 });
+
+const BloomIIIFWrapper = ({ collectionId }: { collectionId: string }) => (
+  <StyledBloomIIIFWrapper>
+    <BloomIIIF collectionId={collectionId} />
+  </StyledBloomIIIFWrapper>
+);
 
 export default BloomIIIFWrapper;

--- a/components/Collection/Tabs/Organization.tsx
+++ b/components/Collection/Tabs/Organization.tsx
@@ -1,4 +1,4 @@
-import { BloomIIIFWrapper } from "@/components/BloomWrapper";
+import BloomIIIFWrapper from "@/components/BloomWrapper";
 import ExpandableList from "@/components/Shared/ExpandableList";
 import { GenericAggsReturn } from "@/lib/collection-helpers";
 import Heading from "@/components/Heading/Heading";

--- a/styles/colors.ts
+++ b/styles/colors.ts
@@ -37,9 +37,19 @@ const basic = {
   gray6: "#f0f0f0",
 };
 
+/**
+ * influence bloom-iiif color tokens
+ */
+const bloom = {
+  accent: `${purple.purple} !important`,
+  accentAlt: `${purple.purple60} !important`,
+  secondary: `${basic.white} !important`,
+};
+
 const colors = {
   ...basic,
   ...black,
+  ...bloom,
   ...purple,
   ...secondary,
   ...slate, // work this out and replace with brand colors.


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/7376450/211059927-729dc0a0-a9e5-496b-a3ae-5400025c2697.png)


## What does this do?

This work address a lingering zIndex issue on Bloom components by wrapping Bloom with a component having a set `zIndex` of `0`. I also addressed the colors on Bloom controls.