### PR TITLE
Add Box and Folder number back as facets.

### DIFF
--- a/lib/constants/facets-model.ts
+++ b/lib/constants/facets-model.ts
@@ -8,6 +8,11 @@ import {
 export const ALL_FACETS: FacetsList = {
   facets: [
     {
+      field: "box_number",
+      id: "boxNumber",
+      label: "Box Number",
+    },
+    {
       field: "collection.title.keyword",
       id: "collection",
       label: "Collection",
@@ -21,6 +26,11 @@ export const ALL_FACETS: FacetsList = {
       field: "creator.label",
       id: "creator",
       label: "Creator",
+    },
+    {
+      field: "folder_number",
+      id: "folderNumber",
+      label: "Folder Number",
     },
     {
       field: "genre.label",
@@ -176,6 +186,16 @@ export const FACETS_LOCATION: FacetsGroup = {
       field: "series",
       id: "series",
       label: "Series",
+    },
+    {
+      field: "box_number",
+      id: "boxNumber",
+      label: "Box Number",
+    },
+    {
+      field: "folder_number",
+      id: "folderNumber",
+      label: "Folder Number",
     },
   ],
   label: "Location",


### PR DESCRIPTION
## What does this do?

This adds back `box_number` and `folder_number` as facetable values. These are located under the **Location** group.

Review here:
https://preview-3552-box-folder-number.d1g4r4p7fos4jz.amplifyapp.com/search?boxNumber=20&folderNumber=10