### PR TITLE
Add alt from canvas label if it exists.

### DIFF
--- a/components/Work/ActionsDialog/DownloadAndShare.tsx
+++ b/components/Work/ActionsDialog/DownloadAndShare.tsx
@@ -195,6 +195,7 @@ const Item: React.FC<ItemProps> = ({ item, showEmbedWarning }) => {
         <ItemThumbnail>
           {item.thumbnail && (
             <Thumbnail
+              altAsLabel={item.label ? item.label : { none: [item.id] }}
               thumbnail={item.thumbnail as IIIFExternalWebResource[]}
             />
           )}


### PR DESCRIPTION
## What does this do?

This is a pretty simple fix the adds an `alt` to the Necter rendered canvas thumbnail from the `label`. If a label does not exist, we fallback to the `id`. This takes advantage of the `altAsLabel` prop in the Nectar `Thumbnail`.