### PR TITLE
Cleanup getStaticPaths for dynamic pages.

### DIFF
--- a/lib/collection-helpers.ts
+++ b/lib/collection-helpers.ts
@@ -17,29 +17,6 @@ export async function getCollection(
   }
 }
 
-export async function getCollectionIds(): Promise<Array<string>> {
-  const body = {
-    _source: ["id"],
-    query: {
-      query_string: {
-        query: "*",
-      },
-    },
-    size: 1000,
-  };
-
-  try {
-    const response = await apiPostRequest<ApiSearchResponse>({
-      body,
-      url: `${process.env.NEXT_PUBLIC_DCAPI_ENDPOINT}/search/collections`,
-    });
-    return response?.data ? response?.data.map((item) => item.id) : [];
-  } catch (err) {
-    console.error("Error getting all Collection Ids", err);
-    return [];
-  }
-}
-
 export async function getCollectionWorkCount(collectionId: string) {
   const body = {
     _source: ["id"],

--- a/lib/work-helpers.ts
+++ b/lib/work-helpers.ts
@@ -1,8 +1,6 @@
 import { DCAPI_ENDPOINT, DC_API_SEARCH_URL } from "@/lib/constants/endpoints";
-import { apiGetRequest, apiPostRequest } from "@/lib/dc-api";
-import { ApiSearchRequestBody } from "@/types/api/request";
-import { ApiSearchResponse } from "@/types/api/response";
 import { type WorkShape } from "@/types/components/works";
+import { apiGetRequest } from "@/lib/dc-api";
 import { shuffle } from "@/lib/utils/array-helpers";
 
 export async function getWork(id: string) {
@@ -15,38 +13,6 @@ export async function getWork(id: string) {
     console.error("Error getting the work", id);
     return null;
   }
-}
-
-export async function getWorkIds(): Promise<Array<string>> {
-  const body = {
-    _source: ["id"],
-    aggs: {
-      allIds: {
-        terms: {
-          field: "_id",
-          order: {
-            _count: "asc",
-          },
-          size: 1,
-        },
-      },
-    },
-    query: {
-      match_all: {},
-    },
-    size: 0,
-  } as ApiSearchRequestBody;
-
-  const response = await apiPostRequest<ApiSearchResponse>({
-    body,
-    url: `${DC_API_SEARCH_URL}`,
-  });
-
-  if (response?.aggregations?.allIds) {
-    return response.aggregations.allIds.buckets.map((bucket) => bucket.key);
-  }
-
-  return [];
 }
 
 export async function getWorkManifest(id: string) {

--- a/pages/collections/[id].tsx
+++ b/pages/collections/[id].tsx
@@ -18,7 +18,6 @@ import {
 import { formatNumber, pluralize } from "@/lib/utils/count-helpers";
 import {
   getCollection,
-  getCollectionIds,
   getCollectionWorkCounts,
   getMetadataAggs,
   getTopMetadataAggs,
@@ -140,12 +139,9 @@ const Collection: NextPage<CollectionProps> = ({
 };
 
 export async function getStaticPaths() {
-  const ids = await getCollectionIds();
-  const paths = ids.map((id) => ({ params: { id } }));
-
   return {
     fallback: "blocking",
-    paths,
+    paths: [],
   };
 }
 

--- a/pages/items/[id].tsx
+++ b/pages/items/[id].tsx
@@ -3,7 +3,7 @@ import {
   getCollectionWorkCounts,
 } from "@/lib/collection-helpers";
 import { GetStaticPropsContext, NextPage } from "next";
-import { getWork, getWorkIds, getWorkSliders } from "@/lib/work-helpers";
+import { getWork, getWorkSliders } from "@/lib/work-helpers";
 import Container from "@/components/Shared/Container";
 import { ErrorBoundary } from "react-error-boundary";
 import ErrorFallback from "@/components/Shared/ErrorFallback";
@@ -93,12 +93,9 @@ const WorkPage: NextPage<WorkPageProps> = ({
 };
 
 export async function getStaticPaths() {
-  const workIds = await getWorkIds();
-  const paths = workIds.map((id) => ({ params: { id } }));
-
   return {
     fallback: "blocking",
-    paths,
+    paths: [],
   };
 }
 


### PR DESCRIPTION
## What does this do?

This little bit of work just cleans out some old code that is no longer being used to generate static paths.

The current version of DC Next does not generate paths on build for `items/[id]` or `collections/[id]`, and instead relies on the `fallback` to create static pages through SSR when those routes are requested. For this reason, getStaticProps on these routes is still somewhat beneficial.

Also, the older function calls of `getWorkIds` and `getCollectionIds`  were not actually returning responses from our current DC API. These requests were built around an early mocked API response in API Gateway -- and I think should be considered trash at this point.

## How should we review?

Seem reasonable? Long-term, I'm wondering how much of this can be moved to some server side stuff in a Next 13 `app` directory?