### PR TITLE
Add an API route and rewrites to fetch sitemaps from an S3 bucket

### DIFF
--- a/lib/constants/bucket.ts
+++ b/lib/constants/bucket.ts
@@ -1,0 +1,3 @@
+const DC_SITEMAP_BUCKET = process.env.NEXT_PUBLIC_DC_SITEMAP_BUCKET;
+
+export { DC_SITEMAP_BUCKET };

--- a/pages/api/sitemap/[filename].tsx
+++ b/pages/api/sitemap/[filename].tsx
@@ -1,0 +1,47 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import axios, { AxiosError, AxiosResponse } from "axios";
+import { DC_SITEMAP_BUCKET } from "@/lib/constants/bucket";
+
+class NotFound extends Error {
+  constructor() {
+    super("Not Found");
+  }
+}
+
+const getObject = async (filename: string): Promise<AxiosResponse> => {
+  if (!DC_SITEMAP_BUCKET || !filename) throw new NotFound();
+  try {
+    return await axios(`http://${DC_SITEMAP_BUCKET}/${filename}`, { responseType: "stream" });
+  } catch (err) {
+    console.warn('caught in getObject', err);
+    if (err instanceof AxiosError) throw new NotFound();
+    throw err;
+  }
+};
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse): Promise<void> {  
+  const { filename } = req.query;
+  try {
+    const response: AxiosResponse = await getObject(filename as string);
+
+    res
+      .status(200)
+      .setHeader("Content-Type", response.headers["content-type"] as string)
+      .setHeader("Content-Length", response.headers["content-length"] as string)
+      .setHeader("ETag", response.headers["etag"] as string)
+      .setHeader("Last-Modified", response.headers["last-modified"] as string);
+    response.data.pipe(res);
+  } catch (err) {
+    if (err instanceof NotFound) {
+      res.status(404).end("Not Found");
+    } else {
+      throw err;
+    }
+  }
+}
+
+export const config = {
+  api: {
+    responseLimit: false,
+  },
+};

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,9 +1,0 @@
-<!-- public/sitemap.xml -->
-   <xml version="1.0" encoding="UTF-8">
-   <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-     <url>
-       <loc>https://sitemaps.dc.library.northwestern.edu/sitemap.xml.gz</loc>
-       <lastmod>2023-01-19</lastmod>
-     </url>
-   </urlset>
-   </xml>

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -69,22 +69,39 @@ resource "aws_amplify_app" "dc-next" {
 
   lifecycle {
     ignore_changes = [
-      custom_rule,
       basic_auth_credentials
     ]
   }
 
   environment_variables = {
-    ENV                        = var.environment_name
-    HONEYBADGER_API_KEY        = var.honeybadger_api_key
-    HONEYBADGER_ENV            = var.environment_name
-    NEXT_PUBLIC_DCAPI_ENDPOINT = var.next_public_dcapi_endpoint
-    NEXT_PUBLIC_DC_URL         = var.next_public_dc_url
+    ENV                           = var.environment_name
+    HONEYBADGER_API_KEY           = var.honeybadger_api_key
+    HONEYBADGER_ENV               = var.environment_name
+    NEXT_PUBLIC_DCAPI_ENDPOINT    = var.next_public_dcapi_endpoint
+    NEXT_PUBLIC_DC_URL            = var.next_public_dc_url
+    NEXT_PUBLIC_DC_SITEMAP_BUCKET = aws_s3_bucket_website_configuration.sitemap_website.website_endpoint
+  }
+
+  custom_rule {
+    source = "/sitemap.xml"
+    target = "/api/sitemap/sitemap.xml"
+    status = 200
+  }
+
+  custom_rule {
+    source = "/sitemap.xml.gz"
+    target = "/api/sitemap/sitemap.xml.gz"
+    status = 200
+  }
+
+  custom_rule {
+    source = "/sitemap-<*>"
+    target = "/api/sitemap/sitemap-<*>"
+    status = 200
   }
 }
 
 resource "aws_iam_role" "dc_next_amplify_role" {
-
   name                = "${var.project}-role"
   assume_role_policy  = join("", data.aws_iam_policy_document.assume_role.*.json)
   managed_policy_arns = ["arn:aws:iam::aws:policy/AdministratorAccess-Amplify"]

--- a/terraform/sitemap_bucket.tf
+++ b/terraform/sitemap_bucket.tf
@@ -1,0 +1,28 @@
+data "aws_iam_policy_document" "allow_sitemap_bucket_access_from_cloudfront" {
+  statement {
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.sitemap_bucket.arn}/*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "sitemap_bucket" {
+  bucket = aws_s3_bucket.sitemap_bucket.id
+  policy = data.aws_iam_policy_document.allow_sitemap_bucket_access_from_cloudfront.json
+}
+
+resource "aws_s3_bucket" "sitemap_bucket" {
+  bucket = "${var.project}-${var.environment_name}-sitemaps"
+}
+
+resource "aws_s3_bucket_website_configuration" "sitemap_website" {
+  bucket = aws_s3_bucket.sitemap_bucket.bucket
+
+  index_document {
+    suffix = "sitemap.xml"
+  }
+}


### PR DESCRIPTION
This PR contains all the changes needed to deliver sitemaps from the root of the server without having to trigger a build every time the sitemap changes.

- Create a public-read static website bucket to hold sitemaps
- Create a NextJS api route `/api/sitemap/:filename` to stream content from the sitemap bucket to the client
- Add three rewrite rules to the Amplify app to transparently rewrite `/sitemap*` to `/api/sitemap/sitemap*` without redirecting the client

Results can be seen in the preview branch at https://preview-sitemap-bucket.d2v1qbdeix3nr2.amplifyapp.com/sitemap.xml

There is a [companion PR](nulib/meadow#3225) to tell Meadow about the new sitemap location and have it generate the proper index file