### PR TITLE
Remove Citation from Work Find  modal

### DIFF
--- a/components/Work/ActionsDialog/Find.test.tsx
+++ b/components/Work/ActionsDialog/Find.test.tsx
@@ -46,7 +46,6 @@ describe("WorkDialogFind", () => {
     expect(within(div).getByText(/ima box/i));
     expect(within(div).getByText(/box number/i));
     expect(within(div).getByText(/53/i));
-    expect(within(div).getByText(/citation/i));
     expect(within(div).getByText(/folder name/i));
     expect(within(div).getByText(/ima folder/i));
     expect(within(div).getByText(/folder number/i));


### PR DESCRIPTION
## What does this do
Remove Citation from Work Find  modal

![image](https://user-images.githubusercontent.com/3020266/215547185-df6d2507-d1a8-4288-b169-c82588633656.png)
