### PR TITLE
Update Search to bypass dynamic route params

### DIFF
--- a/components/Search/Search.tsx
+++ b/components/Search/Search.tsx
@@ -8,6 +8,7 @@ import React, {
   useRef,
   useState,
 } from "react";
+import { ALL_FACETS } from "@/lib/constants/facets-model";
 import useQueryParams from "@/hooks/useQueryParams";
 import { useRouter } from "next/router";
 
@@ -26,6 +27,15 @@ const Search: React.FC<SearchProps> = ({ isSearchActive }) => {
 
   const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
     e.preventDefault();
+
+    /* Guard against searching from a page with dynamic route params */
+    const facetIds = ALL_FACETS.facets.map((facet) => facet.id);
+    const urlFacetsKeys = Object.keys(urlFacets);
+    urlFacetsKeys.forEach((key) => {
+      if (!facetIds.includes(key)) {
+        delete urlFacets[key];
+      }
+    });
 
     router.push({
       pathname: "/search",


### PR DESCRIPTION
## What does this do?
Now when searching from a Work page (which has `id` in the `router`'s `query` object from Next/Router), the `Search` component searches for and eliminates `id`, or any other value not in our Facets.   

## How to test
1. Go to a Work page
2. Search for something and notice `id` is no longer in the browser address bar