### PR TITLE
Support downloading of a Work Fileset via download helper package

### DIFF
--- a/components/Work/ActionsDialog/DownloadAndShare.tsx
+++ b/components/Work/ActionsDialog/DownloadAndShare.tsx
@@ -14,6 +14,7 @@ import {
   ItemThumbnail,
 } from "@/components/Work/ActionsDialog/DownloadAndShare.styled";
 import { Label, Thumbnail } from "@samvera/nectar-iiif";
+import { makeBlob, mimicDownload } from "@samvera/image-downloader";
 import ActionsDialogAside from "@/components/Work/ActionsDialog/Aside";
 import Announcement from "@/components/Shared/Announcement";
 import CopyText from "@/components/Shared/CopyText";
@@ -166,6 +167,28 @@ const Item: React.FC<ItemProps> = ({ item, showEmbedWarning }) => {
     isValidStringArray ? embedHTMLStringArray[5] : ""
   }" />`;
 
+  const handleDownloadClick = async (
+    e: React.SyntheticEvent<HTMLAnchorElement>
+  ) => {
+    e.preventDefault();
+
+    const downloadFilename =
+      item.label?.none && item.label.none.length > 0
+        ? item.label.none[0].replace(/\.[^/.]+$/, "")
+        : "nul_fileset";
+
+    const response = await makeBlob(
+      `${getInfoResponse(item)}/full/1000,/0/default.jpg`
+    );
+
+    if (!response || response.error) {
+      alert("Error fetching the image");
+      return;
+    }
+
+    mimicDownload(response, downloadFilename);
+  };
+
   return (
     <ItemStyled>
       <ItemRow>
@@ -180,12 +203,7 @@ const Item: React.FC<ItemProps> = ({ item, showEmbedWarning }) => {
           {item.label && <Label label={item.label} as="span" />}
           <ItemActions>
             <li>
-              <a
-                href={`${getInfoResponse(item)}/full/1000,/0/default.jpg`}
-                download
-                rel="noreferrer"
-                target="_blank"
-              >
+              <a onClick={handleDownloadClick} href="#">
                 Download JPG
               </a>
             </li>

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,1 +1,2 @@
 declare module "@samvera/clover-iiif";
+declare module "@samvera/image-downloader";

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@radix-ui/react-tabs": "^1.0.1",
         "@samvera/bloom-iiif": "^0.4.1",
         "@samvera/clover-iiif": "^1.13.0",
+        "@samvera/image-downloader": "^1.1.5",
         "@samvera/nectar-iiif": "^0.0.20",
         "@stitches/react": "^1.2.6",
         "axios": "^1.2.2",
@@ -2940,6 +2941,18 @@
         "react": "^16.8  || ^17.0 || ^18.0",
         "react-dom": "^16.8  || ^17.0 || ^18.0",
         "sanitize-html": "^2.7.0"
+      }
+    },
+    "node_modules/@samvera/image-downloader": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@samvera/image-downloader/-/image-downloader-1.1.5.tgz",
+      "integrity": "sha512-Q1UAoNMvKGfEjMf9JEyCf8MvYtUNuOGXf0jOiwthKAh8d/VEXVDqHplND7+kEMiMiGe5srjI9Zr6Ct+KDXBKFQ==",
+      "dependencies": {
+        "svg-loaders-react": "^2.2.1"
+      },
+      "peerDependencies": {
+        "react": "^16.13.1  || ^17 || ^18",
+        "react-dom": "^16.13.1  || ^17 || ^18"
       }
     },
     "node_modules/@samvera/nectar-iiif": {
@@ -12097,6 +12110,11 @@
       "integrity": "sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g==",
       "optional": true
     },
+    "node_modules/svg-loaders-react": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/svg-loaders-react/-/svg-loaders-react-2.2.1.tgz",
+      "integrity": "sha512-ATfg5pAMOla2GqPcwGRDrNTLlTQzl2fMvfW290j20qH7qpB61C3SQAnu+T9t8Z+V4IKKN2Bm1d/SaCv5IR1DDA=="
+    },
     "node_modules/swiper": {
       "version": "8.4.5",
       "resolved": "https://registry.npmjs.org/swiper/-/swiper-8.4.5.tgz",
@@ -15087,6 +15105,14 @@
             "sanitize-html": "^2.7.0"
           }
         }
+      }
+    },
+    "@samvera/image-downloader": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@samvera/image-downloader/-/image-downloader-1.1.5.tgz",
+      "integrity": "sha512-Q1UAoNMvKGfEjMf9JEyCf8MvYtUNuOGXf0jOiwthKAh8d/VEXVDqHplND7+kEMiMiGe5srjI9Zr6Ct+KDXBKFQ==",
+      "requires": {
+        "svg-loaders-react": "^2.2.1"
       }
     },
     "@samvera/nectar-iiif": {
@@ -21761,6 +21787,11 @@
       "resolved": "https://registry.npmjs.org/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.2.0.tgz",
       "integrity": "sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g==",
       "optional": true
+    },
+    "svg-loaders-react": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/svg-loaders-react/-/svg-loaders-react-2.2.1.tgz",
+      "integrity": "sha512-ATfg5pAMOla2GqPcwGRDrNTLlTQzl2fMvfW290j20qH7qpB61C3SQAnu+T9t8Z+V4IKKN2Bm1d/SaCv5IR1DDA=="
     },
     "swiper": {
       "version": "8.4.5",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@radix-ui/react-tabs": "^1.0.1",
     "@samvera/bloom-iiif": "^0.4.1",
     "@samvera/clover-iiif": "^1.13.0",
+    "@samvera/image-downloader": "^1.1.5",
     "@samvera/nectar-iiif": "^0.0.20",
     "@stitches/react": "^1.2.6",
     "axios": "^1.2.2",


### PR DESCRIPTION
## What does this do?
- Prompts a download instead of linking to the IIIF hosted page in a browser
- Updates `@samvera/image-downloader` at https://www.npmjs.com/package/@samvera/image-downloader

![image](https://user-images.githubusercontent.com/3020266/212414609-67d4148f-e160-41c6-ab69-9de53a728587.png)

Will now prompt a download:

![image](https://user-images.githubusercontent.com/3020266/212414836-0ca2bc01-0dee-4378-9096-e57053be865e.png)

## How to test
Mimc the above screenshots