### PR TITLE
Adjust Nectar metadata formatting to include none search metadata.

### DIFF
--- a/components/Work/Metadata.styled.ts
+++ b/components/Work/Metadata.styled.ts
@@ -2,12 +2,30 @@ import { Metadata } from "@samvera/nectar-iiif";
 import { linkStyling } from "@/components/Shared/LinkStyled";
 import { styled } from "@/stitches.config";
 
+/* eslint sort-keys: 0 */
+
 const LinkItemStyled = styled("div", {
+  position: "relative",
+  zIndex: "0",
+  paddingLeft: "$gr4",
+  marginTop: "$gr1",
+
+  "&::before": {
+    display: "block",
+    content: "",
+    width: "$gr1",
+    height: "$gr1",
+    borderRadius: "100%",
+    backgroundColor: "$purple10",
+    position: "absolute",
+    top: "10px",
+    left: "$gr1",
+  },
+
   [`& a`]: {
     ...linkStyling,
     display: "inline-block",
     fontFamily: "$northwesternSansRegular",
-    marginBottom: "$gr1",
   },
 });
 

--- a/components/Work/Metadata.test.tsx
+++ b/components/Work/Metadata.test.tsx
@@ -1,6 +1,5 @@
-import WorkMetadata, { ValueAsSearchLink } from "@/components/Work/Metadata";
+import WorkMetadata, { ValueAsListItem } from "@/components/Work/Metadata";
 import { render, screen, within } from "@/test-utils";
-import { FACETS_WORK_LINK } from "@/lib/constants/works";
 import { MetadataItem } from "@iiif/presentation-3";
 import { manifest } from "@/mocks/sample-work-image";
 
@@ -24,11 +23,15 @@ describe("WorkMetadata component", () => {
     });
   });
 
-  FACETS_WORK_LINK;
-
   it("renders metadata value as custom link pattern", () => {
-    render(<ValueAsSearchLink param="foo" value="bar" />);
+    render(<ValueAsListItem searchParam="foo" value="bar" />);
     const link = screen.getByRole("link");
     expect(link.getAttribute("href")).toContain(`/search?foo=bar`);
+  });
+
+  it("renders metadata value as span if no searchParam is provided", () => {
+    render(<ValueAsListItem value="bar" />);
+    const value = screen.getByText("bar");
+    expect(value).toContainHTML(`<span>bar</span>`);
   });
 });

--- a/components/Work/Metadata.tsx
+++ b/components/Work/Metadata.tsx
@@ -3,45 +3,49 @@ import {
   MetadataStyled,
 } from "@/components/Work/Metadata.styled";
 import { DC_URL } from "@/lib/constants/endpoints";
-import { FACETS_WORK_LINK } from "@/lib/constants/works";
 import Link from "next/link";
 import { MetadataItem } from "@iiif/presentation-3";
+import { WORK_METADATA_LABELS } from "@/lib/constants/works";
 
 interface WorkMetadataProps {
   metadata: MetadataItem[];
 }
 
