### PR TITLE
Update sitemap.xml to point to remote location

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,7 +2,7 @@
    <xml version="1.0" encoding="UTF-8">
    <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
      <url>
-       <loc>https://dc.library.northwestern.edu/sitemap.xml.gz</loc>
+       <loc>https://sitemaps.dc.library.northwestern.edu/sitemap.xml.gz</loc>
        <lastmod>2023-01-19</lastmod>
      </url>
    </urlset>


### PR DESCRIPTION
DC's sitemaps are now hosted at https://sitemaps.dc.library.northwestern.edu/, and this change will direct crawlers there.