### PR TITLE
Add Rights Statement facet link to Work metadata

### DIFF
--- a/lib/constants/works.ts
+++ b/lib/constants/works.ts
@@ -22,6 +22,10 @@ const FACETS_WORK_LINK: FacetsWorkLink[] = [
     param: "language",
   },
   {
+    label: "Rights Statement",
+    param: "rightsStatement",
+  },
+  {
     label: "Series",
     param: "series",
   },


### PR DESCRIPTION
## What does this do?
Adds the new Rights Statement metadata as a faceted link

![image](https://user-images.githubusercontent.com/3020266/213540454-500feae6-340a-4bc0-83d8-da10c445e7e7.png)
