### PR TITLE
Address Safari CSS anomalies.

### DIFF
--- a/components/Facets/Facet/GenericFacet.styled.ts
+++ b/components/Facets/Facet/GenericFacet.styled.ts
@@ -10,6 +10,7 @@ const StyledGenericFacet = styled("div", {
   [`${StyledHeading}`]: {
     margin: "0 0 1rem",
     fontFamily: "$northwesternDisplayBold",
+    fontSize: "$gr5",
     fontWeight: "400",
   },
 });
@@ -73,7 +74,7 @@ const OptionCount = styled("span", {
 });
 
 const OptionText = styled("span", {
-  color: "$black",
+  color: "$black80",
   fontFamily: "$northwesternSansRegular",
 });
 
@@ -90,8 +91,6 @@ const Options = styled("ul", {
 
     label: {
       cursor: "pointer",
-      color: "$black",
-      fontFamily: "$northwesternSansRegular",
       lineHeight: "1.382em",
       flexShrink: "1",
       flexGrow: "0",
@@ -103,10 +102,13 @@ const Options = styled("ul", {
       [`&[data-selected=true]`]: {
         color: "$black",
         fontFamily: "$northwesternSansBold",
-        fontWeight: "700",
 
         [`${OptionCount}`]: {
           fontWeight: "400",
+        },
+
+        [`${OptionText}`]: {
+          fontFamily: "$northwesternSansBold",
         },
       },
     },

--- a/components/Facets/Facets.styled.ts
+++ b/components/Facets/Facets.styled.ts
@@ -9,6 +9,8 @@ const StyledFacets = styled("div", {
   justifyContent: "space-between",
   margin: "1.618rem 0",
   position: "relative",
+  left: "0",
+  transition: "$dcAll",
   zIndex: "1",
 
   [`& ${WorkTypeWrapper}`]: {
@@ -37,6 +39,8 @@ const Wrapper = styled("div", {
 
   "&[data-filter-fixed='true']": {
     margin: "1.618rem 0",
+    flexGrow: "0",
+    flexShrink: "1",
     height: "38px",
 
     [`& ${WorkTypeWrapper}`]: {
@@ -47,7 +51,11 @@ const Wrapper = styled("div", {
     [`& ${StyledFacets}`]: {
       position: "fixed",
       top: "50px",
+      left: "50%",
       zIndex: "1",
+      transform: "translate(-50%)",
+      backfaceVisibility: "hidden",
+      webkitFontSmoothing: "subpixel-antialiased",
     },
 
     [`& ${StyledToggle}`]: {

--- a/components/Facets/Filter/Filter.styled.ts
+++ b/components/Facets/Filter/Filter.styled.ts
@@ -12,28 +12,28 @@ const FilterActivate = styled(Dialog.Trigger, {
   alignItems: "center",
   alignContent: "center",
   cursor: "pointer",
-  backgroundColor: "$white",
+  backgroundColor: "$purple",
   border: "0",
-  color: "$black",
+  color: "$white",
   fontFamily: "$northwesternSansBold",
   fontSize: "$gr3",
   borderRadius: "50px",
-  transition: "all 200ms ease-in-out",
+  transition: "$dcAll",
   padding: "0 $gr3 0 $gr1",
 
   [`& ${IconStyled}`]: {
-    color: "$black50",
-    fill: "$black50",
+    color: "$purple60",
+    fill: "$purple60",
   },
 
   "&:hover": {
-    backgroundColor: "$purple",
+    backgroundColor: "$purple120",
     color: "$white",
-    boxShadow: "2px 2px 5px #0002",
+    boxShadow: "2px 2px 2px #0002",
 
     [`& ${IconStyled}`]: {
-      color: "$purple30",
-      fill: "$purple30",
+      color: "$white",
+      fill: "$white",
     },
   },
 });
@@ -41,18 +41,17 @@ const FilterActivate = styled(Dialog.Trigger, {
 const FilterFloating = styled("div", {
   height: `calc($gr3 * 2)`,
   display: "flex",
-  backgroundColor: "$white",
+  backgroundColor: "$purple30",
   position: "relative",
-  borderRadius: "50px",
   boxShadow: "2px 2px 5px #0002",
-  transition: "all 200ms ease-in-out",
+  borderRadius: "50px",
+  transition: "$dcAll",
 
   [`& ${FilterActivate}`]: {
-    boxShadow: "1px 1px 2px #0002",
+    boxShadow: "2px 2px 5px #0002",
   },
 
   "&:hover": {
-    backgroundColor: "$purple10",
     boxShadow: "2px 2px 5px #0004",
   },
 });
@@ -142,12 +141,12 @@ const FilterHeader = styled("header", {
   backgroundColor: "$white",
 
   h2: {
-    fontSize: "1rem",
+    fontSize: "$gr4",
     lineHeight: "1.5rem",
     padding: "0",
     margin: "0",
     color: "$black50",
-    fontFamily: "$northwesternDisplayBold",
+    fontFamily: "$northwesternDisplayRegular",
     fontWeight: "400",
   },
 
@@ -159,13 +158,14 @@ const FilterHeader = styled("header", {
 
   [`& ${FilterClose}`]: {
     display: "flex",
-    height: "1.5rem",
-    width: "1.5rem",
+    height: "$gr4",
+    width: "$gr4",
     justifyContent: "center",
     textAlign: "center",
     alignItems: "center",
     cursor: "pointer",
-    backgroundColor: "transparent",
+    backgroundColor: "$gray6",
+    boxShadow: "inset 1px 1px 2px #0002",
     zIndex: "1",
     border: "none",
     borderRadius: "50%",
@@ -174,15 +174,18 @@ const FilterHeader = styled("header", {
     stroke: "$black50",
     transition: "all 200ms ease-in-out",
     flexShrink: "0",
+    padding: "$gr1",
 
     "&:hover": {
       backgroundColor: "$brightRed",
+      boxShadow: "3px 3px 8px #0002",
       fill: "$white",
       stroke: "$white",
     },
 
     svg: {
-      transition: "all 200ms ease-in-out",
+      width: "100%",
+      height: "100%",
       fill: "inherit",
       stroke: "inherit",
     },

--- a/components/Facets/Filter/GroupList.styled.ts
+++ b/components/Facets/Filter/GroupList.styled.ts
@@ -40,7 +40,7 @@ const GroupToggle = styled(Accordion.Trigger, {
   borderLeft: "0",
   color: "$black50",
   cursor: "pointer",
-  transition: "background 100ms ease-in-out",
+  transition: "$dcAll",
   borderRadius: "3px",
   borderTopLeftRadius: "0",
   borderBottomLeftRadius: "0",
@@ -102,7 +102,6 @@ const ItemToggle = styled(Tabs.Trigger, {
 
   ["&[aria-selected=true]"]: {
     fontFamily: "$northwesternSansBold",
-    fontWeight: "700",
 
     "&:hover, &:focus": {
       color: "$black",

--- a/components/Facets/Filter/Preview.styled.ts
+++ b/components/Facets/Filter/Preview.styled.ts
@@ -53,6 +53,7 @@ const PreviewList = styled("ul", {
 const StyledPreview = styled("div", {
   [`& ${StyledHeading}`]: {
     fontFamily: "$northwesternDisplayBold",
+    fontSize: "$gr5",
     fontWeight: "400",
     padding: "0 $gr4",
   },

--- a/components/Facets/UserFacets/UserFacets.styled.ts
+++ b/components/Facets/UserFacets/UserFacets.styled.ts
@@ -17,15 +17,15 @@ const DropdownToggle = styled(Dropdown.Trigger, {
   alignItems: "center",
   fontWeight: "700",
   cursor: "pointer",
-  transition: "all 200ms ease-in-out",
+  transition: "$dcAll",
 
   svg: {
-    width: "$gr3",
-    marginRight: "0.25rem",
-    marginBottom: "-2px",
-    color: "$black50",
+    width: "$gr4",
+    marginBottom: "-3px",
+    color: "$purple120",
     transform: "rotate(0deg)",
-    transition: "all 200ms ease-in-out",
+    transition: "$dcAll",
+    padding: "$gr1",
   },
 
   span: {
@@ -41,7 +41,7 @@ const DropdownToggle = styled(Dropdown.Trigger, {
     height: "19px",
     borderRadius: "50%",
     marginTop: "-$gr4",
-    marginRight: "-$gr3",
+    marginRight: "calc(-$gr3 + 4px)",
   },
 
   [`&:hover`]: {
@@ -57,7 +57,7 @@ const DropdownToggle = styled(Dropdown.Trigger, {
   [`&[aria-expanded="true"]`]: {
     svg: {
       transform: "rotate(180deg) !important",
-      marginBottom: "-3px",
+      marginBottom: "-1px",
     },
   },
 });
@@ -71,21 +71,24 @@ const Icon = styled("span", {
   textAlign: "center",
   alignItems: "center",
   cursor: "pointer",
-  backgroundColor: "transparent",
+  backgroundColor: "$gray6",
+  boxShadow: "inset 1px 1px 2px #0002",
   zIndex: "1",
-  border: "1px solid $black10",
   borderRadius: "50%",
   marginRight: "$gr2",
   fill: "$black50",
+  color: "$black50",
   stroke: "$black50",
-  transition: "all 200ms ease-in-out",
+  transition: "$dcAll",
   flexShrink: "0",
+  objectFit: "contain",
 
   svg: {
-    transition: "all 200ms ease-in-out",
+    widht: "100%",
+    height: "100%",
     fill: "inherit",
     stroke: "inherit",
-    padding: "4px",
+    padding: "$gr1",
   },
 });
 
@@ -94,21 +97,24 @@ const Text = styled("div", {
   flexDirection: "column",
   textAlign: "left",
   color: "$black",
-  paddingRight: "1rem",
-  fontSize: "15px",
+  paddingRight: "$gr2",
+  fontSize: "$gr3",
   whiteSpace: "nowrap",
   overflow: "hidden",
   textOverflow: "ellipsis",
 
   strong: {
-    fontFamily: "$northwesternDisplayBold",
+    fontFamily: "$northwesternSansBold",
     fontWeight: "400",
   },
 
   span: {
+    display: "block",
     color: "$black50",
-    fontSize: "12px",
-    fontFamily: "$northwesternDisplayBook",
+    marginTop: "2px",
+    fontSize: "$gr2",
+    fontWeight: "400",
+    fontFamily: "$northwesternSansRegular",
   },
 });
 
@@ -134,8 +140,21 @@ const StyledValue = styled("button", {
 const ValueWrapper = styled("div", {
   display: "flex",
   flexWrap: "wrap",
+
+  variants: {
+    isModal: {
+      true: {
+        marginBottom: "$gr3",
+
+        [`& ${StyledValue}`]: {
+          marginBottom: "$gr2",
+        },
+      },
+    },
+  },
+
   [`& ${StyledValue}`]: {
-    margin: "0 1rem 1rem 0",
+    marginBottom: "$gr1",
   },
 });
 
@@ -145,10 +164,10 @@ const DropdownContent = styled(Dropdown.Content, {
     backgroundColor: "$white",
     boxShadow: "3px 3px 8px #0002",
     borderRadius: "25px",
-    minWidth: "147px",
+    minWidth: "154px",
     maxWidth: "80vw",
     transition: "all 200ms ease-in-out",
-    marginTop: "5px",
+    marginTop: "$gr1",
 
     [`&:hover`]: {
       boxShadow: "3px 3px 8px #0004",

--- a/components/Facets/UserFacets/UserFacets.tsx
+++ b/components/Facets/UserFacets/UserFacets.tsx
@@ -4,6 +4,7 @@ import {
   DropdownToggle,
   ValueWrapper,
 } from "./UserFacets.styled";
+import React, { useRef } from "react";
 import { useEffect, useState } from "react";
 import FacetsCurrentUserValue from "@/components/Facets/UserFacets/Value";
 import { IconChevronDown } from "@/components/Shared/SVG/Icons";
@@ -11,6 +12,7 @@ import { UrlFacets } from "@/types/context/filter-context";
 import { getFacetById } from "@/lib/utils/facet-helpers";
 import { useFilterState } from "@/context/filter-context";
 import { useRouter } from "next/router";
+import { useSearchState } from "@/context/search-context";
 
 interface FacetsCurrentUserProps {
   screen: "modal" | "search";
@@ -28,8 +30,15 @@ const FacetsCurrentUser: React.FC<FacetsCurrentUserProps> = ({
   urlFacets,
 }) => {
   const [currentOptions, setCurrentOptions] = useState<CurrentFacet[]>([]);
+  const [isOpen, setIsOpen] = useState(false);
   const router = useRouter();
   const { filterDispatch, filterState } = useFilterState();
+  const {
+    searchState: { searchFixed },
+  } = useSearchState();
+
+  const dropdownRef = useRef<HTMLButtonElement>(null);
+  const handleOpenChange = (status: boolean) => setIsOpen(status);
 
   let facets: UrlFacets | undefined;
 
@@ -46,6 +55,13 @@ const FacetsCurrentUser: React.FC<FacetsCurrentUserProps> = ({
       );
       break;
   }
+
+  useEffect(() => {
+    if (!searchFixed) {
+      dropdownRef?.current?.blur();
+      handleOpenChange(searchFixed);
+    }
+  }, [searchFixed]);
 
   useEffect(() => {
     if (!facets) return;
@@ -111,16 +127,26 @@ const FacetsCurrentUser: React.FC<FacetsCurrentUserProps> = ({
    */
 
   return (
-    <ValueWrapper data-testid="facet-user-component">
+    <ValueWrapper
+      data-testid="facet-user-component"
+      isModal={screen === "modal"}
+    >
       {screen === "search" && (
-        <Dropdown.Root modal={false}>
-          <DropdownToggle data-testid="facet-user-component-popover-toggle">
+        <Dropdown.Root
+          modal={false}
+          open={isOpen}
+          onOpenChange={handleOpenChange}
+        >
+          <DropdownToggle
+            data-testid="facet-user-component-popover-toggle"
+            ref={dropdownRef}
+          >
             <IconChevronDown />
             <span>{currentOptions.length}</span>
           </DropdownToggle>
           <DropdownContent
             align="start"
-            alignOffset={-95}
+            alignOffset={-97}
             data-testid="facet-user-component-popover-content"
           >
             {currentFacets}

--- a/components/Facets/WorkType/WorkType.styled.ts
+++ b/components/Facets/WorkType/WorkType.styled.ts
@@ -32,7 +32,7 @@ const StyledWorkType = styled("ul", {
       height: "2rem",
       zIndex: "1",
       padding: "0",
-      transition: "all 200ms ease-in-out",
+      transition: "$dcAll",
       color: "$black50",
 
       [`&[aria-checked="true"]`]: {
@@ -64,7 +64,7 @@ const Highlight = styled("div", {
   top: "0",
   borderRadius: "1rem",
   height: "2rem",
-  transition: "all 100ms ease-in-out",
+  transition: "$dcAll",
   zIndex: "0",
 });
 

--- a/components/Grid/Grid.styled.ts
+++ b/components/Grid/Grid.styled.ts
@@ -15,6 +15,7 @@ const GridItem = styled("div", {
         backgroundColor: "$purple10",
         outline: "2px solid $purple60",
         boxShadow: "2px 2px 5px #0003",
+        borderRadius: "3px !important",
       },
     },
   },

--- a/components/Hero/Hero.styled.ts
+++ b/components/Hero/Hero.styled.ts
@@ -18,8 +18,8 @@ const HeroActions = styled("div", {
 const HeroStyled = styled("div", {
   position: "absolute",
   width: "100%",
-  height: "calc(100% + 156px)",
-  marginTop: "-156px",
+  height: "calc(100% + 161px)",
+  marginTop: "-161px",
   zIndex: "0",
   backgroundColor: "$black",
 


### PR DESCRIPTION
## What does this do...

### Before
![image](https://user-images.githubusercontent.com/7376450/213784907-d4f86bfb-9d4c-4b04-aa45-c66ca3e45bb0.png)

### After
![image](https://user-images.githubusercontent.com/7376450/213784952-46f56178-a5f6-4288-a88f-bb0b38cde5a1.png)

This does quite a bit more that just address SVG issues related to safari. While auditing, I noticed a couple of other things that I decided to address as well.

- Addresses SVGs on Filter Modal to now show properly.
- Addresses Safari transition bug on the Filter button when scrolling where the Filter button did not center properly
- Addresses Safari font rendering where Safari would be VERY bold if Northwestern brand fonts were used in conjunection with `font-weight: 700` 
- Addresses a strange fixed positioning bug where the Dropdown of UserFacets on the Filter button if it is currently opened and the use scrolled to the top by forcing the dropdown to close
- General styling updates!

## How should we review?

-  Tryout the search page in Safari and your preferred browser
- Toggle filter, add a few facets, scroll around, in general just play with things
- Things should like a bit neater in general should be much smoother