### PR TITLE
OpenSearch search method upgrade

### DIFF
--- a/components/Grid/Item.tsx
+++ b/components/Grid/Item.tsx
@@ -41,6 +41,8 @@ const GridItem: React.FC<GridItemProps> = ({ item }) => {
     }
   }, [item]);
 
+  if (!endpointPath) return <></>;
+
   return (
     <ItemStyled key={item.id} data-item-id={item.id}>
       <Link href={`${urlPath}/${item.id}`}>

--- a/lib/queries/search.ts
+++ b/lib/queries/search.ts
@@ -22,12 +22,24 @@ const querySearchTemplate: ApiSearchRequest = {
 };
 
 const buildSearchPart = (term: string): SearchSimpleQueryString => {
+  /**
+   * Does the search term contain an OpenSearch "phrase" (ie. "Joan and Bob")
+   *
+   * Reference: https://www.elastic.co/guide/en/elasticsearch/reference/7.17/query-dsl-query-string-query.html#query-string-query-notes
+   */
+  const hasPhrase = term.includes(`"`);
+
+  /** Phrase search terms are passed directly, but regular search adds some forgiveness */
+  const queryTerm = hasPhrase ? term : `${term}~1 | ${term}*`;
+
   return {
-    simple_query_string: {
-      default_operator: "or",
-      // Reference at: https://github.com/nulib/meadow/blob/deploy/staging/app/priv/elasticsearch/v2/settings/work.json
+    query_string: {
+      /**
+       * Reference available index keys/vars:
+       * https://github.com/nulib/meadow/blob/deploy/staging/app/priv/elasticsearch/v2/settings/work.json
+       */
       fields: ["title^5", "all_text", "all_controlled_labels", "all_ids"],
-      query: term ? `${term}~1 | ${term}*` : "",
+      query: queryTerm,
     },
   };
 };

--- a/types/api/request.ts
+++ b/types/api/request.ts
@@ -40,8 +40,8 @@ export interface FacetTerms {
 }
 
 export interface SearchSimpleQueryString {
-  simple_query_string: {
-    default_operator: string;
+  query_string: {
+    default_operator?: string;
     fields: string[];
     query: string;
   };


### PR DESCRIPTION
## What does this do
- Changes the way DC v2 interacts with OpenSearch search as part of the `POST` query.  Now using the more powerful `query_string` method.   Search bar now accepts complex queries.
- Fix the `undefined` API route errors on Search page.

## How to test
- Go to the Search page, and enter complex queries (ie. `title:Berk`, `title:Berk OR subject.label:Foo`, `"Bob Dylan"` etc).

https://www.elastic.co/guide/en/elasticsearch/reference/7.17/query-dsl-query-string-query.html#query-string-query-notes

- Go to the Search page, and notice all the errors (mostly) are gone, or at least the ones relating to #3451