### PR TITLE
3484 homepage updates

### DIFF
--- a/components/Grid/Feature.tsx
+++ b/components/Grid/Feature.tsx
@@ -25,7 +25,7 @@ const GridFeature: React.FC<GridFeatureProps> = ({ data = [] }) => {
     <GridFeatureStyled>
       <GridFeatureItems>
         <GridFeaturePrimary>
-          {primary && <GridItem item={primary} />}
+          {primary && <GridItem item={primary} isFeatured={true} />}
         </GridFeaturePrimary>
         <GridFeatureSecondary>
           {secondary.map((item: SearchShape) => (

--- a/components/Grid/Item.test.tsx
+++ b/components/Grid/Item.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from "@/test-utils";
+import GridItem from "./Item";
+import { SearchShape } from "@/types/api/response";
+
+const mockItem = {
+  api_model: "Work",
+  id: "370f880c-9083-4d9b-9129-45a924522d11",
+  iiif_manifest:
+    "https://dcapi.rdc-staging.library.northwestern.edu/api/v2/works/370f880c-9083-4d9b-9129-45a924522d11?as=iiif",
+  representative_file_set: {
+    aspect_ratio: 1.48565,
+    id: "b92874a0-72b7-4479-979e-38860c412a13",
+    url: "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/b92874a0-72b7-4479-979e-38860c412a13",
+  },
+  thumbnail:
+    "https://dcapi.rdc-staging.library.northwestern.edu/api/v2/works/370f880c-9083-4d9b-9129-45a924522d11/thumbnail",
+
+  title:
+    "Andrews Gospel Singers, Richmond Festival of the Arts folk song concert",
+  visibility: "Public",
+  work_type: "Image",
+};
+
+describe("GridItem component", () => {
+  it("renders the item, link and image", () => {
+    render(<GridItem item={mockItem as SearchShape} />);
+
+    expect(screen.getByTestId("grid-item")).toBeInTheDocument();
+    expect(screen.getByTestId("grid-item-link")).toBeInTheDocument();
+    expect(screen.getByAltText(mockItem.title)).toBeInTheDocument();
+    expect(screen.queryByAltText("booya")).not.toBeInTheDocument();
+  });
+
+  it("renders the expected default image source", () => {
+    render(<GridItem item={mockItem as SearchShape} />);
+
+    expect(screen.getByAltText(mockItem.title)).toHaveAttribute(
+      "src",
+      mockItem.thumbnail
+    );
+  });
+
+  it("renders the full resolution image source is featured", () => {
+    render(<GridItem item={mockItem as SearchShape} isFeatured />);
+
+    expect(screen.getByAltText(mockItem.title)).not.toHaveAttribute(
+      "src",
+      mockItem.thumbnail
+    );
+    expect(screen.getByAltText(mockItem.title)).toHaveAttribute(
+      "src",
+      "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/b92874a0-72b7-4479-979e-38860c412a13/square/512,/0/default.jpg"
+    );
+  });
+});

--- a/components/Grid/Item.tsx
+++ b/components/Grid/Item.tsx
@@ -1,5 +1,4 @@
 import { useContext, useEffect, useState } from "react";
-import { DCAPI_ENDPOINT } from "@/lib/constants/endpoints";
 import Figure from "@/components/Figure/Figure";
 import { GridItem as ItemStyled } from "@/components/Grid/Grid.styled";
 import Link from "next/link";
@@ -8,11 +7,11 @@ import { UserContext } from "@/pages/_app";
 
 interface GridItemProps {
   item: SearchShape;
+  isFeatured?: boolean;
 }
 
-const GridItem: React.FC<GridItemProps> = ({ item }) => {
+const GridItem: React.FC<GridItemProps> = ({ item, isFeatured }) => {
   const [urlPath, setUrlPath] = useState<string>();
-  const [endpointPath, setEndpointPath] = useState<string>();
   const [supplementalInfo, setSupplementalInfo] = useState<string>();
   const userContext = useContext(UserContext);
 
@@ -26,32 +25,29 @@ const GridItem: React.FC<GridItemProps> = ({ item }) => {
     switch (item.api_model) {
       case "Work":
         setUrlPath("/items");
-        setEndpointPath("/works");
         setSupplementalInfo(item.work_type);
         return;
       case "Collection":
         setUrlPath("/collections");
-        setEndpointPath("/collections");
         return;
       default:
         setUrlPath("/items");
-        setEndpointPath("/works");
         setSupplementalInfo(item.work_type);
         return;
     }
   }, [item]);
 
-  if (!endpointPath) return <></>;
-
   return (
-    <ItemStyled key={item.id} data-item-id={item.id}>
+    <ItemStyled key={item.id} data-item-id={item.id} data-testid="grid-item">
       <Link href={`${urlPath}/${item.id}`}>
-        <a>
+        <a data-testid="grid-item-link">
           <Figure
             data={{
               aspectRatio: item.representative_file_set.aspect_ratio,
               isRestricted: isRestricted(item),
-              src: `${DCAPI_ENDPOINT}${endpointPath}/${item.id}/thumbnail`,
+              src: isFeatured
+                ? `${item.representative_file_set.url}/square/512,/0/default.jpg`
+                : item.thumbnail,
               supplementalInfo: supplementalInfo,
               title: item.title,
             }}

--- a/components/Homepage/Collections.tsx
+++ b/components/Homepage/Collections.tsx
@@ -1,12 +1,12 @@
 import Container from "@/components/Shared/Container";
 import GridFeature from "@/components/Grid/Feature";
+import { HomePageContext } from "@/context/home-context";
 import { HomepageCollectionsStyled } from "@/components/Homepage/Collections.styled";
 import SectionHeading from "@/components/Shared/SectionHeading";
-import { collectionData } from "@/lib/constants/homepage";
-import { shuffle } from "@/lib/utils/array-helpers";
+import { useContext } from "react";
 
 const HomepageCollections = () => {
-  const data = shuffle(collectionData);
+  const { featuredCollections } = useContext(HomePageContext);
 
   return (
     <HomepageCollectionsStyled>
@@ -16,7 +16,7 @@ const HomepageCollections = () => {
           linkHref="/collections"
           linkText="View Collections"
         />
-        <GridFeature data={data} />
+        <GridFeature data={featuredCollections} />
       </Container>
     </HomepageCollectionsStyled>
   );

--- a/components/Homepage/Overview.tsx
+++ b/components/Homepage/Overview.tsx
@@ -18,8 +18,10 @@ const HomepageOverview = () => {
           <Content>
             <h2>Enrich your research with primary sources</h2>
             <p>
-              Explore millions of high-quality primary sources and images from
-              around the world, including artworks, maps, photographs, and more.{" "}
+              Explore digital resources from the Northwestern University Library
+              collections – including Letters, photographs, diaries, maps, and
+              audiovisual materials - as well as licensed art historical images
+              for teaching and reference.
             </p>
             <Link href="/about">
               <Button isPrimary>Learn More</Button>

--- a/components/SharedLink/SharedLink.test.tsx
+++ b/components/SharedLink/SharedLink.test.tsx
@@ -173,6 +173,7 @@ const work = {
   technique: [],
   table_of_contents: [],
   representative_file_set: {
+    aspect_ratio: 1,
     id: "7ad42e60-a8b6-444d-b4cf-f53f9c2756f6",
     url: "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/7ad42e60-a8b6-444d-b4cf-f53f9c2756f6",
   },

--- a/context/home-context.tsx
+++ b/context/home-context.tsx
@@ -1,0 +1,34 @@
+import React, { createContext, useEffect, useState } from "react";
+import { type SearchShape } from "@/types/api/response";
+import { featuredCollections } from "@/lib/constants/homepage";
+import { getHomePageCollections } from "@/lib/homepage-helpers";
+import { shuffle } from "@/lib/utils/array-helpers";
+
+type HomePageContextShape = {
+  featuredCollections: SearchShape[];
+};
+
+const HomePageContext = createContext<HomePageContextShape>({
+  featuredCollections: [],
+});
+
+function HomeContextProvider({ children }: { children: React.ReactNode }) {
+  const [data, setData] = useState<SearchShape[]>([]);
+
+  useEffect(() => {
+    async function getCollections() {
+      const collections = await getHomePageCollections(featuredCollections);
+
+      setData(shuffle(collections));
+    }
+    getCollections();
+  }, []);
+
+  return (
+    <HomePageContext.Provider value={{ featuredCollections: data }}>
+      {children}
+    </HomePageContext.Provider>
+  );
+}
+
+export { HomeContextProvider, HomePageContext };

--- a/lib/constants/endpoints.ts
+++ b/lib/constants/endpoints.ts
@@ -1,6 +1,17 @@
 const DCAPI_ENDPOINT = process.env.NEXT_PUBLIC_DCAPI_ENDPOINT;
+const DCAPI_PRODUCTION_ENDPOINT =
+  "https://api.dc.library.northwestern.edu/api/v2";
 const DC_API_SEARCH_URL = `${DCAPI_ENDPOINT}/search`;
 const DC_URL = process.env.NEXT_PUBLIC_DC_URL;
+const IIIF_IMAGE_SERVICE_ENDPOINT =
+  "https://iiif.stack.rdc.library.northwestern.edu/iiif/2";
 const PRODUCTION_URL = "https://digitalcollections.library.northwestern.edu";
 
-export { DC_URL, DCAPI_ENDPOINT, DC_API_SEARCH_URL, PRODUCTION_URL };
+export {
+  DC_URL,
+  DCAPI_ENDPOINT,
+  DCAPI_PRODUCTION_ENDPOINT,
+  DC_API_SEARCH_URL,
+  IIIF_IMAGE_SERVICE_ENDPOINT,
+  PRODUCTION_URL,
+};

--- a/lib/constants/homepage.ts
+++ b/lib/constants/homepage.ts
@@ -50,7 +50,7 @@ export const defaultCollection: HeroCollection = {
       },
       thumbnail: [
         {
-          id: "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/440bcf10-a7ee-4824-a1fb-e505cad222df/210,210,2650,1720/1536,/0/default.jpg",
+          id: `https://iiif.stack.rdc.library.northwestern.edu/iiif/2/440bcf10-a7ee-4824-a1fb-e505cad222df/210,210,2650,1720/1536,/0/default.jpg`,
           type: "Image",
           format: "image/jpeg",
           service: [
@@ -73,7 +73,7 @@ export const defaultCollection: HeroCollection = {
       nul_hero_region: "210,210,2650,1720",
     },
     {
-      id: "https://iiif.stack.rdc.library.northwestern.edu/public/72/98/fd/ce/-a/dc/1-/45/01/-9/e1/4-/9e/8b/d9/85/e1/49-manifest.json",
+      id: "https://iiif.stack.rdc.library.northwestern.edu/public/72/98/fd/ce/-a/dc/1-/45/01/-9/e1/4-/9e/8b/d9/85/e1/49-manifest2.json",
       type: "Collection",
       label: { none: ["Berkeley Folk Music Festival"] },
       summary: {
@@ -103,7 +103,7 @@ export const defaultCollection: HeroCollection = {
       ],
     },
     {
-      id: "https://iiif.stack.rdc.library.northwestern.edu/public/72/98/fd/ce/-a/dc/1-/45/01/-9/e1/4-/9e/8b/d9/85/e1/49-manifest.json",
+      id: "https://iiif.stack.rdc.library.northwestern.edu/public/72/98/fd/ce/-a/dc/1-/45/01/-9/e1/4-/9e/8b/d9/85/e1/49-manifest3.json",
       type: "Collection",
       label: {
         none: ["Athletic Department Football Films"],
@@ -155,7 +155,7 @@ export const defaultCollection: HeroCollection = {
       ],
     },
     {
-      id: "https://iiif.stack.rdc.library.northwestern.edu/public/72/98/fd/ce/-a/dc/1-/45/01/-9/e1/4-/9e/8b/d9/85/e1/49-manifest.json",
+      id: "https://iiif.stack.rdc.library.northwestern.edu/public/72/98/fd/ce/-a/dc/1-/45/01/-9/e1/4-/9e/8b/d9/85/e1/49-manifest4.json",
       type: "Collection",
       label: { none: ["Jim Roberts Photographs"] },
       summary: {
@@ -185,7 +185,7 @@ export const defaultCollection: HeroCollection = {
       ],
     },
     {
-      id: "https://iiif.stack.rdc.library.northwestern.edu/public/05/2b/b6/f0/-b/6f/5-/45/90/-9/51/b-/ff/df/49/ff/af/03-manifest.json",
+      id: "https://iiif.stack.rdc.library.northwestern.edu/public/05/2b/b6/f0/-b/6f/5-/45/90/-9/51/b-/ff/df/49/ff/af/03-manifest2.json",
       type: "Collection",
       label: { none: ["World War II Poster Collection"] },
       summary: { none: ["A careless word-- a needless sinking"] },
@@ -208,6 +208,39 @@ export const defaultCollection: HeroCollection = {
       homepage: [
         {
           id: `${DC_URL}/collections/faf4f60e-78e0-4fbf-96ce-4ca8b4df597a`,
+          type: "Text",
+        },
+      ],
+      nul_hero_region: "100,450,1600,1200",
+    },
+    {
+      id: "https://dcapi.rdc-staging.library.northwestern.edu/api/v2/collections/0ba3a256-4952-44ea-b0d9-0772835ff137?as=iiif",
+      type: "Collection",
+      label: { none: ["Ronald J. Sullivan Photograph Collection"] },
+      summary: {
+        none: [
+          "The Ronald J. Sullivan Photograph Collection is an extensive collection of photographs and slides of public and commercial buses and public transit and commuter trains, dating from 1946-2000. The bulk of the collection comprises photographs taken by Ronald J. Sullivan, an amateur photographer and rail and bus enthusiast; also included are historic images of Chicago-area transit that were part of Sullivan’s personal collection, and which supplement  the photographer’s original material. ",
+        ],
+      },
+      thumbnail: [
+        {
+          id: "https://iiif-test.rdc-staging.library.northwestern.edu/iiif/2/37a27b1d-ea5a-4bbe-b38a-fcd2f5904f25/750,950,1600,1200/800,/0/default.jpg",
+          type: "Image",
+          format: "image/jpeg",
+          service: [
+            {
+              id: "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/37a27b1d-ea5a-4bbe-b38a-fcd2f5904f25",
+              profile: "http://iiif.io/api/image/2/level2.json",
+              type: "ImageService2",
+            },
+          ],
+          width: 1600,
+          height: 1200,
+        },
+      ],
+      homepage: [
+        {
+          id: `${DC_URL}/collections/0ba3a256-4952-44ea-b0d9-0772835ff137`,
           type: "Text",
         },
       ],
@@ -309,87 +342,12 @@ export const overviewThumbnails: Array<IIIFExternalWebResource[]> = [
   ],
 ];
 
-export const collectionData: SearchShape[] = [
-  {
-    api_model: "Collection",
-    representative_file_set: {
-      aspect_ratio: 1.618,
-      id: "ad43c4c9-835f-461b-bae4-92eb62ced935",
-      url: "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/ca25ed3d-0d1b-41a4-95b3-c3a5790eb0a7",
-    },
-    thumbnail:
-      "https://dcapi.rdc-staging.library.northwestern.edu/api/v2/collections/18ec4c6b-192a-4ab8-9903-ea0f393c35f7/thumbnail",
-    visibility: "Public",
-    iiif_manifest:
-      "https://dcapi.rdc-staging.library.northwestern.edu/api/v2/collections/18ec4c6b-192a-4ab8-9903-ea0f393c35f7?as=iiif",
-    work_type: "Image",
-    id: "18ec4c6b-192a-4ab8-9903-ea0f393c35f7",
-    title: "Berkeley Folk Music Festival",
-  },
-  {
-    api_model: "Collection",
-    representative_file_set: {
-      aspect_ratio: 1.618,
-      id: "ad43c4c9-835f-461b-bae4-92eb62ced935",
-      url: "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/ca25ed3d-0d1b-41a4-95b3-c3a5790eb0a7",
-    },
-    thumbnail:
-      "https://dcapi.rdc-staging.library.northwestern.edu/api/v2/collections/18ec4c6b-192a-4ab8-9903-ea0f393c35f7/thumbnail",
-    visibility: "Public",
-    iiif_manifest:
-      "https://dcapi.rdc-staging.library.northwestern.edu/api/v2/collections/18ec4c6b-192a-4ab8-9903-ea0f393c35f7?as=iiif",
-    work_type: "Image",
-    id: "18ec4c6b-192a-4ab8-9903-ea0f393c35f7",
-    title: "Commedia dell'Arte: The Masks of Antonio Fava",
-  },
-  {
-    api_model: "Collection",
-    representative_file_set: {
-      aspect_ratio: 1.618,
-      id: "ad43c4c9-835f-461b-bae4-92eb62ced935",
-      url: "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/ca25ed3d-0d1b-41a4-95b3-c3a5790eb0a7",
-    },
-    thumbnail:
-      "https://dcapi.rdc-staging.library.northwestern.edu/api/v2/collections/18ec4c6b-192a-4ab8-9903-ea0f393c35f7/thumbnail",
-    visibility: "Public",
-    iiif_manifest:
-      "https://dcapi.rdc-staging.library.northwestern.edu/api/v2/collections/18ec4c6b-192a-4ab8-9903-ea0f393c35f7?as=iiif",
-    work_type: "Image",
-    id: "18ec4c6b-192a-4ab8-9903-ea0f393c35f7",
-    title: "Jim Roberts Photographs, 1968-1972",
-  },
-  {
-    api_model: "Collection",
-    representative_file_set: {
-      aspect_ratio: 1.618,
-      id: "ad43c4c9-835f-461b-bae4-92eb62ced935",
-      url: "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/ca25ed3d-0d1b-41a4-95b3-c3a5790eb0a7",
-    },
-    thumbnail:
-      "https://dcapi.rdc-staging.library.northwestern.edu/api/v2/collections/18ec4c6b-192a-4ab8-9903-ea0f393c35f7/thumbnail",
-    visibility: "Public",
-    iiif_manifest:
-      "https://dcapi.rdc-staging.library.northwestern.edu/api/v2/collections/18ec4c6b-192a-4ab8-9903-ea0f393c35f7?as=iiif",
-    work_type: "Image",
-    id: "18ec4c6b-192a-4ab8-9903-ea0f393c35f7",
-    title: "Pat Patrick Collection of Sun Ra Materials",
-  },
-  {
-    api_model: "Collection",
-    representative_file_set: {
-      aspect_ratio: 1.618,
-      id: "ad43c4c9-835f-461b-bae4-92eb62ced935",
-      url: "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/ca25ed3d-0d1b-41a4-95b3-c3a5790eb0a7",
-    },
-    thumbnail:
-      "https://dcapi.rdc-staging.library.northwestern.edu/api/v2/collections/18ec4c6b-192a-4ab8-9903-ea0f393c35f7/thumbnail",
-    visibility: "Public",
-    iiif_manifest:
-      "https://dcapi.rdc-staging.library.northwestern.edu/api/v2/collections/18ec4c6b-192a-4ab8-9903-ea0f393c35f7?as=iiif",
-    work_type: "Image",
-    id: "18ec4c6b-192a-4ab8-9903-ea0f393c35f7",
-    title: "Records of the Bursar’s Office Takeover, May 1968",
-  },
+export const featuredCollections = [
+  "d3a8e587-cc58-4cb0-aea2-65465d42ec3e",
+  "ecacd539-fe38-40ec-bbc0-590acee3d4f2",
+  "4ed2338d-c715-4a86-8ac6-6b4030a42be5",
+  "3121f8ee-5265-4b19-bae3-59f96e9ac01a",
+  "8eb442ee-c545-430b-a489-53befaafa9b7",
 ];
 
 export const worksData: SearchShape[] = [

--- a/lib/homepage-helpers.ts
+++ b/lib/homepage-helpers.ts
@@ -1,0 +1,55 @@
+import { DCAPI_PRODUCTION_ENDPOINT } from "./constants/endpoints";
+import { SearchShape } from "@/types/api/response";
+import { WorkShape } from "@/types/components/works";
+import axios from "axios";
+
+const getHomePageCollections = async (
+  collectionIds: string[] = []
+): Promise<SearchShape[]> => {
+  try {
+    /** Batch fetch all Collections */
+    const collectionsResponse = await axios.all(
+      collectionIds.map((id) => {
+        return axios.get(`${DCAPI_PRODUCTION_ENDPOINT}/collections/${id}`);
+      })
+    );
+    const collections = collectionsResponse.map((cr) => cr.data.data);
+
+    /** Batch fetch all Works which are representative images of Collections returned above */
+    const workIds = collections.map((c) => c.representative_image.work_id);
+    const worksResponse = await axios.all(
+      workIds.map((id) => axios.get(`${DCAPI_PRODUCTION_ENDPOINT}/works/${id}`))
+    );
+    const works: WorkShape[] = worksResponse.map(({ data: { data } }) => ({
+      ...data,
+      representative_file_set: {
+        ...data.representative_file_set,
+        /** Format for nice UI display on the home page */
+        aspect_ratio: 1,
+      },
+    }));
+
+    /** Build the shape of what the Collection Grid wants */
+    const collectionGridItems = collections.map((collection, index) => {
+      const { api_model, id, thumbnail, title, visibility } = collection;
+
+      return {
+        api_model,
+        id,
+        iiif_manifest: `${DCAPI_PRODUCTION_ENDPOINT}/collections/${id}?as=iiif`,
+        representative_file_set: works[index].representative_file_set,
+        thumbnail,
+        title,
+        visibility,
+        work_type: works[index].work_type,
+      };
+    });
+
+    return collectionGridItems;
+  } catch (err) {
+    console.error(err);
+    return [];
+  }
+};
+
+export { getHomePageCollections };

--- a/mocks/sample-work1.ts
+++ b/mocks/sample-work1.ts
@@ -81,6 +81,7 @@ export const sampleWork1: WorkShape = {
   related_material: [],
   related_url: [],
   representative_file_set: {
+    aspect_ratio: 1,
     id: "93d75ffe-20d8-48ea-9206-8db9114f2731",
     url: "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/93d75ffe-20d8-48ea-9206-8db9114f2731",
   },

--- a/mocks/sample-work2.ts
+++ b/mocks/sample-work2.ts
@@ -84,6 +84,7 @@ export const sampleWork2: WorkShape = {
   related_material: [],
   related_url: [],
   representative_file_set: {
+    aspect_ratio: 1.6,
     id: "93d75ffe-20d8-48ea-9206-8db9114f2731",
     url: "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/93d75ffe-20d8-48ea-9206-8db9114f2731",
   },

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/components/Homepage";
 
 import Head from "next/head";
+import { HomeContextProvider } from "@/context/home-context";
 import Layout from "@/components/layout";
 import { PRODUCTION_URL } from "@/lib/constants/endpoints";
 import { buildDataLayer } from "@/lib/ga/data-layer";
@@ -14,23 +15,25 @@ import { loadDefaultStructuredData } from "@/lib/json-ld";
 const HomePage: React.FC = () => {
   return (
     <>
-      {/* Google Structured Data via JSON-LD */}
-      <Head>
-        <script
-          key="app-ld-json"
-          id="app-ld-json"
-          type="application/ld+json"
-          dangerouslySetInnerHTML={{
-            __html: JSON.stringify(loadDefaultStructuredData(), null, "\t"),
-          }}
-        />
-      </Head>
-      <Layout header="hero">
-        <Hero />
-        <Overview />
-        <Collections />
-        <Works />
-      </Layout>
+      <HomeContextProvider>
+        {/* Google Structured Data via JSON-LD */}
+        <Head>
+          <script
+            key="app-ld-json"
+            id="app-ld-json"
+            type="application/ld+json"
+            dangerouslySetInnerHTML={{
+              __html: JSON.stringify(loadDefaultStructuredData(), null, "\t"),
+            }}
+          />
+        </Head>
+        <Layout header="hero">
+          <Hero />
+          <Overview />
+          <Collections />
+          <Works />
+        </Layout>
+      </HomeContextProvider>
     </>
   );
 };

--- a/types/components/works.ts
+++ b/types/components/works.ts
@@ -112,6 +112,7 @@ export interface WorkShape {
   related_material: Array<string>;
   related_url: Array<RelatedUrl>;
   representative_file_set: {
+    aspect_ratio: number;
     id: string;
     url: string;
   };


### PR DESCRIPTION
## What does this do?
- Updates the Homepage featured Collections to use the curated list received.
- Refactors Homepage featured Collections to pull in dynamically instead of hard coded
- Introduces `HomepageContext` to store data which doesn't change during an app session
- Refactors the `GridItem` slightly to use the API `thumbnail` endpoint as image source, or... an enhanced, hi-res version of the image if being used by a consumer component which needs bigger sizing, better resolution, etc.
- Wraps `GridItem` with a unit test


![image](https://user-images.githubusercontent.com/3020266/214424714-a6ee6713-83bc-4536-a9f0-f355e861956d.png)