-interface ValueAsSearchLinkProps {
-  param: string;
+interface ValueAsListItemProps {
+  searchParam?: string;
   value?: string;
 }
 
-export const ValueAsSearchLink: React.FC<ValueAsSearchLinkProps> = ({
-  param,
+export const ValueAsListItem: React.FC<ValueAsListItemProps> = ({
+  searchParam,
   value,
 }) => {
   if (!value) return <></>;
-  const search = `${DC_URL}/search?${param}=`;
+  const search = `${DC_URL}/search?${searchParam}=`;
   return (
     <LinkItemStyled>
-      <Link href={search.concat(encodeURIComponent(value))}>
-        <a>{value}</a>
-      </Link>
+      {searchParam ? (
+        <Link href={search.concat(encodeURIComponent(value))}>
+          <a>{value}</a>
+        </Link>
+      ) : (
+        <span dangerouslySetInnerHTML={{ __html: value }} />
+      )}
     </LinkItemStyled>
   );
 };
 
 const WorkMetadata: React.FC<WorkMetadataProps> = ({ metadata }) => {
-  const customValues = FACETS_WORK_LINK.map((value) => {
+  const formattedValues = WORK_METADATA_LABELS.map((value) => {
     return {
-      Content: <ValueAsSearchLink param={value.param} />,
+      Content: <ValueAsListItem searchParam={value.searchParam} />,
       matchingLabel: { none: [value.label] },
     };
   });
 
   return (
     <MetadataStyled
-      customValueContent={customValues}
+      customValueContent={formattedValues}
       customValueDelimiter=""
       data-testid="metadata"
       metadata={metadata}

--- a/lib/constants/works.ts
+++ b/lib/constants/works.ts
@@ -1,46 +1,94 @@
-import { FacetsWorkLink } from "@/types/components/works";
+import { WorkMetadata } from "@/types/components/works";
 
-const FACETS_WORK_LINK: FacetsWorkLink[] = [
+const WORK_METADATA_LABELS: WorkMetadata[] = [
+  {
+    label: "Abstract",
+  },
+  {
+    label: "Alternate Title",
+  },
+  {
+    label: "Caption",
+  },
   {
     label: "Contributor",
-    param: "contributor",
+    searchParam: "contributor",
   },
   {
     label: "Creator",
-    param: "creator",
+    searchParam: "creator",
+  },
+  {
+    label: "Cultural Context",
+  },
+  {
+    label: "Date",
   },
   {
     label: "Department",
-    param: "libraryDepartment",
+    searchParam: "libraryDepartment",
   },
   {
     label: "Genre",
-    param: "genre",
+    searchParam: "genre",
+  },
+  {
+    label: "Keyword",
   },
   {
     label: "Language",
-    param: "language",
+    searchParam: "language",
+  },
+  {
+    label: "Location",
+  },
+  {
+    label: "Notes",
+  },
+  {
+    label: "Provenance",
+  },
+  {
+    label: "Publisher",
+  },
+  {
+    label: "Related Material",
+  },
+  {
+    label: "Related URL",
+  },
+  {
+    label: "Rights Holder",
   },
   {
     label: "Rights Statement",
-    param: "rightsStatement",
+    searchParam: "rightsStatement",
+  },
+  {
+    label: "Scope and Contents",
   },
   {
     label: "Series",
-    param: "series",
+    searchParam: "series",
+  },
+  {
+    label: "Source",
   },
   {
     label: "Style Period",
-    param: "stylePeriod",
+    searchParam: "stylePeriod",
   },
   {
     label: "Subject",
-    param: "subject",
+    searchParam: "subject",
+  },
+  {
+    label: "Table of Contents",
   },
   {
     label: "Technique",
-    param: "technique",
+    searchParam: "technique",
   },
 ];
 
-export { FACETS_WORK_LINK };
+export { WORK_METADATA_LABELS };

--- a/types/components/works.ts
+++ b/types/components/works.ts
@@ -56,9 +56,9 @@ export interface Subject {
   role: string;
 }
 
-export interface FacetsWorkLink {
+export interface WorkMetadata {
   label: string;
-  param: string;
+  searchParam?: string;
 }
 
 export type PreservationLevelStatus = "Level 1" | "Level 2" | "Level 3";


### PR DESCRIPTION
## What does this do?

![image](https://user-images.githubusercontent.com/7376450/213549111-35bda14c-ed2a-4014-bd73-43f5c5abbe7a.png)

This reworks some previously completed code used for customizing Links to faceting from metadata to wrap all values in a stylized bulleted `div`. If the `label` also has  `searchParam`, a `next/link` will wrap the metadata value. Otherwise a `span` will.

### Notes
- I use the `dangerouslySetInnerHTML` prop to render values as some values do contain HTML (Related URL)
- I'm not entirely in love with this approach as it does require curated constants for formatting. Long-term, we may want to look into better extending out some options relating to `customValueContent` in the Nectar metadata component so that this is not required.