### PR TITLE
Facet narrowing

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,19 @@ npm run test
 
 ## API
 
+### Notes
+
+Currently DC v2 hits a new DC API v2 for it's indexed data.
+
+`https://dcapi.rdc-staging.library.northwestern.edu/docs/v2`
+
+Behind the scenes, DC API v2 is using OpenSearch `v 1.2` or Elasticsearch `v 7.17`. (For documentation references).
+
+### Endpoints
+
 The API endpoint is an environment variable which is accessed in a local dev environment via the `miscellany` Git repo.
+
+### Viewing OpenSearch data locally
 
 In a local dev environment, to view API data coming from the index (for now), run the following:
 
@@ -98,21 +110,23 @@ The API supports both POST for searching and GET for Work and Collection items.
 
 ```
 # Search Works (default)
-curl -X POST 'http://127.0.0.1:3000/search' --data-binary '{"query": {"match_all": {}}, "_source": "id", "size": 1000}' | jq
+curl -X POST '[URL]/search' --data-binary '{"query": {"match_all": {}}, "_source": "id", "size": 1000}' | jq
 
 # Search Collections
-curl -X POST 'http://127.0.0.1:3000/search/collections' --data-binary '{"query": {"match_all": {}}, "_source": "id", "size": 1000}' | jq
+curl -X POST '[URL]/search/collections' --data-binary '{"query": {"match_all": {}}, "_source": "id", "size": 1000}' | jq
 ```
 
-### Work / Collection examples
+### Direct GET request endpoint examples
 
 ```
-https://pylxu5f2l2.execute-api.us-east-1.amazonaws.com/v2/works/4359936f-9091-499b-893f-b8e900db49ec
+[URL]/works/4359936f-9091-499b-893f-b8e900db49ec
 
-https://pylxu5f2l2.execute-api.us-east-1.amazonaws.com/v2/collections/18ec4c6b-192a-4ab8-9903-ea0f393c35f7
+[URL]/collections/18ec4c6b-192a-4ab8-9903-ea0f393c35f7
 
-https://pylxu5f2l2.execute-api.us-east-1.amazonaws.com/v2/file-sets/ce1f6d18-8563-4f70-aabc-d4ce1688d8dc
+[URL]/file-sets/ce1f6d18-8563-4f70-aabc-d4ce1688d8dc
 ```
+
+See documentation in above link for more info
 
 ## Design
 

--- a/components/Facets/Facet/GenericFacet.styled.ts
+++ b/components/Facets/Facet/GenericFacet.styled.ts
@@ -138,6 +138,14 @@ const Options = styled("ul", {
   },
 });
 
