### PR TITLE
Swap out Facet aggs request useFetchApiData hook for apiPostRequest.

### DIFF
--- a/components/Facets/Filter/Filter.tsx
+++ b/components/Facets/Filter/Filter.tsx
@@ -51,7 +51,7 @@ const DialogWrapper: React.FC = () => {
       <Dialog.Portal>
         <DialogOverlay />
         <FilterContent data-testid="modal-content">
-          <FilterModal q={searchTerm} setIsModalOpen={setIsModalOpen} />
+          <FilterModal q={searchTerm || ""} setIsModalOpen={setIsModalOpen} />
         </FilterContent>
       </Dialog.Portal>
     </Dialog.Root>

--- a/hooks/useQueryParams.ts
+++ b/hooks/useQueryParams.ts
@@ -6,7 +6,7 @@ import { useRouter } from "next/router";
 export default function useQueryParams() {
   const { isReady, query } = useRouter();
   const [urlFacets, setUrlFacets] = React.useState<UrlFacets>({});
-  const [searchTerm, setSearchTerm] = React.useState<string>("");
+  const [searchTerm, setSearchTerm] = React.useState<string>();
 
   React.useEffect(() => {
     if (!isReady) return;

--- a/lib/queries/builder.ts
+++ b/lib/queries/builder.ts
@@ -31,7 +31,7 @@ export function buildQuery(obj: BuildQueryProps) {
       },
     }),
     ...(aggs && { aggs: buildAggs(aggs, aggsFilterValue, urlFacets) }),
-    ...(typeof size !== undefined && { size: size }),
+    ...(typeof size !== "undefined" && { size: size }),
   } as ApiSearchRequestBody;
 }
 


### PR DESCRIPTION
## What does this do?

This swaps out the older `geFetchApiData` in favor the more current `apiPostRequest()`.

Along with this we set the default value for **searchTerm** that is peeled off of `router.query.q` to be undefined. There was a React timing bug that sometimes allowed through the default value of an empty string even if a term was set. We now do not make aggregation requests unless we have verified the value of `router.query.q`. This seems to have fixed the root issue here.

## How should we review?

- Go to `/search`
- Complete a search for `Berkeley`
- Hit filter, check agg doc_counts,
- They should remain consistent as the open and close the filter modal.