### PR TITLE
Format number util for large numbers to read as 12,345 etc...

### DIFF
--- a/components/Collection/Tabs/Metadata.tsx
+++ b/components/Collection/Tabs/Metadata.tsx
@@ -2,6 +2,7 @@ import { ApiResponseBucket } from "@/types/api/response";
 import { GroupedList } from "@/components/Collection/Tabs/Metadata.styled";
 import Heading from "@/components/Heading/Heading";
 import React from "react";
+import { formatNumber } from "@/lib/utils/count-helpers";
 import { useRouter } from "next/router";
 
 interface CollectionTabsMetadataProps {
@@ -41,7 +42,7 @@ const CollectionTabsMetadata: React.FC<CollectionTabsMetadataProps> = ({
               {grouped[letter].map(({ doc_count, key }) => (
                 <li key={key}>
                   <a onClick={() => handleMetadataClick(key)}>
-                    {key} ({doc_count})
+                    {key} ({formatNumber(doc_count)})
                   </a>
                 </li>
               ))}

--- a/components/Search/PaginationAltCounts.tsx
+++ b/components/Search/PaginationAltCounts.tsx
@@ -5,6 +5,7 @@ import {
 } from "@/components/Search/Pagination.styled";
 import { Button } from "@nulib/design-system";
 import { Pagination as PaginationShape } from "@/types/api/response";
+import { pluralize } from "@/lib/utils/count-helpers";
 import { useRouter } from "next/router";
 
 interface PaginationProps {
@@ -38,7 +39,7 @@ const PaginationAltCounts: React.FC<PaginationProps> = ({ pagination }) => {
     >
       <Results data-testid="results">
         Showing <span>{startCount}</span> to <span>{endCount}</span> of{" "}
-        <span>{total_hits}</span> results
+        {pluralize("result", total_hits)}
       </Results>
 
       <NavWrapper>

--- a/components/Shared/WorkCount/WorkCount.tsx
+++ b/components/Shared/WorkCount/WorkCount.tsx
@@ -5,6 +5,7 @@ import {
   WorkCountTypes as Types,
   WorkCountStyled,
 } from "@/components/Shared/WorkCount/WorkCount.styled";
+import { formatNumber, pluralize } from "@/lib/utils/count-helpers";
 import React from "react";
 
 export interface WorkCountProps {
@@ -22,9 +23,7 @@ const WorkCount: React.FC<WorkCountProps> = ({
 
   return (
     <WorkCountStyled>
-      <Total data-testid="work-count-total">
-        {total} {total !== 1 ? "Works" : "Work"}
-      </Total>
+      <Total data-testid="work-count-total">{pluralize("Work", total)}</Total>
       <Types>
         {image ? (
           <Type
@@ -32,7 +31,7 @@ const WorkCount: React.FC<WorkCountProps> = ({
             data-testid="work-count-type"
             data-type="image"
           >
-            {image} <IconImage />
+            {formatNumber(image)} <IconImage />
           </Type>
         ) : (
           <></>
@@ -43,7 +42,7 @@ const WorkCount: React.FC<WorkCountProps> = ({
             data-testid="work-count-type"
             data-type="audio"
           >
-            {audio} <IconAudio />
+            {formatNumber(audio)} <IconAudio />
           </Type>
         ) : (
           <></>
@@ -54,7 +53,7 @@ const WorkCount: React.FC<WorkCountProps> = ({
             data-testid="work-count-type"
             data-type="video"
           >
-            {video} <IconVideo />
+            {formatNumber(video)} <IconVideo />
           </Type>
         ) : (
           <></>

--- a/lib/utils/count-helpers.test.ts
+++ b/lib/utils/count-helpers.test.ts
@@ -1,0 +1,26 @@
+import { formatNumber } from "@/lib/utils/count-helpers";
+import { pluralize } from "@/lib/utils/count-helpers";
+
+describe("Number Format helper util", () => {
+  it("renders formatted numbers", () => {
+    expect(formatNumber(23)).toEqual("23");
+    expect(formatNumber(123)).toEqual("123");
+    expect(formatNumber(1234)).toEqual("1,234");
+    expect(formatNumber(12345)).toEqual("12,345");
+    expect(formatNumber(123456)).toEqual("123,456");
+    expect(formatNumber(1234567)).toEqual("1,234,567");
+  });
+});
+
+describe("Pluralize text helper", () => {
+  it("pluralizes values accordingly", () => {
+    /** Combo text and count scenario */
+    expect(pluralize("zebra", 0)).toEqual("0 zebras");
+    expect(pluralize("zebra", 1)).toEqual("1 zebra");
+    expect(pluralize("zebra", 6)).toEqual("6 zebras");
+
+    /** Extended suffix word */
+    expect(pluralize("fox", 6, "es")).toEqual("6 foxes");
+    expect(pluralize("fox", 6666, "es")).toEqual("6,666 foxes");
+  });
+});

--- a/lib/utils/count-helpers.ts
+++ b/lib/utils/count-helpers.ts
@@ -1,0 +1,14 @@
+const formatNumber = (number: number): string => {
+  if (!number && number !== 0) return "";
+  return number.toLocaleString(undefined);
+};
+
+const pluralize = (noun: string, count: number, suffix = "s") => {
+  if (!count && count !== 0) {
+    console.error("Missing count argument to pluralize()");
+    return "";
+  }
+  return `${formatNumber(count)} ${noun}${count !== 1 ? suffix : ""}`;
+};
+
+export { formatNumber, pluralize };

--- a/pages/collections/[id].tsx
+++ b/pages/collections/[id].tsx
@@ -15,6 +15,7 @@ import {
   TabsList,
   TabsTrigger,
 } from "@/components/Collection/NavTabs.styled";
+import { formatNumber, pluralize } from "@/lib/utils/count-helpers";
 import {
   getCollection,
   getCollectionIds,
@@ -55,6 +56,12 @@ const Collection: NextPage<CollectionProps> = ({
   if (!collection) return null;
 
   const { description, id } = collection;
+  const {
+    totalAudio = 0,
+    totalImage = 0,
+    totalVideo = 0,
+    totalWorks = 0,
+  } = workTypeCounts;
 
   return (
     <>
@@ -79,20 +86,20 @@ const Collection: NextPage<CollectionProps> = ({
           <Container>
             <Facts>
               <Facts.Item
-                big={workTypeCounts?.totalWorks}
-                small="Total Works"
+                big={formatNumber(totalWorks)}
+                small={pluralize("Total Work", totalWorks)}
               />
               <Facts.Item
-                big={workTypeCounts?.totalImage}
-                small="Image Works"
+                big={formatNumber(totalImage)}
+                small={pluralize("Image Work", totalImage)}
               />
               <Facts.Item
-                big={workTypeCounts?.totalVideo}
-                small="Video Works"
+                big={formatNumber(totalVideo)}
+                small={pluralize("Video Work", totalVideo)}
               />
               <Facts.Item
-                big={workTypeCounts?.totalAudio}
-                small="Audio Works"
+                big={formatNumber(totalAudio)}
+                small={pluralize("Audio Works", totalAudio)}
               />
               <Facts.Item big="Across" small="[Count here] Boxes" />
             </Facts>

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -17,6 +17,7 @@ import { buildDataLayer } from "@/lib/ga/data-layer";
 import { buildQuery } from "@/lib/queries/builder";
 import { loadDefaultStructuredData } from "@/lib/json-ld";
 import { parseUrlFacets } from "@/lib/utils/facet-helpers";
+import { pluralize } from "@/lib/utils/count-helpers";
 import { useRouter } from "next/router";
 
 type RequestState = {
@@ -102,6 +103,7 @@ const SearchPage: NextPage = () => {
   }
 
   const { data: apiData, error, loading } = requestState;
+  const totalResults = requestState.data?.pagination.total_hits;
 
   return (
     <>
@@ -129,7 +131,7 @@ const SearchPage: NextPage = () => {
             {apiData && (
               <>
                 <Results>
-                  {requestState.data?.pagination.total_hits} results
+                  {totalResults && pluralize("result", totalResults)}
                 </Results>
                 <Grid data={apiData.data} info={apiData.info} />
                 <PaginationAltCounts pagination={apiData.pagination} />


### PR DESCRIPTION
## What does this do?
Introduces a helper function to format `12345` like:

```js
formatNumber(12345);  // 12,345
```

and a helper function to display nouns and suffixes properly.

```js
pluralize("bear", 3);  // 3 bears
```