### PR TITLE
Numerical string sorting of Series agg values.

### DIFF
--- a/components/Collection/Tabs/Organization.tsx
+++ b/components/Collection/Tabs/Organization.tsx
@@ -1,6 +1,6 @@
+import { GenericAggsReturn, sortAggsByKey } from "@/lib/collection-helpers";
 import BloomIIIFWrapper from "@/components/BloomWrapper";
 import ExpandableList from "@/components/Shared/ExpandableList";
-import { GenericAggsReturn } from "@/lib/collection-helpers";
 import Heading from "@/components/Heading/Heading";
 
 interface CollectionTabsOrganizationProps {
@@ -12,12 +12,14 @@ const url = process.env.NEXT_PUBLIC_DCAPI_ENDPOINT;
 const CollectionTabsOrganization: React.FC<CollectionTabsOrganizationProps> = ({
   series,
 }) => {
+  const list = sortAggsByKey(series);
+
   return (
     <div data-testid="organization-wrapper">
       <section>
         <Heading as="h2">Explore Series</Heading>
         <ExpandableList>
-          {series.map((entry, index) => {
+          {list.map((entry, index) => {
             const { key, doc_count } = entry;
             const summary =
               doc_count > 1 ? `${doc_count} Items` : `${doc_count}  Item`;

--- a/lib/collection-helpers.test.ts
+++ b/lib/collection-helpers.test.ts
@@ -1,4 +1,8 @@
-import type { GetTopMetadataAggsReturn } from "@/lib/collection-helpers";
+import {
+  GenericAggsReturn,
+  GetTopMetadataAggsReturn,
+  sortAggsByKey,
+} from "@/lib/collection-helpers";
 import { getTopMetadataAggs } from "@/lib/collection-helpers";
 
 /* eslint sort-keys: 0 */
@@ -110,5 +114,44 @@ describe("getTopMetadataAggs() function", () => {
 
   it("should return an empty 'value' property if buckets are empty for an aggregated field", async () => {
     expect(response).toEqual([{ field: "subject.label", value: [] }]);
+  });
+});
+
+describe("sortAggsByKey() function", () => {
+  const givenAggs: GenericAggsReturn[] = [
+    {
+      key: "Sample -- 1.",
+      doc_count: 1,
+    },
+    {
+      key: "Sample -- 10.",
+      doc_count: 2,
+    },
+    {
+      key: "Sample -- 2.",
+      doc_count: 3,
+    },
+  ];
+
+  const expectedAggs: GenericAggsReturn[] = [
+    {
+      key: "Sample -- 1.",
+      doc_count: 1,
+    },
+    {
+      key: "Sample -- 2.",
+      doc_count: 3,
+    },
+    {
+      key: "Sample -- 10.",
+      doc_count: 2,
+    },
+  ];
+
+  it("sorts generic agg arrays numerically by key value", () => {
+    const output = sortAggsByKey(givenAggs);
+    output.forEach((agg, index) => {
+      expect(agg.key).toBe(expectedAggs[index].key);
+    });
   });
 });

--- a/lib/collection-helpers.ts
+++ b/lib/collection-helpers.ts
@@ -321,3 +321,14 @@ export async function getTopMetadataAggs({
     return [];
   }
 }
+
+/**
+ * Specialized array helper for numerical string
+ * sorting an array by the `key` property
+ */
+export const sortAggsByKey = (arr: GenericAggsReturn[]) => {
+  const collator = new Intl.Collator("en", { numeric: true });
+  return arr.sort(function (a, b) {
+    return collator.compare(a.key, b.key);
+  });
+};


### PR DESCRIPTION
## What does this do?

This creates a numerical string sorting helper that can be applied to an array of Agg results following the shape of
 
```ts
{
  key: string;
  doc_count: number;
}
```

This helper is then applied to the `series` array that renders the accordion UI on the Collection Organization page for each individual collection.

The expect behavior is that this will sort arrays by the **key** `string`, and apply a compare  function to ensure numeric strings are ordered as expected, see: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Collator/compare

And thanks to @bmquinn !!!

## How should we review?
Spin up DC Next. Take a look at the ABC.123.TEST collection in staging. The Collection Organization series should be ordered as expected. A test for sort function also has been written.