### PR TITLE
GTM dataLayer send user logged in status

### DIFF
--- a/components/Header/Super.tsx
+++ b/components/Header/Super.tsx
@@ -38,7 +38,6 @@ export default function HeaderSuper() {
   }, []);
 
   const userAuthContext = React.useContext(UserContext);
-
   const handleMenu = () => setIsExpanded(!isExpanded);
 
   return (

--- a/context/user-context.tsx
+++ b/context/user-context.tsx
@@ -1,7 +1,6 @@
 import React, { ReactNode, createContext, useState } from "react";
 import { type User, type UserContext } from "@/types/context/user";
-import { DCAPI_ENDPOINT } from "@/lib/constants/endpoints";
-import axios from "axios";
+import { getUser } from "@/lib/user-helpers";
 
 const UserContext = createContext<UserContext>({ user: null });
 
@@ -10,30 +9,24 @@ const UserProvider = ({ children }: { children: ReactNode }) => {
 
   React.useEffect(() => {
     /* Determine if user is authenticated via cookie */
-    axios
-      .get(`${DCAPI_ENDPOINT}/auth/whoami`, {
-        withCredentials: true,
-      })
-      .then((result) => {
-        if (!result.data) return;
-        const {
-          email,
-          isLoggedIn = false,
-          isReadingRoom = false,
-          name,
-          sub,
-        } = result.data;
-        setUser({
-          email,
-          isLoggedIn,
-          isReadingRoom,
-          name,
-          sub,
-        });
+    getUser().then((result) => {
+      if (!result) return;
+      const {
+        email,
+        isLoggedIn = false,
+        isReadingRoom = false,
+        name,
+        sub,
+      } = result;
+      setUser({
+        email,
+        isLoggedIn,
+        isReadingRoom,
+        name,
+        sub,
       });
+    });
   }, []);
-
-  //  165.124.167.1
 
   return (
     <UserContext.Provider value={{ user }}>{children}</UserContext.Provider>

--- a/lib/dc-api.ts
+++ b/lib/dc-api.ts
@@ -73,4 +73,4 @@ function handleError(err: unknown) {
     console.log("Error", error.message);
   }
 }
-export { apiGetRequest, apiPostRequest, getIIIFResource };
+export { apiGetRequest, apiPostRequest, getIIIFResource, handleError };

--- a/lib/ga/data-layer.ts
+++ b/lib/ga/data-layer.ts
@@ -52,7 +52,6 @@ export function buildWorkDataLayer(work: Work): DataLayer {
     adminset: work?.library_unit || "",
     collections: work?.collection?.title ? work.collection.title : null,
     creatorsContributors,
-    isLoggedIn: false,
     pageTitle: work?.title || "",
     rightsStatement: work?.rights_statement?.label
       ? work.rights_statement.label

--- a/lib/user-helpers.ts
+++ b/lib/user-helpers.ts
@@ -1,0 +1,14 @@
+import { DCAPI_ENDPOINT } from "@/lib/constants/endpoints";
+import axios from "axios";
+import { handleError } from "./dc-api";
+
+export async function getUser() {
+  try {
+    const response = await axios.get(`${DCAPI_ENDPOINT}/auth/whoami`, {
+      withCredentials: true,
+    });
+    return response.data;
+  } catch (err) {
+    handleError(err);
+  }
+}


### PR DESCRIPTION
## What does this do?
Fixes GTM's `dataLayer` user logged in status.

![image](https://user-images.githubusercontent.com/3020266/218525599-267aff4d-4d30-4ae3-8cb0-84a9a5013209.png)


## How to test
From any page in DC, load the page, then in the browser console type `dataLayer` to get access viewing the `window` object.  Look for `isLoggedIn`, being logged in, and not being logged in.

