### PR TITLE
Address filter button styling, update transitions.

### DIFF
--- a/components/Collection/NavTabs.styled.ts
+++ b/components/Collection/NavTabs.styled.ts
@@ -38,7 +38,7 @@ const StyledTrigger = styled(TabsPrimitive.Trigger, {
     position: "absolute",
     bottom: "-4px",
     left: "0",
-    transition: "$all",
+    transition: "$dcAll",
   },
 
   "&[data-state='active']": {

--- a/components/Facets/Facets.styled.ts
+++ b/components/Facets/Facets.styled.ts
@@ -14,6 +14,7 @@ const StyledFacets = styled("div", {
   [`& ${WorkTypeWrapper}`]: {
     borderRight: "1px solid $black10",
     paddingRight: "$gr2",
+    transition: "$dcWidth",
   },
 
   "@sm": {
@@ -31,7 +32,7 @@ const Width = styled("span", {
 
 const Wrapper = styled("div", {
   ".facets-ui-container": {
-    transition: "$all",
+    transition: "$dcAll",
   },
 
   "&[data-filter-fixed='true']": {

--- a/components/Facets/Filter/Filter.styled.ts
+++ b/components/Facets/Filter/Filter.styled.ts
@@ -6,7 +6,11 @@ import { styled } from "@/stitches.config";
 /* eslint sort-keys: 0 */
 
 const FilterActivate = styled(Dialog.Trigger, {
-  height: "38px",
+  display: "flex",
+  flexDirection: "row",
+  justifyContent: "center",
+  alignItems: "center",
+  alignContent: "center",
   cursor: "pointer",
   backgroundColor: "$white",
   border: "0",
@@ -15,14 +19,11 @@ const FilterActivate = styled(Dialog.Trigger, {
   fontSize: "$gr3",
   borderRadius: "50px",
   transition: "all 200ms ease-in-out",
-  display: "flex",
-  alignItems: "center",
-  padding: "0 1rem 0 0.5rem",
+  padding: "0 $gr3 0 $gr1",
 
   [`& ${IconStyled}`]: {
     color: "$black50",
     fill: "$black50",
-    marginBottom: "-1px",
   },
 
   "&:hover": {
@@ -38,6 +39,7 @@ const FilterActivate = styled(Dialog.Trigger, {
 });
 
 const FilterFloating = styled("div", {
+  height: `calc($gr3 * 2)`,
   display: "flex",
   backgroundColor: "$white",
   position: "relative",

--- a/components/Facets/Filter/GroupList.styled.ts
+++ b/components/Facets/Filter/GroupList.styled.ts
@@ -18,12 +18,12 @@ const GroupToggleIcon = styled("span", {
   right: "$gr3",
   marginTop: "-1px",
   opacity: "0.5",
-  transition: "$all",
+  transition: "$dcAll",
 
   svg: {
     height: "$gr3",
     transform: "rotate(-90deg)",
-    transition: "$all",
+    transition: "$dcAll",
   },
 });
 

--- a/components/Facets/UserFacets/UserFacets.styled.ts
+++ b/components/Facets/UserFacets/UserFacets.styled.ts
@@ -5,7 +5,7 @@ import { styled } from "@/stitches.config";
 
 const DropdownToggle = styled(Dropdown.Trigger, {
   display: "flex",
-  padding: "0 1rem",
+  padding: "0 $gr2",
   border: "none",
   position: "relative",
   backgroundColor: "transparent",
@@ -20,7 +20,7 @@ const DropdownToggle = styled(Dropdown.Trigger, {
   transition: "all 200ms ease-in-out",
 
   svg: {
-    width: "16px",
+    width: "$gr3",
     marginRight: "0.25rem",
     marginBottom: "-2px",
     color: "$black50",
@@ -32,14 +32,16 @@ const DropdownToggle = styled(Dropdown.Trigger, {
     display: "flex",
     justifyContent: "center",
     alignItems: "center",
-    fontSize: "11px",
     backgroundColor: "$darkBlueA",
+    fontFamily: "$northwesternSansBold",
+    fontWeight: "400",
+    fontSize: "$gr1",
     color: "$white",
     width: "19px",
     height: "19px",
     borderRadius: "50%",
-    marginTop: "-1.5rem",
-    marginRight: "-1.25rem",
+    marginTop: "-$gr4",
+    marginRight: "-$gr3",
   },
 
   [`&:hover`]: {
@@ -48,7 +50,7 @@ const DropdownToggle = styled(Dropdown.Trigger, {
     svg: {
       transform: "rotate(0deg) !important",
       color: "$purple",
-      marginBottom: "-7px",
+      marginBottom: "-$gr1",
     },
   },
 
@@ -63,17 +65,17 @@ const DropdownToggle = styled(Dropdown.Trigger, {
 const Icon = styled("span", {
   display: "flex",
   right: "0",
-  height: "31px",
-  width: "31px",
+  height: "$gr4",
+  width: "$gr4",
   justifyContent: "center",
   textAlign: "center",
   alignItems: "center",
   cursor: "pointer",
   backgroundColor: "transparent",
   zIndex: "1",
-  border: "2px solid $black10",
+  border: "1px solid $black10",
   borderRadius: "50%",
-  marginRight: "0.5rem",
+  marginRight: "$gr2",
   fill: "$black50",
   stroke: "$black50",
   transition: "all 200ms ease-in-out",

--- a/components/Facets/WorkType/WorkType.styled.ts
+++ b/components/Facets/WorkType/WorkType.styled.ts
@@ -7,7 +7,7 @@ const Wrapper = styled(Radio.Root, {
   position: "relative",
   height: "2rem",
   opacity: "1",
-  transition: "$all",
+  transition: "$dcAll",
 });
 
 const StyledWorkType = styled("ul", {

--- a/components/Header/Header.styled.ts
+++ b/components/Header/Header.styled.ts
@@ -29,7 +29,7 @@ const Primary = styled("div", {
   display: "flex",
   margin: "0 auto",
   zIndex: "1",
-  transition: "$all",
+  transition: "$dcAll",
   position: "relative",
   top: "unset",
   height: "$gr5",
@@ -40,7 +40,7 @@ const Primary = styled("div", {
     alignItems: "center",
     justifyContent: "space-between",
     flexGrow: "1",
-    transition: "$all",
+    transition: "$dcAll",
 
     [`& ${NavStyled}`]: {
       backgroundColor: "$gray6",

--- a/components/Header/Primary.tsx
+++ b/components/Header/Primary.tsx
@@ -13,7 +13,8 @@ import { useSearchState } from "@/context/search-context";
 
 const HeaderPrimary: React.FC = () => {
   const router = useRouter();
-  const isCollectionPage = router.pathname.includes("collection");
+  const isCollectionPage =
+    router.pathname.includes("collection") && router.query.id;
 
   const [searchActive, setSearchActive] = useState<boolean>(false);
 

--- a/components/Search/JumpTo.styled.ts
+++ b/components/Search/JumpTo.styled.ts
@@ -2,22 +2,50 @@ import { styled } from "@/stitches.config";
 
 /* eslint sort-keys: 0 */
 
+const HelperStyled = styled("div", {
+  position: "absolute",
+  top: "10px",
+  right: "$gr2",
+  padding: "$gr1 $gr3",
+  background: "transparent",
+  borderRadius: "1rem",
+  color: "$black50",
+  display: "flex",
+  alignItems: "center",
+  transition: "$dcAll",
+  fontFamily: "$northwesternSansRegular",
+
+  "& > svg": {
+    position: "relative",
+    display: "inline-block",
+    padding: "0",
+    marginLeft: "$gr1",
+    height: "$gr3",
+    width: "0",
+    color: "inherit",
+    transition: "$dcAll",
+  },
+});
+
 const JumpToListStyled = styled("ul", {
   position: "absolute",
   left: "0px",
   display: "block",
   margin: "0",
   padding: "0",
-  background: "white",
+  background: "$white",
   width: "100%",
-  fontSize: "$gr3",
+  fontSize: "$gr2",
   listStyle: "none",
   top: "50px",
   border: "1px solid $black10",
+  boxShadow: "3px 3px 8px #0003",
 });
 
 const JumpItem = styled("li", {
   position: "relative",
+  backgroundColor: "$gray6",
+  transition: "$dcAll",
 
   "& a": {
     display: "block",
@@ -26,30 +54,21 @@ const JumpItem = styled("li", {
     borderTopColor: "$black20",
     borderTopStyle: "solid",
     cursor: "pointer",
+    color: "$purple120",
   },
 
   "&[aria-selected='true']": {
     background: "$purple10",
-  },
-});
 
-const HelperStyled = styled("div", {
-  position: "absolute",
-  top: "$gr2",
-  right: "$gr2",
-  padding: "0 $gr2",
-  background: "$purple60",
-  color: "$white",
-  display: "flex",
-  alignItems: "center",
+    [`${HelperStyled}`]: {
+      color: "$purple10",
+      background: "$purple",
+      boxShadow: "2px 2px 5px #0001",
 
-  "& > svg": {
-    position: "relative",
-    display: "inline-block",
-    padding: "0",
-    marginLeft: "$gr1",
-    height: "$gr4",
-    width: "auto",
+      svg: {
+        width: "$gr3",
+      },
+    },
   },
 });
 

--- a/components/Shared/Expand/Expand.styled.ts
+++ b/components/Shared/Expand/Expand.styled.ts
@@ -6,7 +6,7 @@ import { Button } from "@nulib/design-system";
 const ExpandButton = styled(Button, {
   margin: "0 auto",
   opacity: "1",
-  transition: "$all",
+  transition: "$dcAll",
 });
 
 const ExpandEdge = styled("div", {
@@ -18,7 +18,7 @@ const ExpandEdge = styled("div", {
   padding: "$4 0 0",
   backgroundColor: "$white",
   background: "linear-gradient(to bottom, #fff0 0%, #fff 61.8%)",
-  transition: "$all",
+  transition: "$dcAll",
   overflow: "hidden",
 });
 
@@ -29,7 +29,7 @@ const ExpandContent = styled("div", {
 const ExpandStyled = styled("div", {
   position: "relative",
   overflow: "hidden",
-  transition: "$all",
+  transition: "$dcAll",
   backgroundColor: "transparent",
 
   variants: {

--- a/components/Shared/ExpandableList.styled.ts
+++ b/components/Shared/ExpandableList.styled.ts
@@ -42,7 +42,7 @@ const ExpandableListItemTrigger = styled(Accordion.Trigger, {
     marginRight: "$gr1",
     marginTop: "2px",
     transform: "rotate(-90deg)",
-    transition: "$all",
+    transition: "$dcAll",
     flexShrink: "0",
     flexGrow: "1",
   },

--- a/components/Shared/Switch.styled.ts
+++ b/components/Shared/Switch.styled.ts
@@ -25,17 +25,17 @@ const StyledSwitch = styled(Switch.Root, {
 
 const StyledThumb = styled(Switch.Thumb, {
   display: "block",
-  height: "calc(2rem - 12px)",
-  width: "calc(2rem - 12px)",
+  height: "calc(2rem - 14px)",
+  width: "calc(2rem - 14px)",
   backgroundColor: "$white",
   borderRadius: "100%",
   boxShadow: `2px 2px 5px #0001`,
-  transition: "$all",
-  transform: "translateX(6px)",
+  transition: "$dcAll",
+  transform: "translateX(7px)",
   willChange: "transform",
 
   '&[data-state="checked"]': {
-    transform: "translateX(calc(1.236rem + 6px))",
+    transform: "translateX(calc(1.236rem + 7px))",
   },
 });
 

--- a/styles/transitions.ts
+++ b/styles/transitions.ts
@@ -6,6 +6,7 @@ export const timingFunction = `cubic-bezier(0.3, 1, 0.3, 1)`;
 const transitions = {
   dcAll: `all ${seconds}s ${timingFunction}`,
   dcOpacity: `opacity ${seconds}s ${timingFunction}`,
+  dcWidth: `width ${seconds}s ${timingFunction}`,
 };
 
 export default transitions;


### PR DESCRIPTION
## What does this do?
This handles a few different issues.

- Addresses Filter button padding issue on the dropdown.
- Updates some transitions that never made the changeover from the `$all` to `$dcAll` token
- Fixes a small bug in the `/collections` list page where the Jump To search component was accidentally rendering there.
- Adjust styling of the Jump To after a quick conversation with @adamjarling 

## How should we review?
- Glance at search, scroll up and down, add some facets, remove some facets
- Glance at `/collections`, attempt a search
- Glance at a Collection page, attempt a search