### PR TITLE
Add Academic N and prevent flicker.

### DIFF
--- a/components/Header/Header.styled.ts
+++ b/components/Header/Header.styled.ts
@@ -62,12 +62,17 @@ const Primary = styled("div", {
 
     "> span": {
       display: "flex",
-      width: "0",
       opacity: "0",
       justifyContent: "center",
       textAlign: "center",
       alignItems: "center",
+      height: "$gr5",
       flexGrow: "0",
+      backgroundColor: "$purple",
+
+      svg: {
+        fill: "$white",
+      },
     },
   },
 
@@ -78,15 +83,24 @@ const Primary = styled("div", {
       maxWidth: "100%",
       backgroundColor: "white",
       boxShadow: "0px 3px 11px #0003",
+      transition: "$dcAll",
 
       "> span": {
         opacity: "1",
         width: "$gr5",
+
+        svg: {
+          height: "$gr3",
+        },
       },
 
       [`& ${NavStyled}`]: {
         width: "0",
         opacity: "0",
+      },
+
+      button: {
+        backgroundColor: "$purple10",
       },
 
       [`& ${SearchStyled}`]: {

--- a/components/Header/Primary.tsx
+++ b/components/Header/Primary.tsx
@@ -1,5 +1,6 @@
 import { Primary, PrimaryInner } from "@/components/Header/Header.styled";
 import { useEffect, useRef, useState } from "react";
+import { AcademicN } from "@/components/Shared/SVG/Northwestern";
 import Container from "@/components/Shared/Container";
 import Heading from "@/components/Heading/Heading";
 import Link from "next/link";
@@ -27,7 +28,7 @@ const HeaderPrimary: React.FC = () => {
   useEffect(
     () =>
       searchDispatch({
-        searchFixed: scrollPosition >= 0,
+        searchFixed: scrollPosition > 0,
         type: "updateSearchFixed",
       }),
     [searchDispatch, scrollPosition]
@@ -47,7 +48,7 @@ const HeaderPrimary: React.FC = () => {
       >
         <Container>
           <Heading as="span">
-            <strong>N</strong>
+            <AcademicN />
           </Heading>
           <PrimaryInner>
             {!isCollectionPage && (

--- a/components/Shared/SVG/Northwestern.tsx
+++ b/components/Shared/SVG/Northwestern.tsx
@@ -1,3 +1,14 @@
+const AcademicN: React.FC = () => (
+  <svg
+    id="nortwestern-academic-n"
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 293.04 282.02"
+  >
+    <title>Northwestern University</title>
+    <polygon points="186.1 2.11 186.1 22 219.48 30.38 226.07 38.65 226.07 198.03 59.61 1.03 58.74 0 9.54 0 9.54 14.89 36.8 45.49 36.8 252.21 0 262.5 0 279.93 105.46 279.93 105.46 262.39 72.81 253.76 66.06 245.44 66.06 79.2 236.42 282.02 256.05 282.02 256.05 31.43 293.04 20.24 293.04 2.11 186.1 2.11" />
+  </svg>
+);
+
 const NorthwesternWordmark: React.FC = () => (
   <svg
     version="1.1"
@@ -76,4 +87,4 @@ const NorthwesternWordmark: React.FC = () => (
   </svg>
 );
 
-export { NorthwesternWordmark };
+export { AcademicN, NorthwesternWordmark };

--- a/components/Transition.tsx
+++ b/components/Transition.tsx
@@ -1,21 +1,19 @@
 import { AnimatePresence, motion } from "framer-motion";
+import { seconds } from "@/styles/transitions";
 import { useRouter } from "next/router";
 
 const variants = {
   in: {
     opacity: 1,
     transition: {
-      delay: 0.25,
-      duration: 0.25,
+      duration: seconds,
     },
-    y: 0,
   },
   out: {
     opacity: 0,
     transition: {
-      duration: 0.25,
+      duration: seconds,
     },
-    y: 0,
   },
 };
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -27,6 +27,9 @@ function MyApp({ Component, pageProps }: MyAppProps) {
   const ogData = { ...defaultOpenGraphData, ...openGraphData };
 
   const [user, setUser] = React.useState<User | null>(null);
+  const [mounted, setMounted] = React.useState(false);
+
+  React.useEffect(() => setMounted(true), []);
 
   React.useEffect(() => {
     /* Determine if user is authenticated via cookie */
@@ -89,7 +92,7 @@ function MyApp({ Component, pageProps }: MyAppProps) {
         })(window,document,'script','dataLayer','GTM-NDJXLQW');
       `}
             </Script>
-            <Component {...pageProps} />
+            {mounted && <Component {...pageProps} />}
           </SearchProvider>
         </Transition>
       </UserContext.Provider>

--- a/styles/transitions.ts
+++ b/styles/transitions.ts
@@ -1,10 +1,11 @@
 /* eslint sort-keys: 0 */
 
-const timingFunction = `cubic-bezier(0.3, 1, 0.3, 1)`;
+export const seconds = 0.2;
+export const timingFunction = `cubic-bezier(0.3, 1, 0.3, 1)`;
 
 const transitions = {
-  dcAll: `all 200ms ${timingFunction}`,
-  dcOpacity: `opacity 200ms ${timingFunction}`,
+  dcAll: `all ${seconds}s ${timingFunction}`,
+  dcOpacity: `opacity ${seconds}s ${timingFunction}`,
 };
 
 export default transitions;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7376450/211391779-2d411c73-6892-412e-b674-ddadd78abad6.png)


## What does this do?

This adds the Academic N to the fixed header on scroll. I also addressed a flickering issue of the search bar and cleaned up transition in general which may or may not intersect w/ https://github.com/nulib/dc-nextjs/pull/135