### PR TITLE
Address footer styling.

### DIFF
--- a/components/Footer/Footer.styled.ts
+++ b/components/Footer/Footer.styled.ts
@@ -1,5 +1,12 @@
 import { styled } from "@/stitches.config";
 
+/* eslint sort-keys: 0 */
+
 export const FooterStyled = styled("div", {
-  background: "$black80",
+  background: "$purple",
+  padding: "$gr2 0",
+
+  "a, a:visited": {
+    color: "$white !important",
+  },
 });

--- a/components/Footer/Footer.tsx
+++ b/components/Footer/Footer.tsx
@@ -2,13 +2,12 @@ import Container from "@/components/Shared/Container";
 import { FooterStyled } from "@/components/Footer/Footer.styled";
 import { Footer as NUFooter } from "@nulib/design-system";
 import React from "react";
-import colors from "@/styles/colors";
 
 export default function Footer() {
   return (
     <FooterStyled>
       <Container>
-        <NUFooter css={{ background: colors.black80 }} />
+        <NUFooter />
       </Container>
     </FooterStyled>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "name": "dc-nextjs",
       "dependencies": {
         "@iiif/parser": "^1.0.10",
-        "@nulib/design-system": "^1.6.0",
+        "@nulib/design-system": "^1.6.1",
         "@radix-ui/colors": "^0.1.8",
         "@radix-ui/react-accordion": "^1.0.1",
         "@radix-ui/react-aspect-ratio": "^1.0.1",
@@ -1958,9 +1958,9 @@
       }
     },
     "node_modules/@nulib/design-system": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@nulib/design-system/-/design-system-1.6.0.tgz",
-      "integrity": "sha512-uZunrPockebj7UWvC9vNaOe4/JhbscDPSpE2yo24RtNg6sKXLwQZITbuFj6ciPVjcSjNKzwfDsuSNkWJf8IMCg==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@nulib/design-system/-/design-system-1.6.1.tgz",
+      "integrity": "sha512-U8gKtb+Pu64Knw4P518LK1hDVeyb67+8iSDC/1+WqNHK7KsO+UoOfkiPoDNQSsyNn8/3D5msDiMl01rXbDt46Q==",
       "dependencies": {
         "@radix-ui/react-popover": "^0.1.7-rc.43",
         "@stitches/react": "^1.2.7",
@@ -14310,9 +14310,9 @@
       }
     },
     "@nulib/design-system": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@nulib/design-system/-/design-system-1.6.0.tgz",
-      "integrity": "sha512-uZunrPockebj7UWvC9vNaOe4/JhbscDPSpE2yo24RtNg6sKXLwQZITbuFj6ciPVjcSjNKzwfDsuSNkWJf8IMCg==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@nulib/design-system/-/design-system-1.6.1.tgz",
+      "integrity": "sha512-U8gKtb+Pu64Knw4P518LK1hDVeyb67+8iSDC/1+WqNHK7KsO+UoOfkiPoDNQSsyNn8/3D5msDiMl01rXbDt46Q==",
       "requires": {
         "@radix-ui/react-popover": "^0.1.7-rc.43",
         "@stitches/react": "^1.2.7",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@iiif/parser": "^1.0.10",
-    "@nulib/design-system": "^1.6.0",
+    "@nulib/design-system": "^1.6.1",
     "@radix-ui/colors": "^0.1.8",
     "@radix-ui/react-accordion": "^1.0.1",
     "@radix-ui/react-aspect-ratio": "^1.0.1",


### PR DESCRIPTION
## What does this do?

![image](https://user-images.githubusercontent.com/7376450/212361516-85106267-d34f-48f6-a367-8c2fc1377e26.png)

This addresses two issues and updates the @nulib/design-system dependency. The footer is now Northwestern Purple and the hover links issue has been resolved.

- https://github.com/nulib/repodev_planning_and_docs/issues/3462
- https://github.com/nulib/repodev_planning_and_docs/issues/3391

Note, ZenHub is acting up so I'm not able to connect to these issues for some reason.