### PR TITLE
Create WorkCount component and implement.

### DIFF
--- a/components/Collection/Item/Item.tsx
+++ b/components/Collection/Item/Item.tsx
@@ -3,15 +3,14 @@ import {
   ItemContent,
   ItemImageWrapper,
   ItemStyled,
-  MetadataIcons,
 } from "@/components/Collection/Item/Item.styled";
-import { IconAudio, IconImage, IconVideo } from "@/components/Shared/SVG/Icons";
 import { type CollectionListShape } from "@/pages/collections";
 import Figure from "@/components/Figure/Figure";
 import Heading from "@/components/Heading/Heading";
 import Link from "next/link";
 import { LinkStyled } from "@/components/Shared/LinkStyled";
 import ReadMore from "@/components/Shared/ReadMore";
+import WorkCount from "@/components/Shared/WorkCount/WorkCount";
 
 const CollectionItem: React.FC<CollectionListShape> = ({
   title,
@@ -21,7 +20,6 @@ const CollectionItem: React.FC<CollectionListShape> = ({
   totalAudio,
   totalImage,
   totalVideo,
-  totalWorks,
 }) => {
   return (
     <ItemStyled data-collection={id}>
@@ -43,31 +41,7 @@ const CollectionItem: React.FC<CollectionListShape> = ({
             <LinkStyled>{title}</LinkStyled>
           </Link>
         </Heading>
-
-        {totalWorks && totalWorks > 0 ? (
-          <MetadataIcons>
-            {totalWorks && totalWorks > 0 ? (
-              <span>{totalWorks} Works</span>
-            ) : null}
-            {totalImage && totalImage > 0 ? (
-              <span title={`${totalImage} images`}>
-                {totalImage} <IconImage />
-              </span>
-            ) : null}
-            {totalAudio && totalAudio > 0 ? (
-              <span title={`${totalAudio} audio files`}>
-                {totalAudio} <IconAudio />
-              </span>
-            ) : null}
-
-            {totalVideo && totalVideo > 0 ? (
-              <span title={`${totalVideo} videos`}>
-                {totalVideo} <IconVideo />
-              </span>
-            ) : null}
-          </MetadataIcons>
-        ) : null}
-
+        <WorkCount image={totalImage} audio={totalAudio} video={totalVideo} />
         {description && (
           <Description>
             <ReadMore text={description} words={55} />

--- a/components/Figure/Figure.tsx
+++ b/components/Figure/Figure.tsx
@@ -9,14 +9,14 @@ import {
   FigureTitle,
   FigureVariants,
 } from "@/components/Figure/Figure.styled";
+import React, { ReactNode } from "react";
 import { IconLock } from "@/components/Shared/SVG/Icons";
-import React from "react";
 
 interface Figure {
   aspectRatio?: number;
   isRestricted?: boolean;
   src: string;
-  supplementalInfo?: string;
+  supplementalInfo?: ReactNode;
   title: string;
 }
 

--- a/components/Shared/Card.tsx
+++ b/components/Shared/Card.tsx
@@ -1,15 +1,15 @@
+import React, { ReactNode } from "react";
 import { CardStyled } from "@/components/Shared/Card.styled";
 import Figure from "@/components/Figure/Figure";
 import Link from "next/link";
 import { LinkStyled } from "@/components/Shared/LinkStyled";
-import React from "react";
 import ReadMore from "./ReadMore";
 
 export interface CardProps {
   description?: string | null;
   href?: string;
   imageUrl: string;
-  supplementalInfo?: string;
+  supplementalInfo?: ReactNode;
   title: string;
 }
 

--- a/components/Shared/WorkCount/WorkCount.styled.ts
+++ b/components/Shared/WorkCount/WorkCount.styled.ts
@@ -1,0 +1,49 @@
+import { styled } from "@/stitches.config";
+
+/* eslint sort-keys: 0 */
+
+const WorkCountStyled = styled("div", {
+  display: "inline-flex",
+  backgroundColor: "$purple10",
+  color: "$white",
+  fontSize: "$gr1",
+  borderRadius: "1rem",
+  margin: "0 0 $gr3",
+  fontFamily: "$northwesternSansBold",
+});
+
+const WorkCountTotal = styled("span", {
+  backgroundColor: "$purple120",
+  borderRadius: "1rem",
+  padding: "$gr1 $gr2",
+});
+
+const WorkCountType = styled("span", {
+  display: "flex",
+  flexDirection: "row",
+  alignItems: "center",
+  paddingRight: "$gr2",
+  backgroundColor: "transparent",
+
+  svg: {
+    height: "$gr3",
+    width: "$gr3",
+    fill: "$purple120",
+    marginLeft: "3px",
+  },
+
+  "&:first-child": {
+    paddingLeft: "$gr2",
+  },
+
+  "&:last-child": {
+    paddingRight: "$gr2",
+  },
+});
+
+const WorkCountTypes = styled("div", {
+  color: "$purple120",
+  display: "flex",
+});
+
+export { WorkCountStyled, WorkCountTotal, WorkCountTypes, WorkCountType };

--- a/components/Shared/WorkCount/WorkCount.test.tsx
+++ b/components/Shared/WorkCount/WorkCount.test.tsx
@@ -1,0 +1,44 @@
+import WorkCount, {
+  WorkCountProps,
+} from "@/components/Shared/WorkCount/WorkCount";
+import { render, screen } from "@/test-utils";
+
+const imageOnly: WorkCountProps = {
+  audio: 0,
+  image: 123,
+  video: 0,
+};
+
+const mixedTypes: WorkCountProps = {
+  audio: 2,
+  image: 123,
+  video: 5,
+};
+
+describe("renders WorkCount component", () => {
+  it("displays Total and individual Image counts", () => {
+    render(<WorkCount {...imageOnly} />);
+    const total = screen.getByTestId("work-count-total");
+    expect(total).toHaveTextContent("123 Works");
+
+    const types = screen.getAllByTestId("work-count-type");
+    types.forEach((el) => {
+      const type = el.getAttribute("data-type") as string;
+      const count = imageOnly[type as keyof WorkCountProps];
+      expect(el).toHaveAccessibleName(`${count} ${type} works`);
+    });
+  });
+
+  it("displays cumulative Total, and individual Audio, Image, and Video counts", () => {
+    render(<WorkCount {...mixedTypes} />);
+    const total = screen.getByTestId("work-count-total");
+    expect(total).toHaveTextContent("130 Works");
+
+    const types = screen.getAllByTestId("work-count-type");
+    types.forEach((el) => {
+      const type = el.getAttribute("data-type") as string;
+      const count = mixedTypes[type as keyof WorkCountProps];
+      expect(el).toHaveAccessibleName(`${count} ${type} works`);
+    });
+  });
+});

--- a/components/Shared/WorkCount/WorkCount.tsx
+++ b/components/Shared/WorkCount/WorkCount.tsx
@@ -1,0 +1,67 @@
+import { IconAudio, IconImage, IconVideo } from "@/components/Shared/SVG/Icons";
+import {
+  WorkCountTotal as Total,
+  WorkCountType as Type,
+  WorkCountTypes as Types,
+  WorkCountStyled,
+} from "@/components/Shared/WorkCount/WorkCount.styled";
+import React from "react";
+
+export interface WorkCountProps {
+  audio?: number;
+  image?: number;
+  video?: number;
+}
+
+const WorkCount: React.FC<WorkCountProps> = ({
+  audio = 0,
+  image = 0,
+  video = 0,
+}) => {
+  const total = audio + image + video;
+
+  return (
+    <WorkCountStyled>
+      <Total data-testid="work-count-total">
+        {total} {total !== 1 ? "Works" : "Work"}
+      </Total>
+      <Types>
+        {image ? (
+          <Type
+            aria-label={`${image} image works`}
+            data-testid="work-count-type"
+            data-type="image"
+          >
+            {image} <IconImage />
+          </Type>
+        ) : (
+          <></>
+        )}
+        {audio ? (
+          <Type
+            aria-label={`${audio} audio works`}
+            data-testid="work-count-type"
+            data-type="audio"
+          >
+            {audio} <IconAudio />
+          </Type>
+        ) : (
+          <></>
+        )}
+        {video ? (
+          <Type
+            aria-label={`${video} video works`}
+            data-testid="work-count-type"
+            data-type="video"
+          >
+            {video} <IconVideo />
+          </Type>
+        ) : (
+          <></>
+        )}
+      </Types>
+    </WorkCountStyled>
+  );
+};
+
+export default WorkCount;

--- a/components/Work/ActionsDialog/Aside.tsx
+++ b/components/Work/ActionsDialog/Aside.tsx
@@ -12,13 +12,15 @@ const ActionsDialogAside: React.FC<ActionsDialogAsideProps> = ({
   const { workState } = useWorkState();
   const { work } = workState;
 
+  const WorkType = () => <>{work?.work_type}</>;
+
   return (
     <ActionsDialogAsideStyled data-testid="actions-dialog-aside">
       {work && (
         <Card
           title={work.title}
           imageUrl={work.thumbnail}
-          supplementalInfo={work.work_type}
+          supplementalInfo={<WorkType />}
         />
       )}
       {children}

--- a/components/Work/TopInfo.tsx
+++ b/components/Work/TopInfo.tsx
@@ -10,9 +10,9 @@ import { Button } from "@nulib/design-system";
 import Card from "@/components/Shared/Card";
 import { DefinitionListWrapper } from "@/components/Shared/DefinitionList.styled";
 import Expand from "@/components/Shared/Expand/Expand";
-// import Heading from "@/components/Heading/Heading";
 import { Manifest } from "@iiif/presentation-3";
 import WorkActionsDialog from "@/components/Work/ActionsDialog/ActionsDialog";
+import WorkCount from "@/components/Shared/WorkCount/WorkCount";
 import WorkMetadata from "@/components/Work/Metadata";
 import { WorkShape } from "@/types/components/works";
 import { type WorkTypeCountMap } from "@/lib/collection-helpers";
@@ -57,15 +57,10 @@ const WorkTopInfo: React.FC<TopInfoProps> = ({
     }
   };
 
-  function buildWorkCountsText() {
+  function buildWorkCounts() {
     if (!collectionWorkTypeCounts) return "";
-    const { totalAudio, totalImage, totalVideo, totalWorks } =
-      collectionWorkTypeCounts;
-    let text = `${totalWorks} Total Works:`;
-    text += totalImage && totalImage > 0 ? ` ${totalImage} Images` : "";
-    text += totalAudio && totalAudio > 0 ? ` ${totalAudio} Audio` : "";
-    text += totalVideo && totalVideo > 0 ? ` ${totalVideo} Video` : "";
-    return text;
+    const { totalAudio, totalImage, totalVideo } = collectionWorkTypeCounts;
+    return { audio: totalAudio, image: totalImage, video: totalVideo };
   }
 
   return (
@@ -129,7 +124,7 @@ const WorkTopInfo: React.FC<TopInfoProps> = ({
               description={work.collection?.description}
               href={`/collections/${work.collection?.id}`}
               imageUrl={`${process.env.NEXT_PUBLIC_DCAPI_ENDPOINT}/collections/${work.collection?.id}/thumbnail?aspect=square `}
-              supplementalInfo={buildWorkCountsText()}
+              supplementalInfo={<WorkCount {...buildWorkCounts()} />}
             />
           </TopInfoCollection>
         </TopInfoContent>

--- a/lib/collection-helpers.ts
+++ b/lib/collection-helpers.ts
@@ -176,10 +176,9 @@ export async function getCollectionWorkCounts(collectionId = "") {
       if (collectionId) {
         return {
           [collectionId]: {
-            totalAudio: 0,
-            totalImage: 0,
-            totalWorks: 0,
-            totalVideo: 0,
+            audio: 0,
+            image: 0,
+            video: 0,
           },
         };
       }


### PR DESCRIPTION
## What does this do?

**Individual Work**
![image](https://user-images.githubusercontent.com/7376450/213009840-946a07d4-5013-45b2-9299-5364975961d9.png)

**Browse Collections**
![image](https://user-images.githubusercontent.com/7376450/213011280-bd3071b3-0161-4a04-8859-96f44a3ea03a.png)


This creates a `WorkCount` component that can be implemented in any case where we know _audio_, _image_, and _video_ work type counts. To implement in cases this information is passed down to a `Card` figure as a **string**, I allowed the the supplementingInfo prop on the `Card` component to be a `ReactNode` instead, giving greater flexibility at higher levels in our component structure.

## How should we review?

The work impacts three different views:

1. The Collection listing page where each collection item listing renders `WorkCount`.
2. Any work page where we deliver a `Card` rendering `WorkCount` for the related collection.
3. Any work page where the actions dialog for **Find**, **Cite**, and **Download & Share** are rendered. In this case the `WorkCount` component is not rendered and instead a react fragment wraps what a string for `WorkType` of the specific image.