### PR TITLE
Ensure filter footer is visible in mobile browsers.

### DIFF
--- a/components/Facets/Facet/GenericFacet.styled.ts
+++ b/components/Facets/Facet/GenericFacet.styled.ts
@@ -31,6 +31,7 @@ const Find = styled("div", {
   height: "40px",
   marginBottom: "1rem",
   borderRadius: "3px",
+  zIndex: "1",
 
   [`& ${FindInput}`]: {
     position: "relative",

--- a/components/Facets/Filter/Filter.styled.ts
+++ b/components/Facets/Filter/Filter.styled.ts
@@ -107,6 +107,10 @@ const FilterFooter = styled("footer", {
   justifyContent: "space-between",
   alignItems: "center",
 
+  "@sm": {
+    padding: "$gr2",
+  },
+
   button: {
     display: "flex",
     alignItems: "center",
@@ -132,7 +136,8 @@ const FilterFooter = styled("footer", {
     },
 
     "@sm": {
-      fontSize: "$gr3",
+      fontSize: "$gr2",
+      padding: "$gr2 $gr3",
     },
   },
 });
@@ -208,7 +213,7 @@ const FilterContent = styled(Dialog.Content, {
   right: 0,
   bottom: 0,
   overflowY: "auto",
-  zIndex: "2",
+  zIndex: "10",
   borderRadius: "3px",
   boxShadow: "5px 5px 11px #0003",
 
@@ -227,8 +232,8 @@ const FilterContent = styled(Dialog.Content, {
   },
 
   "@sm": {
-    width: "100vw",
-    height: "100vh",
+    width: "100%",
+    height: "100%",
     top: "0",
     left: "0",
     borderRadius: "0",


### PR DESCRIPTION
## What does this do?

This styling fix makes sure that the Filter Footer is visible in mobile browsers. The heart of the is [resolved](https://github.com/nulib/dc-nextjs/pull/226/files#diff-746eb9b76bd76763779d6fd8f7f58e7f7ab226a9b7f5110e67d16fada5818101R235-R236) be using `100%` values in replacement of `100vh`. `vh` values are not great in mobile situations as browsers account for some of the vertical height for navigation controls.


https://github.com/nulib/dc-nextjs/blob/c64f951731273582055ad17ff1ca63c15853a750/components/Facets/Filter/Filter.styled.ts#L235-L236

Basically what was happening was that the Footer was there in the DOM, but not visible in the screen as it had extended beyond the bounds of the visible portion to a user. This also explains why we didn't see it in Browser responsive dev tools as they don't take into account browser controls.

## How should we review?

I have a few screens of how it looks now in a few devices:

**iPhone 8 + Safari**
![image](https://user-images.githubusercontent.com/7376450/217628710-b5bddaf5-e75e-4c3b-8a36-9523874e5366.png)

**iPhone 14 Pro + Safari**
![image](https://user-images.githubusercontent.com/7376450/217629069-4390a9d6-d126-404c-9ec9-453c88861b86.png)

**Samsung Galary S22 + Chrome**
![image](https://user-images.githubusercontent.com/7376450/217629264-46620269-100d-4987-b136-e52f498a432e.png)
