### PR TITLE
Reconfigure Honeybadger to upload and make use of source maps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ yarn-error.log*
 *.tfvars
 /terraform/.terraform
 /terraform/*.plan
+
+# ephemeral build artifacts
+/lib/honeybadger/config.vars.js

--- a/lib/honeybadger/config.js
+++ b/lib/honeybadger/config.js
@@ -1,18 +1,23 @@
+import {
+  HONEYBADGER_API_KEY,
+  HONEYBADGER_ENV,
+  HONEYBADGER_REVISION,
+} from "./config.vars.js";
 import Honeybadger from "@honeybadger-io/js";
 
 const setupHoneyBadger = () => {
   // https://docs.honeybadger.io/lib/javascript/reference/configuration.html
   const sharedHoneybadgerConfig = {
-    apiKey: process.env.HONEYBADGER_API_KEY,
-    environment: process.env.HONEYBADGER_ENV || process.env.NODE_ENV,
+    apiKey: HONEYBADGER_API_KEY,
+    environment: HONEYBADGER_ENV || process.env.NODE_ENV,
     projectRoot: "webpack://_N_E/./",
 
     // Uncomment to report errors in development:
     reportData: true,
 
-    revision: process.env.AWS_COMMIT_ID,
+    revision: HONEYBADGER_REVISION,
   };
-
+  
   if (typeof window === "undefined") {
     // Node config
     const projectRoot = process.cwd();
@@ -20,11 +25,11 @@ const setupHoneyBadger = () => {
       ...sharedHoneybadgerConfig,
       projectRoot: "webpack:///./",
     }).beforeNotify((notice) => {
-      notice.backtrace.forEach((line) => {
+      notice.backtrace = notice.backtrace.map((line) => {
         if (line.file) {
           line.file = line.file.replace(
             `${projectRoot}/.next/server`,
-            `${process.env.HONEYBADGER_ASSETS_URL}/..`
+            `${process.env.NEXT_PUBLIC_DC_URL}/_next/..`
           );
         }
         return line;
@@ -35,6 +40,16 @@ const setupHoneyBadger = () => {
     Honeybadger.configure({
       ...sharedHoneybadgerConfig,
       projectRoot: "webpack://_N_E/./",
+    }).beforeNotify((notice) => {
+      notice.backtrace = notice.backtrace.map((line) => {
+        if (line.file) {
+          line.file = line.file.replace(
+            /^.+\/_next\//,
+            `${process.env.NEXT_PUBLIC_DC_URL}/_next/`
+          );
+        }
+        return line;
+      });
     });
   }
 

--- a/next.config.js
+++ b/next.config.js
@@ -1,14 +1,27 @@
+const fs = require("fs");
 const HoneybadgerSourceMapPlugin = require("@honeybadger-io/webpack");
 
 // Use the HoneybadgerSourceMapPlugin to upload the source maps during build step
 const {
   HONEYBADGER_API_KEY,
   HONEYBADGER_ENV,
-  HONEYBADGER_ASSETS_URL,
   HONEYBADGER_REPORT_DATA,
+  NEXT_PUBLIC_DC_URL,
 } = process.env;
 const NODE_ENV = process.env.HONEYBADGER_ENV || process.env.NODE_ENV;
-const HONEYBADGER_REVISION = process.env.AWS_COMMIT_ID;
+const HONEYBADGER_REVISION = process.env.HONEYBADGER_REVISION || process.env.AWS_COMMIT_ID;
+
+const HoneybadgerConfig = JSON.stringify({
+  HONEYBADGER_API_KEY,
+  HONEYBADGER_ENV,
+  HONEYBADGER_REPORT_DATA,
+  HONEYBADGER_REVISION,
+}, null, 2);
+
+fs.writeFileSync(
+  "lib/honeybadger/config.vars.js",
+  `module.exports = ${HoneybadgerConfig};`
+);
 
 /** @type {import('next').NextConfig} */
 module.exports = {
@@ -28,7 +41,7 @@ module.exports = {
     ],
   },
   reactStrictMode: true,
-  swcMinify: false,
+  swcMinify: true,
   webpack: (config) => {
     // When all the Honeybadger configuration env variables are
     // available/configured The Honeybadger webpack plugin gets pushed to the
@@ -36,10 +49,10 @@ module.exports = {
     // This is an alternative to manually uploading the source maps.
     // See https://docs.honeybadger.io/lib/javascript/guides/using-source-maps.html
     // Note: This is disabled in development mode.
+
     if (
       HONEYBADGER_API_KEY &&
-      HONEYBADGER_ASSETS_URL &&
-      NODE_ENV === "production"
+      (NODE_ENV === "production" || NODE_ENV === "staging")
     ) {
       // `config.devtool` must be 'hidden-source-map' or 'source-map' to properly pass sourcemaps.
       // Next.js uses regular `source-map` which doesnt pass its sourcemaps to Webpack.
@@ -47,11 +60,10 @@ module.exports = {
       // Use the hidden-source-map option when you don't want the source maps to be
       // publicly available on the servers, only to the error reporting
       config.devtool = "hidden-source-map";
-
       config.plugins.push(
         new HoneybadgerSourceMapPlugin({
           apiKey: HONEYBADGER_API_KEY,
-          assetsUrl: HONEYBADGER_ASSETS_URL,
+          assetsUrl: `${NEXT_PUBLIC_DC_URL}/_next`,
           revision: HONEYBADGER_REVISION,
         })
       );


### PR DESCRIPTION
The `AWS_COMMIT_ID` provided by Amplify is a build-time only variable, so while it was working for the building and uploading of source maps (which happens a build time), the error reporting component was not receiving the revision ID at runtime. We fixed this by writing the configuration variables to a file at build time and importing them at runtime.