### PR TITLE
Add copy mechanism for contact email.

### DIFF
--- a/components/Shared/BlockStyled.ts
+++ b/components/Shared/BlockStyled.ts
@@ -1,9 +1,14 @@
+import { StyledCopyText } from "@/components/Shared/CopyText.styled";
 import { styled } from "stitches.config";
 
 /* eslint sort-keys: 0 */
 
 const BlockStyled = styled("div", {
   marginBottom: "$gr6",
+
+  [`${StyledCopyText}`]: {
+    fontSize: "inherit",
+  },
 
   "@md": {
     marginBottom: "$gr5",

--- a/pages/contact.tsx
+++ b/pages/contact.tsx
@@ -1,5 +1,6 @@
 import { BlockStyled } from "@/components/Shared/BlockStyled";
 import Container from "@/components/Shared/Container";
+import CopyText from "@/components/Shared/CopyText";
 import Head from "next/head";
 import Heading from "@/components/Heading/Heading";
 import Layout from "components/layout";
@@ -36,15 +37,11 @@ const ContactPage: NextPage = () => {
 
             <p>
               Questions about digitization, description of items, or software
-              can be directed here.{" "}
-              <a
-                href="mailto:repository@northwestern.edu"
-                style={{
-                  unicodeBidi: "bidi-override",
-                }}
-              >
-                repository@northwestern.edu
-              </a>
+              can be directed to:{" "}
+              <CopyText
+                textPrompt="repository@northwestern.edu"
+                textToCopy="repository@northwestern.edu"
+              />
             </p>
 
             <p>


### PR DESCRIPTION
## What does this do?

This replaces the generic `mailto` anchor link of our contact email address with a Copy mechanism.