+const SpinWrapper = styled("div", {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "flex-start",
+  paddingTop: "$gr2",
+  paddingLeft: "$gr3",
+});
+
 export {
   Find,
   FindInput,
@@ -145,5 +153,6 @@ export {
   Options,
   OptionCount,
   OptionText,
+  SpinWrapper,
   StyledGenericFacet,
 };

--- a/components/Facets/Facet/Options.tsx
+++ b/components/Facets/Facet/Options.tsx
@@ -1,6 +1,6 @@
+import { Options, SpinWrapper } from "./GenericFacet.styled";
 import { FacetsInstance } from "@/types/components/facets";
 import Option from "./Option";
-import { Options } from "./GenericFacet.styled";
 import { SpinLoader } from "@/components/Shared/Loader.styled";
 import useFetchApiData from "@/hooks/useFetchApiData";
 import { useFilterState } from "@/context/filter-context";
@@ -30,7 +30,12 @@ const FacetOptions: React.FC<FacetOptionsProps> = ({
     urlFacets: userFacetsUnsubmitted,
   });
 
-  if (loading) return <SpinLoader />;
+  if (loading)
+    return (
+      <SpinWrapper>
+        <SpinLoader />
+      </SpinWrapper>
+    );
   if (error) return <p>Error fetching data</p>;
   if (
     !data ||

--- a/lib/queries/builder.ts
+++ b/lib/queries/builder.ts
@@ -3,7 +3,7 @@ import { ApiSearchRequest } from "@/types/api/request";
 import { FacetsInstance } from "@/types/components/facets";
 import { UrlFacets } from "@/types/context/filter-context";
 import { buildAggs } from "@/lib/queries/aggs";
-import { buildFacetPart } from "@/lib/queries/facet";
+import { buildFacetFilters } from "@/lib/queries/facet";
 
 type BuildQueryProps = {
   aggs?: FacetsInstance[];
@@ -43,11 +43,27 @@ export function addFacetsToQuery(
   query: ApiSearchRequest,
   urlFacets: UrlFacets
 ) {
-  for (const [key, value] of Object.entries(urlFacets)) {
-    if (value?.length > 0) {
-      query.query.bool.must.push(buildFacetPart(key, value));
-    }
+  /** Verify at least one user facet has been activated */
+  if (Object.keys(urlFacets).length > 0) {
+    /** 
+     * It should end up looking like this:
+     * 
+      "bool": {
+        "filter": [
+            { "term": { "subject.label": "Berkeley (Calif.)" } },
+            { "term": {  "subject.label": "Baez, Joan" } },
+            { "term": {  "genre.label": "Photographs" } }
+        ]
+      }
+     */
+
+    query.query.bool.must.push({
+      bool: {
+        filter: buildFacetFilters(urlFacets),
+      },
+    });
   }
+
   return query;
 }
 

--- a/lib/queries/facet.test.ts
+++ b/lib/queries/facet.test.ts
@@ -1,0 +1,64 @@
+import * as facetFns from "./facet";
+
+describe("buildFacetFilters fn()", () => {
+  it("returns an empty array if no url facets exist", () => {
+    const result = facetFns.buildFacetFilters({});
+    expect(result).toEqual([]);
+  });
+
+  it("returns an empty array if somehow bad data (which isnt a facet)  gets passed in", () => {
+    const result = facetFns.buildFacetFilters({ foo: ["bar"] });
+    expect(result).toEqual([]);
+  });
+
+  it("handles single facet values", () => {
+    const result = facetFns.buildFacetFilters({ subject: ["bar"] });
+    expect(result).toMatchObject([
+      {
+        term: {
+          "subject.label": "bar",
+        },
+      },
+    ]);
+  });
+
+  it("handles facet multiple values", () => {
+    const result = facetFns.buildFacetFilters({ subject: ["bar", "baz"] });
+    expect(result).toMatchObject([
+      {
+        term: {
+          "subject.label": "bar",
+        },
+      },
+      {
+        term: {
+          "subject.label": "baz",
+        },
+      },
+    ]);
+  });
+
+  it("handles multiple facets multiple values", () => {
+    const result = facetFns.buildFacetFilters({
+      genre: ["ima genre"],
+      subject: ["bar", "baz"],
+    });
+    expect(result).toMatchObject([
+      {
+        term: {
+          "genre.label": "ima genre",
+        },
+      },
+      {
+        term: {
+          "subject.label": "bar",
+        },
+      },
+      {
+        term: {
+          "subject.label": "baz",
+        },
+      },
+    ]);
+  });
+});

--- a/lib/queries/facet.ts
+++ b/lib/queries/facet.ts
@@ -1,25 +1,33 @@
-import { ALL_FACETS } from "../constants/facets-model";
+import { ALL_FACETS } from "@/lib/constants/facets-model";
+import { FacetTerm } from "@/types/api/request";
+import { UrlFacets } from "@/types/context/filter-context";
 
-const buildFacetPart = (id: string, values: string[]) => {
-  /**
-   * Lookup facet field by ID to pass to query
-   */
-  const facet = ALL_FACETS.facets.find((item) => item.id === id);
+const buildFacetFilters = (urlFacets: UrlFacets) => {
+  const filter: FacetTerm[] = [];
 
-  if (!facet) return;
+  /** Sample urlFacets object for reference
+  const sampleUrlFacets = {
+    collection: [],
+    genre: ['baz'],
+    subject: ["foo", "bar"]
+  }
+  */
 
-  const obj = {
-    bool: {
-      should: [
-        {
-          terms: {
-            [facet.field]: [...values],
-          },
-        },
-      ],
-    },
-  };
-  return obj;
+  /** Loop through facet keys */
+  for (const [key, value] of Object.entries(urlFacets)) {
+    /** Lookup facet field by ID to pass to query */
+    const facet = ALL_FACETS.facets.find((item) => item.id === key);
+
+    if (facet && value?.length > 0) {
+      /** Loop through facet values */
+      value.forEach((facetValue) => {
+        filter.push({
+          term: { [facet.field]: facetValue },
+        });
+      });
+    }
+  }
+  return filter;
 };
 
-export { buildFacetPart };
+export { buildFacetFilters };

--- a/types/api/request.ts
+++ b/types/api/request.ts
@@ -27,13 +27,15 @@ export interface ApiSearchQuery {
   };
 }
 
+export type FacetTerm = {
+  term: {
+    [key: string]: string;
+  };
+};
+
 export interface FacetTerms {
   bool: {
-    should: Array<{
-      terms: {
-        [key: string]: string[];
-      };
-    }>;
+    filter: Array<FacetTerm>;
   };
 }
 


### PR DESCRIPTION
## What does this do?
Narrows search results in the Filter window to match the behavior here (a nice visual and way to A/B our filtering):

https://www.artic.edu/collection

Every applied filter will reduce returned values, acting as an `AND`, not an expansive `OR`.

Thanks @davidschober for sorting this one out.  My head was about to blow up 💥

![image](https://user-images.githubusercontent.com/3020266/212169947-6c079d9a-4840-4792-8e2e-79cdb7efe87d.png)

![image](https://user-images.githubusercontent.com/3020266/212170061-8fca3d08-0459-4ae3-9b96-40c5e4a95fa4.png)

![image](https://user-images.githubusercontent.com/3020266/212170136-8c934c91-5798-432e-a354-a89ad5c72068.png)

![image](https://user-images.githubusercontent.com/3020266/212170242-1f2aca7b-79fa-4868-9b8e-90368f71a7a9.png)


## How to test?
1. Check out the Art Institute way of faceting
2. Go to our facets, and play with it.  Try to arrive at a way where returned results expand instead of contract (Facets only...working on Search next)

