### PR TITLE
Create responsive menu.

### DIFF
--- a/components/Header/Header.styled.ts
+++ b/components/Header/Header.styled.ts
@@ -18,6 +18,43 @@ const Lockup = styled("div", {
   },
 });
 
+const Menu = styled("div", {
+  "@sm": {
+    position: "absolute",
+    width: "100%",
+    left: "0",
+    top: "-2000px",
+    transition: "$dcOpacity",
+    zIndex: "0",
+    backgroundColor: "$purple",
+    opacity: "0",
+    boxShadow: "5px 5px 13px #0006",
+  },
+
+  variants: {
+    isExpanded: {
+      true: {
+        zIndex: "10",
+        top: "$gr5",
+        opacity: "1",
+      },
+    },
+  },
+});
+
+const MenuToggle = styled("button", {
+  display: "none",
+  height: "$gr5",
+  background: "none",
+  border: "transparent",
+  color: "$white",
+  cursor: "pointer",
+
+  "@sm": {
+    display: "block",
+  },
+});
+
 const PrimaryInner = styled("div", {
   display: "flex",
   flexGrow: "1",
@@ -114,7 +151,7 @@ const Super = styled("div", {
   position: "relative",
   backgroundColor: "$purple120",
   color: "$purple10",
-  zIndex: "1",
+  zIndex: "10",
 
   [`& ${ContainerStyled}`]: {
     display: "flex",
@@ -176,4 +213,13 @@ const HeaderStyled = styled("header", {
 
 export type HeaderVariants = VariantProps<typeof HeaderStyled>;
 
-export { Lockup, Primary, PrimaryInner, HeaderStyled, Super, User };
+export {
+  Lockup,
+  Menu,
+  MenuToggle,
+  Primary,
+  PrimaryInner,
+  HeaderStyled,
+  Super,
+  User,
+};

--- a/components/Header/Super.tsx
+++ b/components/Header/Super.tsx
@@ -1,9 +1,15 @@
-import { Super, User } from "@/components/Header/Header.styled";
-
+import { IconClear, IconMenu } from "../Shared/SVG/Icons";
+import {
+  Menu,
+  MenuToggle,
+  Super,
+  User,
+} from "@/components/Header/Header.styled";
 import Container from "../Shared/Container";
 import { DCAPI_ENDPOINT } from "@/lib/constants/endpoints";
 import Link from "next/link";
 import Nav from "@/components/Nav/Nav";
+import { NavResponsiveOnly } from "@/components/Nav/Nav.styled";
 import { NorthwesternWordmark } from "@/components/Shared/SVG/Northwestern";
 import React from "react";
 import { UserContext } from "@/context/user-context";
@@ -25,6 +31,7 @@ const nav = [
 
 export default function HeaderSuper() {
   const [isLoaded, setIsLoaded] = React.useState(false);
+  const [isExpanded, setIsExpanded] = React.useState(false);
 
   React.useEffect(() => {
     setIsLoaded(true);
@@ -32,39 +39,52 @@ export default function HeaderSuper() {
 
   const userAuthContext = React.useContext(UserContext);
 
+  const handleMenu = () => setIsExpanded(!isExpanded);
+
   return (
     <Super>
       <Container>
         <Link href="https://www.northwestern.edu/">
           {isLoaded && <NorthwesternWordmark />}
         </Link>
-        <Nav>
-          {nav.map(({ href, label }) => (
-            <Link key={label} href={href}>
-              {label}
-            </Link>
-          ))}
-          {!userAuthContext?.user?.isLoggedIn && (
-            <Link href={`${DCAPI_ENDPOINT}/auth/login?goto=${window.location}`}>
-              Sign in
-            </Link>
-          )}
-          {userAuthContext?.user?.isLoggedIn && (
-            <>
-              <User>{userAuthContext.user.name}</User>
-              <a
-                href={`${DCAPI_ENDPOINT}/auth/logout`}
-                style={{
-                  cursor: "pointer",
-                  paddingLeft: "8px",
-                  textDecoration: "underline",
-                }}
+        <Menu isExpanded={isExpanded}>
+          <NavResponsiveOnly>
+            <Link href="/search">Explore Works</Link>
+            <Link href="/collections">Browse Collections</Link>
+          </NavResponsiveOnly>
+          <Nav>
+            {nav.map(({ href, label }) => (
+              <Link key={label} href={href}>
+                {label}
+              </Link>
+            ))}
+            {!userAuthContext?.user?.isLoggedIn && (
+              <Link
+                href={`${DCAPI_ENDPOINT}/auth/login?goto=${window.location}`}
               >
-                Logout
-              </a>
-            </>
-          )}
-        </Nav>
+                Sign in
+              </Link>
+            )}
+            {userAuthContext?.user?.isLoggedIn && (
+              <>
+                <User>{userAuthContext.user.name}</User>
+                <a
+                  href={`${DCAPI_ENDPOINT}/auth/logout`}
+                  style={{
+                    cursor: "pointer",
+                    paddingLeft: "8px",
+                    textDecoration: "underline",
+                  }}
+                >
+                  Logout
+                </a>
+              </>
+            )}
+          </Nav>
+        </Menu>
+        <MenuToggle onClick={handleMenu}>
+          {isExpanded ? <IconClear /> : <IconMenu />}
+        </MenuToggle>
       </Container>
     </Super>
   );

--- a/components/Nav/Nav.styled.ts
+++ b/components/Nav/Nav.styled.ts
@@ -2,15 +2,57 @@ import { styled } from "@/stitches.config";
 
 /* eslint sort-keys: 0 */
 
+const NavResponsiveOnly = styled("div", {
+  display: "none",
+
+  "@sm": {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    padding: "$gr5 0 0",
+    fontFamily: "$northwesternSansBook",
+
+    "a, a:visited ": {
+      fontSize: "$gr4",
+      display: "flex",
+      marginBottom: "$gr3",
+      color: "$white",
+
+      "&:last-child": {
+        marginBottom: "0",
+      },
+    },
+  },
+});
+
 const NavStyled = styled("nav", {
   display: "flex",
   alignItems: "center",
   flexShrink: "1",
   flexGrow: "0",
 
-  a: {
+  "@sm": {
+    flexDirection: "column",
+    padding: "$gr5 0",
+    height: "unset !important",
+  },
+
+  "a, a:visited ": {
     textDecoration: "none",
+
+    "@sm": {
+      fontFamily: "$northwesternSansLight",
+      fontSize: "$gr3",
+      display: "flex",
+      marginBottom: "$gr3",
+      padding: "0 !important",
+      color: "$purple10",
+
+      "&:last-child": {
+        marginBottom: "0",
+      },
+    },
   },
 });
 
-export { NavStyled };
+export { NavResponsiveOnly, NavStyled };

--- a/components/Shared/SVG/Icons.tsx
+++ b/components/Shared/SVG/Icons.tsx
@@ -115,6 +115,20 @@ const IconLock: React.FC = () => (
   </svg>
 );
 
+const IconMenu: React.FC = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+    <title>Menu</title>
+    <path
+      fill="none"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-miterlimit="10"
+      stroke-width="48"
+      d="M88 152h336M88 256h336M88 360h336"
+    />
+  </svg>
+);
+
 const IconReturnDownBack: React.FC = () => (
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
     <title>Return Down Back</title>
@@ -191,6 +205,7 @@ export {
   IconImage,
   IconInfo,
   IconLock,
+  IconMenu,
   IconReturnDownBack,
   IconSearch,
   IconSocialFacebook,


### PR DESCRIPTION
## What does this do?

This adds a global minimal responsive menu at the `@sm` breakpoint. State is handled locally in the `<Super/>` subcomponent of `<Header>`

![image](https://user-images.githubusercontent.com/7376450/217057594-58ba7edf-20a1-4f18-b5a5-31d0cc7539e2.png)
