### PR TITLE
Add dimensions and materials to label constant.

### DIFF
--- a/lib/constants/works.ts
+++ b/lib/constants/works.ts
@@ -29,6 +29,9 @@ const WORK_METADATA_LABELS: WorkMetadata[] = [
     searchParam: "libraryDepartment",
   },
   {
+    label: "Dimensions",
+  },
+  {
     label: "Genre",
     searchParam: "genre",
   },
@@ -41,6 +44,9 @@ const WORK_METADATA_LABELS: WorkMetadata[] = [
   },
   {
     label: "Location",
+  },
+  {
+    label: "Materials",
   },
   {
     label: "Notes",


### PR DESCRIPTION
## What does this do?

This adds Dimensions and Materials to the label constant object that is fed into Nectar's Metadata component.

## How should we review?
Checkout these works. Materials and Dimensions render bulleted like other metadata.

- https://devbox.library.northwestern.edu:3000/items/675fa149-9a92-4d81-b001-3cad32224579
- https://devbox.library.northwestern.edu:3000/items/1e63bd7e-9a42-43d4-b752-afe92e23f270