### PR TITLE
Responsive refinements.

### DIFF
--- a/components/BloomWrapper.tsx
+++ b/components/BloomWrapper.tsx
@@ -15,9 +15,10 @@ const StyledBloomIIIFWrapper = styled("div", {
     display: "none",
   },
 
-  "@sm": {
+  "@xs": {
     "& > div > div": {
       alignItems: "center",
+      textAlign: "center",
 
       "& > div": {
         "&:last-child": {

--- a/components/Facets/Facets.styled.ts
+++ b/components/Facets/Facets.styled.ts
@@ -1,4 +1,3 @@
-import { StyledToggle } from "@/components/Shared/Switch.styled";
 import { Wrapper as WorkTypeWrapper } from "@/components/Facets/WorkType/WorkType.styled";
 import { styled } from "@/stitches.config";
 
@@ -7,23 +6,28 @@ import { styled } from "@/stitches.config";
 const StyledFacets = styled("div", {
   display: "flex",
   justifyContent: "space-between",
-  margin: "1.618rem 0",
   position: "relative",
+  margin: "$gr4 0",
   left: "0",
-  transition: "$dcAll",
+  transition: "$dcScrollLeft",
   zIndex: "1",
 
   [`& ${WorkTypeWrapper}`]: {
     borderRight: "1px solid $black10",
     paddingRight: "$gr2",
     transition: "$dcWidth",
+
+    "@sm": {
+      marginTop: "$gr3",
+      borderRight: "none",
+      paddingRight: "0",
+    },
   },
 
   "@sm": {
-    [`& ${WorkTypeWrapper}`]: {
-      width: "0",
-      opacity: "0",
-    },
+    padding: "$gr4 0",
+    flexDirection: "column",
+    alignItems: "center",
   },
 });
 
@@ -32,41 +36,61 @@ const Width = styled("span", {
   width: "100%",
 });
 
+const FacetExtras = styled("div", {
+  display: "flex",
+
+  "@sm": {
+    marginTop: "$gr4",
+    flexDirection: "column-reverse",
+    alignItems: "center",
+  },
+});
+
 const Wrapper = styled("div", {
+  height: "38px",
+  transition: "$dcScrollHeight",
+  margin: "$gr4 0",
+
+  "@sm": {
+    margin: "-$gr4 0 $gr4",
+    backgroundColor: "$gray6",
+    height: "225px",
+  },
+
   ".facets-ui-container": {
     transition: "$dcAll",
   },
 
   "&[data-filter-fixed='true']": {
-    margin: "1.618rem 0",
     flexGrow: "0",
     flexShrink: "1",
     height: "38px",
 
-    [`& ${WorkTypeWrapper}`]: {
+    "@sm": {
+      backgroundColor: "transparent",
+      margin: "0",
+    },
+
+    [`& ${FacetExtras}`]: {
       width: "0",
       opacity: "0",
     },
 
     [`& ${StyledFacets}`]: {
       position: "fixed",
-      top: "50px",
+      margin: "0",
+      top: "$gr6",
       left: "50%",
       zIndex: "1",
       transform: "translate(-50%)",
       backfaceVisibility: "hidden",
       webkitFontSmoothing: "subpixel-antialiased",
-    },
 
-    [`& ${StyledToggle}`]: {
-      width: "0",
-      opacity: "0",
+      "@sm": {
+        top: "$gr5",
+      },
     },
   },
-});
-
-const FacetExtras = styled("div", {
-  display: "flex",
 });
 
 export { FacetExtras, StyledFacets, Width, Wrapper };

--- a/components/Facets/Filter/Clear.styled.ts
+++ b/components/Facets/Filter/Clear.styled.ts
@@ -17,6 +17,7 @@ const FilterClearStyled = styled("button", {
   marginLeft: "$gr2",
   padding: "0 $gr3",
   transition: "$dcAll",
+  whiteSpace: "nowrap",
 
   "&:focus, &:hover": {
     color: "$purple",

--- a/components/Header/Header.styled.ts
+++ b/components/Header/Header.styled.ts
@@ -76,6 +76,7 @@ const Primary = styled("div", {
   position: "relative",
   top: "unset",
   height: "$gr5",
+  boxShadow: "2px 2px 5px #0001",
 
   [`& ${ContainerStyled}`]: {
     display: "flex",
@@ -86,15 +87,15 @@ const Primary = styled("div", {
     transition: "$dcAll",
 
     [`& ${NavStyled}`]: {
-      backgroundColor: "$gray6",
-      color: "$purple",
+      backgroundColor: "$purple120",
       fontSize: "$gr4",
-      fontFamily: "$northwesternSansBold",
-      paddingTop: "2px",
+      fontFamily: "$northwesternSansRegular",
       display: "flex",
       height: "$gr5",
+      boxShadow: "3px -3px 19px #fff1",
 
       a: {
+        color: "$white",
         display: "flex",
         height: "100%",
         justifyContent: "center",
@@ -120,6 +121,8 @@ const Primary = styled("div", {
   },
 
   "&[data-search-fixed='true']": {
+    zIndex: "2",
+
     [`& ${ContainerStyled}`]: {
       position: "fixed",
       top: "0",
@@ -141,10 +144,6 @@ const Primary = styled("div", {
       [`& ${NavStyled}`]: {
         width: "0",
         opacity: "0",
-      },
-
-      button: {
-        backgroundColor: "$purple10",
       },
 
       [`& ${SearchStyled}`]: {
@@ -209,6 +208,8 @@ const HeaderStyled = styled("header", {
         },
 
         [`& ${Primary}`]: {
+          boxShadow: "unset",
+
           [`& ${SearchStyled}, & ${NavStyled}`]: {
             boxShadow: "8px 8px 19px #0003",
           },

--- a/components/Heading/Heading.styled.ts
+++ b/components/Heading/Heading.styled.ts
@@ -19,6 +19,10 @@ const StyledHeading = styled("h2", {
     letterSpacing: "-0.015em",
     margin: "$gr6 0 $gr4",
 
+    "@sm": {
+      fontSize: "$gr7 !important",
+    },
+
     "&::before": {
       height: "$gr1",
       width: "$gr7",

--- a/components/Homepage/Overview.tsx
+++ b/components/Homepage/Overview.tsx
@@ -25,7 +25,7 @@ const HomepageOverview = () => {
               audiovisual materials - as well as licensed art historical images
               for teaching and reference.
             </p>
-            <Button isPrimary onClick={() => router.push("/about")}>
+            <Button isPrimary isLowercase onClick={() => router.push("/about")}>
               Learn More
             </Button>
           </Content>

--- a/components/Search/Search.styled.ts
+++ b/components/Search/Search.styled.ts
@@ -10,12 +10,16 @@ const SearchStyled = styled("form", {
   backgroundColor: "$white",
   height: "$gr5",
   marginRight: "$gr5",
-  boxShadow: "inset 0 -1px 0 #f0f0f0",
+  boxShadow: "3px -3px 19px #fff1",
   transition: "$dcAll",
 
   "@sm": {
     width: "100%",
     marginRight: "0",
+  },
+
+  "@lg": {
+    marginRight: "$gr3",
   },
 
   svg: {
@@ -41,19 +45,30 @@ const Input = styled("input", {
   width: "100%",
   border: "none",
   backgroundColor: "transparent",
-  padding: "2px $gr5 0",
+  padding: "1px $gr3 0 $gr5",
   fontSize: "$gr3",
   zIndex: "1",
   fontFamily: "$northwesternSansRegular",
+  whiteSpace: "nowrap",
+
+  "&::placeholder": {
+    overflow: "hidden",
+    color: "$black80",
+    textOverflow: "ellipsis",
+    marginRight: "$gr5",
+  },
 });
 
 const Button = styled("button", {
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "center",
   border: "none",
-  backgroundColor: "$gray6",
-  padding: "2px $3 0",
-  color: "$purple",
+  backgroundColor: "$purple120",
+  padding: "0 $gr3 ",
+  color: "$white",
   fontSize: "$gr4",
-  fontFamily: "$northwesternSansBold",
+  fontFamily: "$northwesternSansRegular",
   cursor: "pointer",
   textRendering: "optimizeLegibility",
 });
@@ -63,18 +78,25 @@ const Clear = styled("button", {
   display: "flex",
   right: "5rem",
   height: "$gr5",
-  width: "$gr5",
+  width: "calc($gr5 + $gr2)",
   justifyContent: "center",
   textAlign: "center",
   alignItems: "center",
   cursor: "pointer",
   border: "none",
-  backgroundColor: "transparent",
+  background: "linear-gradient(90deg, #fff0 0, #fff  38.2%)",
   zIndex: "1",
+  fill: "$black80",
+
+  "&:focus, &:hover": {
+    fill: "$purple30",
+  },
 
   svg: {
-    fill: "$black50",
-    padding: "$gr1",
+    fill: "inherit",
+    padding: "$gr2",
+    marginLeft: "$gr2",
+    transition: "$dcAll",
   },
 });
 

--- a/components/Search/Search.tsx
+++ b/components/Search/Search.tsx
@@ -1,5 +1,9 @@
 import { Button, Clear, Input, SearchStyled } from "./Search.styled";
-import { IconClear, IconSearch } from "@/components/Shared/SVG/Icons";
+import {
+  IconArrowForward,
+  IconClear,
+  IconSearch,
+} from "@/components/Shared/SVG/Icons";
 import React, {
   ChangeEvent,
   FocusEvent,
@@ -98,7 +102,7 @@ const Search: React.FC<SearchProps> = ({ isSearchActive }) => {
         </Clear>
       )}
       <Button type="submit" data-testid="submit-button">
-        Search
+        Search <IconArrowForward />
       </Button>
       {isLoaded && <IconSearch />}
     </SearchStyled>

--- a/components/Work/TopInfo.styled.ts
+++ b/components/Work/TopInfo.styled.ts
@@ -7,12 +7,12 @@ const ActionButtons = styled("div", {
   display: "flex",
   flexDirection: "row",
   justifyContent: "flext-start",
-  padding: "1rem 0",
+  padding: "$gr2 0",
 
   button: {
-    marginRight: "$4",
+    marginRight: "$gr3",
     fontFamily: "$northwesternSansLight",
-    paddingTop: "$3",
+    paddingTop: "$gr3",
 
     "&:last-child": {
       marginRight: "0",
@@ -30,9 +30,9 @@ const ActionButtons = styled("div", {
 
 const TopInfoContent = styled("div", {
   display: "grid",
-  gap: "$7",
+  gap: "$gr7",
   gridTemplateColumns: "618fr 382fr",
-  margin: "$3 0",
+  margin: "$gr3 0",
 
   "@md": {
     gap: "$gr5",
@@ -45,7 +45,7 @@ const TopInfoContent = styled("div", {
 });
 
 const TopInfoWrapper = styled("section", {
-  margin: "$6 0",
+  margin: "$gr5 0",
 
   [`> header`]: {
     display: "flex",
@@ -58,28 +58,26 @@ const TopInfoWrapper = styled("section", {
       letterSpacing: "-0.015em",
       margin: "0",
 
-      "&::before": {
-        height: "$1",
-        width: "$7",
-        display: "block",
-        backgroundColor: "$purple10",
-        content: "",
-        position: "relative",
-        top: "-$4",
+      "@sm": {
+        fontSize: "$gr7",
       },
     },
 
     p: {
-      fontSize: "$5",
+      fontSize: "$gr5",
       color: "$black50",
       fontFamily: "$northwesternSansLight",
       lineHeight: "1.47em",
+
+      "@sm": {
+        fontSize: "$gr4",
+      },
     },
   },
 });
 
 const TopInfoCollection = styled("div", {
-  padding: "1rem 0",
+  padding: "$gr4 0",
 
   [`& ${StyledHeading}`]: {
     color: "$black80",

--- a/styles/transitions.ts
+++ b/styles/transitions.ts
@@ -7,6 +7,8 @@ const transitions = {
   dcAll: `all ${seconds}s ${timingFunction}`,
   dcOpacity: `opacity ${seconds}s ${timingFunction}`,
   dcImageLoad: `all 1s ${timingFunction}`,
+  dcScrollLeft: `left 1s ${timingFunction}`,
+  dcScrollHeight: `height 1s ${timingFunction}`,
   dcWidth: `width ${seconds}s ${timingFunction}`,
 };
 


### PR DESCRIPTION
## What does this do?

This work resolves a handful of small responsive issues that have lingered for a bit.

  - The Clear All and Public Works Only actions now collapse into columns in a small viewport. We also have show the Work Type actions as well (these were hidden). Transitions on scrolling to a fixed search bar are now quite a bit smoother here too. 
  - The zIndex issue on the Search bar for Image works is resolve. The fixed search bar now glides over top of the viewer, rather than under.
  - Some small font size adjustments were made to increase legibility in small viewports on an individual work
  - The search bar has some minor styling adjustments, 1) the placeholder text now has an ellipsis for overflow, 2) the clear button for search queries renders with a fading gradient over text inputs, 3) the search button is purple and pops a bit more, and 4) some minor margin/padding updates were made.
  - Bloom label and summary are now centered on `xs` viewports.