### PR TITLE
Update bloom, adjust View All class.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@radix-ui/react-select": "^1.0.0",
         "@radix-ui/react-switch": "^1.0.1",
         "@radix-ui/react-tabs": "^1.0.1",
-        "@samvera/bloom-iiif": "^0.4.1",
+        "@samvera/bloom-iiif": "^0.4.2",
         "@samvera/clover-iiif": "^1.13.0",
         "@samvera/image-downloader": "^1.1.5",
         "@samvera/nectar-iiif": "^0.0.20",
@@ -2923,9 +2923,9 @@
       "dev": true
     },
     "node_modules/@samvera/bloom-iiif": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@samvera/bloom-iiif/-/bloom-iiif-0.4.1.tgz",
-      "integrity": "sha512-sANb6h04mXk7qkO8WgsrUbfdmUfaVK8lVzW3p9+7nQ39NHbNVf1IUdcNvWgk2FkkX8kxbGdmUZ9isua/uupTQg==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@samvera/bloom-iiif/-/bloom-iiif-0.4.2.tgz",
+      "integrity": "sha512-gPH/tkeXSX1A0IH5FkGBjBsnrwsaFc9/URXkz9pTXcyMo4Rpyvq/8V//6I0nXFee/USBCTpZDV7Gf2VUz59uWw==",
       "dependencies": {
         "@iiif/vault": "^0.9.19",
         "@iiif/vault-helpers": "^0.9.11",
@@ -15768,9 +15768,9 @@
       "dev": true
     },
     "@samvera/bloom-iiif": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@samvera/bloom-iiif/-/bloom-iiif-0.4.1.tgz",
-      "integrity": "sha512-sANb6h04mXk7qkO8WgsrUbfdmUfaVK8lVzW3p9+7nQ39NHbNVf1IUdcNvWgk2FkkX8kxbGdmUZ9isua/uupTQg==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@samvera/bloom-iiif/-/bloom-iiif-0.4.2.tgz",
+      "integrity": "sha512-gPH/tkeXSX1A0IH5FkGBjBsnrwsaFc9/URXkz9pTXcyMo4Rpyvq/8V//6I0nXFee/USBCTpZDV7Gf2VUz59uWw==",
       "requires": {
         "@iiif/vault": "^0.9.19",
         "@iiif/vault-helpers": "^0.9.11",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@radix-ui/react-select": "^1.0.0",
     "@radix-ui/react-switch": "^1.0.1",
     "@radix-ui/react-tabs": "^1.0.1",
-    "@samvera/bloom-iiif": "^0.4.1",
+    "@samvera/bloom-iiif": "^0.4.2",
     "@samvera/clover-iiif": "^1.13.0",
     "@samvera/image-downloader": "^1.1.5",
     "@samvera/nectar-iiif": "^0.0.20",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7376450/216426334-6bd6c1f5-0091-472c-b2af-1515517f6e9f.png)


## What does this do?

This updates the Bloom package to help render the View All button with the distinct classname, `bloom-header-view-all`, allowing it not be included in the selectors targeted by styling completed in #198.

## How can we review?

Take a look at the preview instance here to verify:
https://preview-3459-bloom-classes.d1g4r4p7fos4jz.amplifyapp.com/collections/18ec4c6b-192a-4ab8-9903-ea0f393c35f7