### PR TITLE
Clean up Collection page box stat reference, Audio Workss bug, and re…

### DIFF
--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -6,7 +6,6 @@ import "swiper/css/pagination";
 import Footer from "@/components/Footer/Footer";
 import Head from "next/head";
 import Header from "@/components/Header/Header";
-import Message from "@/components/Shared/Message/Message";
 import React from "react";
 import { styled } from "@/stitches.config";
 
@@ -45,7 +44,9 @@ const Layout: React.FC<LayoutProps> = ({
       <Header isHero={header === "hero"} />
       <MainStyled>{children}</MainStyled>
       <Footer />
-      <Message />
+
+      {/* De-activated temporarily */}
+      {/* <Message /> */}
     </>
   );
 };

--- a/pages/collections/[id].tsx
+++ b/pages/collections/[id].tsx
@@ -99,9 +99,8 @@ const Collection: NextPage<CollectionProps> = ({
               />
               <Facts.Item
                 big={formatNumber(totalAudio)}
-                small={pluralize("Audio Works", totalAudio)}
+                small={pluralize("Audio Work", totalAudio)}
               />
-              <Facts.Item big="Across" small="[Count here] Boxes" />
             </Facts>
           </Container>
         </Interstitial>


### PR DESCRIPTION
## What does this do?

- Clean up Collection page box stat reference, 
- Collection page Audio "Workss" typo,
- Remove Harmful Content message from the homepage

![image](https://user-images.githubusercontent.com/3020266/214635534-98d4c65e-5501-4b7a-b38a-d3a36646543c.png)

