### PR TITLE
Resolve query infinite growth issues for search results and aggs.

### DIFF
--- a/lib/queries/builder.ts
+++ b/lib/queries/builder.ts
@@ -1,6 +1,7 @@
 import { buildSearchPart, querySearchTemplate } from "@/lib/queries/search";
 import { ApiSearchRequestBody } from "@/types/api/request";
 import { FacetsInstance } from "@/types/components/facets";
+import { QueryDslQueryContainer } from "@elastic/elasticsearch/api/types";
 import { UrlFacets } from "@/types/context/filter-context";
 import { buildAggs } from "@/lib/queries/aggs";
 import { buildFacetFilters } from "@/lib/queries/facet";
@@ -16,66 +17,28 @@ type BuildQueryProps = {
 export function buildQuery(obj: BuildQueryProps) {
   const { aggs, aggsFilterValue, size, term, urlFacets } = obj;
 
-  let newQuery: ApiSearchRequestBody = querySearchTemplate;
+  const must: QueryDslQueryContainer[] = [];
+  if (term) must.push(buildSearchPart(term));
+  if (Object.keys(urlFacets).length > 0) must.push(addFacetsToQuery(urlFacets));
 
-  if (typeof size !== undefined && newQuery) newQuery.size = size as number;
-
-  /**
-   * Add search term to the API query
-   */
-  newQuery = addSearchTermToQuery(newQuery, term);
-
-  /**
-   * Add facets to the API query
-   */
-  newQuery = addFacetsToQuery(newQuery, urlFacets);
-
-  /**
-   * Add aggregations to the API query
-   */
-  if (aggs && newQuery)
-    newQuery.aggs = buildAggs(aggs, aggsFilterValue, urlFacets);
-
-  return newQuery;
-}
-
-export function addFacetsToQuery(
-  query: ApiSearchRequestBody,
-  urlFacets: UrlFacets
-) {
-  /** Verify at least one user facet has been activated */
-  if (Object.keys(urlFacets).length > 0) {
-    /** 
-     * It should end up looking like this:
-     * 
-      "bool": {
-        "filter": [
-            { "term": { "subject.label": "Berkeley (Calif.)" } },
-            { "term": {  "subject.label": "Baez, Joan" } },
-            { "term": {  "genre.label": "Photographs" } }
-        ]
-      }
-     */
-
-    const nestedMust = query?.query?.bool?.must;
-    Array.isArray(nestedMust) &&
-      nestedMust.push({
+  return {
+    ...querySearchTemplate,
+    ...(must.length > 0 && {
+      query: {
         bool: {
-          filter: buildFacetFilters(urlFacets),
+          must: must,
         },
-      });
-  }
-
-  return query;
+      },
+    }),
+    ...(aggs && { aggs: buildAggs(aggs, aggsFilterValue, urlFacets) }),
+    ...(typeof size !== undefined && { size: size }),
+  } as ApiSearchRequestBody;
 }
 
-export function addSearchTermToQuery(
-  query: ApiSearchRequestBody,
-  term: string
-) {
-  if (term) {
-    const nestedMust = query?.query?.bool?.must;
-    Array.isArray(nestedMust) && nestedMust.push(buildSearchPart(term));
-  }
-  return query;
+export function addFacetsToQuery(urlFacets: UrlFacets) {
+  return {
+    bool: {
+      filter: buildFacetFilters(urlFacets),
+    },
+  };
 }

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -12,6 +12,7 @@ import { NextPage } from "next";
 import { PRODUCTION_URL } from "@/lib/constants/endpoints";
 import PaginationAltCounts from "@/components/Search/PaginationAltCounts";
 import { Results } from "@/components/Search/Search.styled";
+import { apiPostRequest } from "@/lib/dc-api";
 import axios from "axios";
 import { buildDataLayer } from "@/lib/ga/data-layer";
 import { buildQuery } from "@/lib/queries/builder";
@@ -51,15 +52,19 @@ const SearchPage: NextPage = () => {
           urlFacets,
         });
 
-        const response = await axios.post(DC_API_SEARCH_URL, body);
-        const { pagination } = response?.data;
+        const response = await apiPostRequest<ApiSearchResponse>({
+          body: body,
+          url: DC_API_SEARCH_URL,
+        });
 
         /**
          * Construct url for page request
          */
-        const url = new URL(pagination.query_url);
-        url.searchParams.append("page", page ? (page as string) : "1");
-        setPageQueryUrl(url.toString());
+        if (response) {
+          const url = new URL(response.pagination.query_url);
+          url.searchParams.append("page", page ? (page as string) : "1");
+          setPageQueryUrl(url.toString());
+        }
       } catch (err) {
         handleErrors(err);
       }


### PR DESCRIPTION
## What does this do?

This fixes a pretty ugly issue relating to queries on search results and aggs infinitely growing and not being able to be destructed. The entire `buildQuery()` call has now been recreated to ensure that the a new query is built from scratch on each unique request.

```tsx
export function buildQuery(obj: BuildQueryProps) {
  const { aggs, aggsFilterValue, size, term, urlFacets } = obj;

  const must: QueryDslQueryContainer[] = [];
  if (term) must.push(buildSearchPart(term));
  if (Object.keys(urlFacets).length > 0) must.push(addFacetsToQuery(urlFacets));

  return {
    ...querySearchTemplate,
    ...(must.length > 0 && {
      query: {
        bool: {
          must: must,
        },
      },
    }),
    ...(aggs && { aggs: buildAggs(aggs, aggsFilterValue, urlFacets) }),
    ...(typeof size !== undefined && { size: size }),
  }
```