### PR TITLE
Hide last-modified manifest metadata item.

### DIFF
--- a/components/Work/Metadata.styled.ts
+++ b/components/Work/Metadata.styled.ts
@@ -1,3 +1,4 @@
+import { Metadata } from "@samvera/nectar-iiif";
 import { linkStyling } from "@/components/Shared/LinkStyled";
 import { styled } from "@/stitches.config";
 
@@ -10,4 +11,10 @@ const LinkItemStyled = styled("div", {
   },
 });
 
-export { LinkItemStyled };
+const MetadataStyled = styled(Metadata, {
+  "[data-label=last-modified]": {
+    display: "none",
+  },
+});
+
+export { LinkItemStyled, MetadataStyled };

--- a/components/Work/Metadata.tsx
+++ b/components/Work/Metadata.tsx
@@ -1,8 +1,10 @@
+import {
+  LinkItemStyled,
+  MetadataStyled,
+} from "@/components/Work/Metadata.styled";
 import { DC_URL } from "@/lib/constants/endpoints";
 import { FACETS_WORK_LINK } from "@/lib/constants/works";
 import Link from "next/link";
-import { LinkItemStyled } from "@/components/Work/Metadata.styled";
-import { Metadata } from "@samvera/nectar-iiif";
 import { MetadataItem } from "@iiif/presentation-3";
 
 interface WorkMetadataProps {
@@ -38,7 +40,7 @@ const WorkMetadata: React.FC<WorkMetadataProps> = ({ metadata }) => {
   });
 
   return (
-    <Metadata
+    <MetadataStyled
       customValueContent={customValues}
       customValueDelimiter=""
       data-testid="metadata"

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@radix-ui/react-tabs": "^1.0.1",
         "@samvera/bloom-iiif": "^0.3.6",
         "@samvera/clover-iiif": "^1.12.6",
-        "@samvera/nectar-iiif": "^0.0.19",
+        "@samvera/nectar-iiif": "^0.0.20",
         "@stitches/react": "^1.2.6",
         "axios": "^1.2.2",
         "framer-motion": "^8.1.4",
@@ -2942,9 +2942,9 @@
       }
     },
     "node_modules/@samvera/nectar-iiif": {
-      "version": "0.0.19",
-      "resolved": "https://registry.npmjs.org/@samvera/nectar-iiif/-/nectar-iiif-0.0.19.tgz",
-      "integrity": "sha512-G4DBZ/rfWgcpag1vohkII6MbGZfVolOHbCeR3L9DkgT+88ijn3v5RdUUzD6BVH9DMKb13SrniAbwSI5BgT2hVQ==",
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@samvera/nectar-iiif/-/nectar-iiif-0.0.20.tgz",
+      "integrity": "sha512-hoZW/k49jE087KXT25MX9uuz97j1+GtT2UYPOVuWytF6+Al3SyWqiA1NUoO/5Ft/E5G4XtnvgrHZusJvKoLnzw==",
       "dependencies": {
         "@stitches/react": "^1.2.8",
         "hls.js": "^1.2.8",
@@ -15088,9 +15088,9 @@
       }
     },
     "@samvera/nectar-iiif": {
-      "version": "0.0.19",
-      "resolved": "https://registry.npmjs.org/@samvera/nectar-iiif/-/nectar-iiif-0.0.19.tgz",
-      "integrity": "sha512-G4DBZ/rfWgcpag1vohkII6MbGZfVolOHbCeR3L9DkgT+88ijn3v5RdUUzD6BVH9DMKb13SrniAbwSI5BgT2hVQ==",
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@samvera/nectar-iiif/-/nectar-iiif-0.0.20.tgz",
+      "integrity": "sha512-hoZW/k49jE087KXT25MX9uuz97j1+GtT2UYPOVuWytF6+Al3SyWqiA1NUoO/5Ft/E5G4XtnvgrHZusJvKoLnzw==",
       "requires": {
         "@stitches/react": "^1.2.8",
         "hls.js": "^1.2.8",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@radix-ui/react-tabs": "^1.0.1",
     "@samvera/bloom-iiif": "^0.3.6",
     "@samvera/clover-iiif": "^1.12.6",
-    "@samvera/nectar-iiif": "^0.0.19",
+    "@samvera/nectar-iiif": "^0.0.20",
     "@stitches/react": "^1.2.6",
     "axios": "^1.2.2",
     "framer-motion": "^8.1.4",


### PR DESCRIPTION
<img width="1654" alt="image" src="https://user-images.githubusercontent.com/7376450/211099496-8ea7745c-540b-4961-9b07-0b2ee9c7e72f.png">

## What does this do?

This simply hides the Last Modified metadata item that is carried in our IIIF Manifests by using the CSS selector rendered in the Nectar component.