### PR TITLE
Bloom options updates, disable preview.

### DIFF
--- a/components/BloomWrapper.tsx
+++ b/components/BloomWrapper.tsx
@@ -1,5 +1,9 @@
+import { SwiperProps } from "swiper/react";
 import dynamic from "next/dynamic";
+import { gr } from "@/styles/sizes";
+import { rem } from "@/styles/global";
 import { styled } from "@/stitches.config";
+import { width } from "@/styles/media";
 
 /* eslint sort-keys: 0 */
 
@@ -12,15 +16,62 @@ const StyledBloomIIIFWrapper = styled("div", {
   },
 });
 
+type SwiperBreakpoints = SwiperProps["breakpoints"];
+
+const breakpoints: SwiperBreakpoints = {
+  [width.xxs]: {
+    slidesPerView: 2,
+    slidesPerGroup: 2,
+    spaceBetween: rem,
+  },
+  [width.xs]: {
+    slidesPerView: 2,
+    slidesPerGroup: 2,
+    spaceBetween: rem,
+  },
+  [width.sm]: {
+    slidesPerView: 3,
+    slidesPerGroup: 3,
+    spaceBetween: rem,
+  },
+  [width.md]: {
+    slidesPerView: 4,
+    slidesPerGroup: 4,
+    spaceBetween: rem * gr(1),
+  },
+  [width.lg]: {
+    slidesPerView: 5,
+    slidesPerGroup: 5,
+    spaceBetween: rem * gr(1),
+  },
+  [width.xl]: {
+    slidesPerView: 6,
+    slidesPerGroup: 6,
+    spaceBetween: rem * gr(2),
+  },
+};
+
 const BloomIIIF: React.ComponentType<{
   collectionId: string;
+  options: {
+    breakpoints: SwiperBreakpoints;
+    credentials: "include" | "omit" | "same-origin";
+    enablePreview: boolean;
+  };
 }> = dynamic(() => import("@samvera/bloom-iiif"), {
   ssr: false,
 });
 
 const BloomIIIFWrapper = ({ collectionId }: { collectionId: string }) => (
   <StyledBloomIIIFWrapper>
-    <BloomIIIF collectionId={collectionId} />
+    <BloomIIIF
+      collectionId={collectionId}
+      options={{
+        enablePreview: false,
+        breakpoints: breakpoints,
+        credentials: "include",
+      }}
+    />
   </StyledBloomIIIFWrapper>
 );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@radix-ui/react-select": "^1.0.0",
         "@radix-ui/react-switch": "^1.0.1",
         "@radix-ui/react-tabs": "^1.0.1",
-        "@samvera/bloom-iiif": "^0.4.2",
+        "@samvera/bloom-iiif": "^0.5.0",
         "@samvera/clover-iiif": "^1.13.1",
         "@samvera/image-downloader": "^1.1.6",
         "@samvera/nectar-iiif": "^0.0.20",
@@ -2929,9 +2929,9 @@
       "dev": true
     },
     "node_modules/@samvera/bloom-iiif": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@samvera/bloom-iiif/-/bloom-iiif-0.4.2.tgz",
-      "integrity": "sha512-gPH/tkeXSX1A0IH5FkGBjBsnrwsaFc9/URXkz9pTXcyMo4Rpyvq/8V//6I0nXFee/USBCTpZDV7Gf2VUz59uWw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@samvera/bloom-iiif/-/bloom-iiif-0.5.0.tgz",
+      "integrity": "sha512-45Og5KT9DYx6MZzGymJKqLT5AlV3uAyqOUHroyGe4uFmQzavpoUsoXYYFVlXFw+S8vpICvAxsIXMPCSzHuP5qA==",
       "dependencies": {
         "@iiif/vault": "^0.9.19",
         "@iiif/vault-helpers": "^0.9.11",
@@ -15780,9 +15780,9 @@
       "dev": true
     },
     "@samvera/bloom-iiif": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@samvera/bloom-iiif/-/bloom-iiif-0.4.2.tgz",
-      "integrity": "sha512-gPH/tkeXSX1A0IH5FkGBjBsnrwsaFc9/URXkz9pTXcyMo4Rpyvq/8V//6I0nXFee/USBCTpZDV7Gf2VUz59uWw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@samvera/bloom-iiif/-/bloom-iiif-0.5.0.tgz",
+      "integrity": "sha512-45Og5KT9DYx6MZzGymJKqLT5AlV3uAyqOUHroyGe4uFmQzavpoUsoXYYFVlXFw+S8vpICvAxsIXMPCSzHuP5qA==",
       "requires": {
         "@iiif/vault": "^0.9.19",
         "@iiif/vault-helpers": "^0.9.11",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@radix-ui/react-select": "^1.0.0",
     "@radix-ui/react-switch": "^1.0.1",
     "@radix-ui/react-tabs": "^1.0.1",
-    "@samvera/bloom-iiif": "^0.4.2",
+    "@samvera/bloom-iiif": "^0.5.0",
     "@samvera/clover-iiif": "^1.13.1",
     "@samvera/image-downloader": "^1.1.6",
     "@samvera/nectar-iiif": "^0.0.20",

--- a/styles/global.ts
+++ b/styles/global.ts
@@ -2,6 +2,8 @@ import { globalCss } from "@stitches/react";
 
 /* eslint sort-keys: 0 */
 
+export const rem = 19;
+
 const defaults = {
   [`*`]: {
     boxSizing: "border-box",
@@ -24,7 +26,7 @@ const defaults = {
   html: {
     color: "$black80",
     fontFamily: "$northwesternSansRegular",
-    fontSize: "19px",
+    fontSize: `${rem}px`,
   },
 
   p: {


### PR DESCRIPTION
## What does this do?

This work updates the Bloom IIIF package, allowing us to disable the preview option on the Bloom slider. Additionally, I cleaned up the options been sent to each Bloom instance: set credentials to `include`,  customized the breakpoints to match our constant breakpoints, and set an explicit false on the **enablePreview** property.

## How should we review?
Go to any work. Bloom sliders should render without previews on hover/focus for each item. Breakpoints should also match our breakpoints better.