### PR TITLE
Add no results message.

### DIFF
--- a/components/Search/Search.styled.ts
+++ b/components/Search/Search.styled.ts
@@ -78,14 +78,53 @@ const Clear = styled("button", {
   },
 });
 
-const Results = styled("p", {
+const ResultsMessage = styled("span", {
   color: "$black50",
-  padding: "0 $gr4",
+  padding: "0 $gr4 $gr4",
   fontSize: "$gr3",
 
-  "@md": {
-    padding: "0",
+  "@lg": {
+    padding: "0 0 $gr3",
   },
 });
 
-export { Button, Clear, Input, Results, SearchStyled };
+const NoResultsMessage = styled("span", {
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "center",
+  height: "100%",
+  alignItems: "center",
+  alignSelf: "center",
+  color: "$black50",
+  padding: "0 0 $gr8",
+  margin: "0 auto",
+  fontSize: "$gr3",
+  fontFamily: "$northwesternSansLight",
+  textAlign: "center",
+  flexGrow: "1",
+
+  strong: {
+    color: "$black",
+    fontFamily: "$northwesternSansBold",
+    fontWeight: "400",
+    display: "block",
+    margin: "0 0 $gr2",
+    fontSize: "$gr4",
+  },
+});
+
+const ResultsWrapper = styled("div", {
+  display: "flex",
+  flexDirection: "column",
+  minHeight: "80vh",
+});
+
+export {
+  Button,
+  Clear,
+  Input,
+  NoResultsMessage,
+  ResultsMessage,
+  ResultsWrapper,
+  SearchStyled,
+};

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -1,3 +1,8 @@
+import {
+  NoResultsMessage,
+  ResultsMessage,
+  ResultsWrapper,
+} from "@/components/Search/Search.styled";
 import React, { useEffect, useState } from "react";
 import { ApiSearchRequestBody } from "@/types/api/request";
 import { ApiSearchResponse } from "@/types/api/response";
@@ -11,7 +16,6 @@ import Layout from "@/components/layout";
 import { NextPage } from "next";
 import { PRODUCTION_URL } from "@/lib/constants/endpoints";
 import PaginationAltCounts from "@/components/Search/PaginationAltCounts";
-import { Results } from "@/components/Search/Search.styled";
 import { apiPostRequest } from "@/lib/dc-api";
 import axios from "axios";
 import { buildDataLayer } from "@/lib/ga/data-layer";
@@ -130,19 +134,32 @@ const SearchPage: NextPage = () => {
         </Heading>
         <Facets />
         <Container containerType="wide">
-          <div style={{ minHeight: "80vh" }}>
+          <ResultsWrapper>
             {loading && <></>}
             {error && <p>{error}</p>}
             {apiData && (
               <>
-                <Results>
-                  {totalResults && pluralize("result", totalResults)}
-                </Results>
+                {totalResults ? (
+                  <ResultsMessage>
+                    {" "}
+                    {pluralize("result", totalResults)}
+                  </ResultsMessage>
+                ) : (
+                  <NoResultsMessage>
+                    <strong>Your search did not match any results.</strong>{" "}
+                    Please try broadening your search terms or adjusting your
+                    filters.
+                  </NoResultsMessage>
+                )}
                 <Grid data={apiData.data} info={apiData.info} />
-                <PaginationAltCounts pagination={apiData.pagination} />
+                {totalResults ? (
+                  <PaginationAltCounts pagination={apiData.pagination} />
+                ) : (
+                  <></>
+                )}
               </>
             )}
-          </div>
+          </ResultsWrapper>
         </Container>
       </Layout>
     </>


### PR DESCRIPTION
## What does this do?

This adds a nice visually centered no results message on the `/search`page. Pagination also does not show any longer if results are `0`. Most of the work here is styling with some minor reworking of the conditionals to render the Results messages and the Pagination. 

![image](https://user-images.githubusercontent.com/7376450/217936749-fb8ae113-5142-494d-b63f-d03f4022b451.png)
