### PR TITLE
Update width on fileset download.

### DIFF
--- a/components/Work/ActionsDialog/DownloadAndShare.tsx
+++ b/components/Work/ActionsDialog/DownloadAndShare.tsx
@@ -178,7 +178,7 @@ const Item: React.FC<ItemProps> = ({ item, showEmbedWarning }) => {
         : "nul_fileset";
 
     const response = await makeBlob(
-      `${getInfoResponse(item)}/full/1000,/0/default.jpg`
+      `${getInfoResponse(item)}/full/3000,/0/default.jpg`
     );
 
     if (!response || response.error) {


### PR DESCRIPTION
## What does this do?

Oh, this is simple. Really simple. The IIIF image URI now just asks for a size of `3000,` instead of the previous 1000. 