### PR TITLE
Fix action dialog close icon in Safari

### DIFF
--- a/components/Shared/Dialog.styled.ts
+++ b/components/Shared/Dialog.styled.ts
@@ -3,7 +3,12 @@ import { styled } from "@/stitches.config";
 
 /* eslint sort-keys: 0 */
 
-const DialogClose = styled(Dialog.Close, {});
+const DialogClose = styled(Dialog.Close, {
+  svg: {
+    width: "100%",
+    height: "100%",
+  },
+});
 
 const DialogOverlay = styled(Dialog.Overlay, {
   background: "rgba(0 0 0 / 0.382)",


### PR DESCRIPTION
## What does this do?

This addresses SVG icon sizing in safari on the Work actions dialog modal (Cite/Find/Download&share).

## How should we review?

Checkout any work in Safari. Close Icon is visible.

## Notes....

Long-term tech debt, we should try to build a better wrapper for all of these icons so it can be handled in one spot.