### PR TITLE
All credentialed requests on image downloader.

### DIFF
--- a/components/Work/ActionsDialog/DownloadAndShare.tsx
+++ b/components/Work/ActionsDialog/DownloadAndShare.tsx
@@ -182,7 +182,8 @@ const Item: React.FC<ItemProps> = ({ item, showEmbedWarning }) => {
         : "nul_fileset";
 
     const response = await makeBlob(
-      `${getInfoResponse(item)}/full/3000,/0/default.jpg`
+      `${getInfoResponse(item)}/full/3000,/0/default.jpg`,
+      { credentials: "include" }
     );
 
     if (!response || response.error) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@radix-ui/react-tabs": "^1.0.1",
         "@samvera/bloom-iiif": "^0.4.1",
         "@samvera/clover-iiif": "^1.13.0",
-        "@samvera/image-downloader": "^1.1.5",
+        "@samvera/image-downloader": "^1.1.6",
         "@samvera/nectar-iiif": "^0.0.20",
         "@stitches/react": "^1.2.6",
         "axios": "^1.2.2",
@@ -2986,9 +2986,9 @@
       }
     },
     "node_modules/@samvera/image-downloader": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@samvera/image-downloader/-/image-downloader-1.1.5.tgz",
-      "integrity": "sha512-Q1UAoNMvKGfEjMf9JEyCf8MvYtUNuOGXf0jOiwthKAh8d/VEXVDqHplND7+kEMiMiGe5srjI9Zr6Ct+KDXBKFQ==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@samvera/image-downloader/-/image-downloader-1.1.6.tgz",
+      "integrity": "sha512-CcSHxVtH8FEBFQ977fC6ygxMh45bu5kIEAT1NOojh68jfcEFADLT1FtlsZFd4XuA2ZQDfUgD0UXwKjS4MKoJIQ==",
       "dependencies": {
         "svg-loaders-react": "^2.2.1"
       },
@@ -15835,9 +15835,9 @@
       }
     },
     "@samvera/image-downloader": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@samvera/image-downloader/-/image-downloader-1.1.5.tgz",
-      "integrity": "sha512-Q1UAoNMvKGfEjMf9JEyCf8MvYtUNuOGXf0jOiwthKAh8d/VEXVDqHplND7+kEMiMiGe5srjI9Zr6Ct+KDXBKFQ==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@samvera/image-downloader/-/image-downloader-1.1.6.tgz",
+      "integrity": "sha512-CcSHxVtH8FEBFQ977fC6ygxMh45bu5kIEAT1NOojh68jfcEFADLT1FtlsZFd4XuA2ZQDfUgD0UXwKjS4MKoJIQ==",
       "requires": {
         "svg-loaders-react": "^2.2.1"
       }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@radix-ui/react-tabs": "^1.0.1",
     "@samvera/bloom-iiif": "^0.4.1",
     "@samvera/clover-iiif": "^1.13.0",
-    "@samvera/image-downloader": "^1.1.5",
+    "@samvera/image-downloader": "^1.1.6",
     "@samvera/nectar-iiif": "^0.0.20",
     "@stitches/react": "^1.2.6",
     "axios": "^1.2.2",


### PR DESCRIPTION
## What does this do?

This updates the `makeBlob()` requests to use [credentialed](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials) requests. This action is handled by the Download action on the Download and Share modal.