### PR TITLE
Collection page requests all client side

### DIFF
--- a/lib/collection-helpers.ts
+++ b/lib/collection-helpers.ts
@@ -131,7 +131,9 @@ export async function getCollectionWorkCount(collectionId: string) {
 }
 
 /* eslint sort-keys:0 */
-export async function getCollectionWorkCounts(collectionId = "") {
+export async function getCollectionWorkCounts(
+  collectionId = ""
+): Promise<CollectionWorkCountMap | null> {
   function getCount(
     buckets: ApiResponseBucket[],
     targetWorkType: "Audio" | "Image" | "Video"
@@ -185,9 +187,10 @@ export async function getCollectionWorkCounts(collectionId = "") {
       if (collectionId) {
         return {
           [collectionId]: {
-            audio: 0,
-            image: 0,
-            video: 0,
+            totalWorks: 0,
+            totalImage: 0,
+            totalAudio: 0,
+            totalVideo: 0,
           },
         };
       }


### PR DESCRIPTION
## What does this do?

- Move all Collection page supplemental data to the client side, to get Reading Room Private works to work.
- Open Graph data and GTM data layer properties won't fire correctly from within the Reading Room for a private work.

## How to test
- @kdid mimic within reading room.  A Private Collection page should load