### PR TITLE
Address Bloom related errors.

### DIFF
--- a/components/BloomWrapper.tsx
+++ b/components/BloomWrapper.tsx
@@ -1,9 +1,15 @@
 import dynamic from "next/dynamic";
 import { styled } from "@/stitches.config";
 
+/* eslint sort-keys: 0 */
+
 const StyledBloomIIIFWrapper = styled("div", {
   position: "relative",
   zIndex: "0",
+
+  ".swiper-slide[data-type='collection']": {
+    display: "none",
+  },
 });
 
 const BloomIIIF: React.ComponentType<{

--- a/components/Collection/Tabs/Organization.tsx
+++ b/components/Collection/Tabs/Organization.tsx
@@ -21,11 +21,9 @@ const CollectionTabsOrganization: React.FC<CollectionTabsOrganizationProps> = ({
             const { key, doc_count } = entry;
             const summary =
               doc_count > 1 ? `${doc_count} Items` : `${doc_count}  Item`;
-            const collectionId = encodeURI(
-              `${url}/search?query=series:"${key}"
-            &collectionLabel=${key}&collectionSummary=${summary}&as=iiif`
-            );
 
+            const sanitizedKey = key.replace(/&/g, "%26");
+            const collectionId = `${url}/search?query=series:"${sanitizedKey}"&collectionLabel=${sanitizedKey}&collectionSummary=${summary}&as=iiif`;
             const value = `series-${index}`;
             const title = entry.key;
             const indicator = `${entry.doc_count} Items`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@radix-ui/react-select": "^1.0.0",
         "@radix-ui/react-switch": "^1.0.1",
         "@radix-ui/react-tabs": "^1.0.1",
-        "@samvera/bloom-iiif": "^0.3.6",
+        "@samvera/bloom-iiif": "^0.4.1",
         "@samvera/clover-iiif": "^1.13.0",
         "@samvera/nectar-iiif": "^0.0.20",
         "@stitches/react": "^1.2.6",
@@ -2880,9 +2880,9 @@
       "dev": true
     },
     "node_modules/@samvera/bloom-iiif": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@samvera/bloom-iiif/-/bloom-iiif-0.3.6.tgz",
-      "integrity": "sha512-Oi67rbzYM/4g1W82GP+8Ncln3kThaC3X4ErESsCIzTyNUbjFdoxGZi86Fn1smSbeF1zqMp+EwpIqZCl+mUGlpw==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@samvera/bloom-iiif/-/bloom-iiif-0.4.1.tgz",
+      "integrity": "sha512-sANb6h04mXk7qkO8WgsrUbfdmUfaVK8lVzW3p9+7nQ39NHbNVf1IUdcNvWgk2FkkX8kxbGdmUZ9isua/uupTQg==",
       "dependencies": {
         "@iiif/vault": "^0.9.19",
         "@iiif/vault-helpers": "^0.9.11",
@@ -2891,6 +2891,7 @@
         "@stitches/react": "^1.2.8",
         "react": "^16.13.1  || ^17 || ^18",
         "react-dom": "^16.13.1  || ^17 || ^18",
+        "react-error-boundary": "^3.1.4",
         "swiper": "^8.4.5"
       }
     },
@@ -15022,9 +15023,9 @@
       "dev": true
     },
     "@samvera/bloom-iiif": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@samvera/bloom-iiif/-/bloom-iiif-0.3.6.tgz",
-      "integrity": "sha512-Oi67rbzYM/4g1W82GP+8Ncln3kThaC3X4ErESsCIzTyNUbjFdoxGZi86Fn1smSbeF1zqMp+EwpIqZCl+mUGlpw==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@samvera/bloom-iiif/-/bloom-iiif-0.4.1.tgz",
+      "integrity": "sha512-sANb6h04mXk7qkO8WgsrUbfdmUfaVK8lVzW3p9+7nQ39NHbNVf1IUdcNvWgk2FkkX8kxbGdmUZ9isua/uupTQg==",
       "requires": {
         "@iiif/vault": "^0.9.19",
         "@iiif/vault-helpers": "^0.9.11",
@@ -15033,6 +15034,7 @@
         "@stitches/react": "^1.2.8",
         "react": "^16.13.1  || ^17 || ^18",
         "react-dom": "^16.13.1  || ^17 || ^18",
+        "react-error-boundary": "^3.1.4",
         "swiper": "^8.4.5"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@radix-ui/react-select": "^1.0.0",
     "@radix-ui/react-switch": "^1.0.1",
     "@radix-ui/react-tabs": "^1.0.1",
-    "@samvera/bloom-iiif": "^0.3.6",
+    "@samvera/bloom-iiif": "^0.4.1",
     "@samvera/clover-iiif": "^1.13.0",
     "@samvera/nectar-iiif": "^0.0.20",
     "@stitches/react": "^1.2.6",


### PR DESCRIPTION
## What does this do?

This work brings in the updated Bloom IIIF component, addressing error handling for various resource type errors. Additionally, the `Next Page` slide is now hidden by targeting a `data-type` attribute on the swiper slide. Finally, a bug related to `&` character in strings of constructed IIIF Collections URIs that source Bloom sliders for series have been fixed.

- Update bloom dependency, hide next page,
- Address series IIIF collection construction.

## How to review?

1. Go to the Berkley collection
2. Click the **Collection Organization** tab
3. All sliders should render and function without error.