### PR TITLE
Remove fuzziness and wildcard from Search

### DIFF
--- a/lib/honeybadger/config.js
+++ b/lib/honeybadger/config.js
@@ -13,11 +13,11 @@ const setupHoneyBadger = () => {
     projectRoot: "webpack://_N_E/./",
 
     // Uncomment to report errors in development:
-    reportData: true,
+    //reportData: true,
 
     revision: HONEYBADGER_REVISION,
   };
-  
+
   if (typeof window === "undefined") {
     // Node config
     const projectRoot = process.cwd();

--- a/lib/queries/search.ts
+++ b/lib/queries/search.ts
@@ -23,15 +23,8 @@ const querySearchTemplate = {
 
 const buildSearchPart = (term: string) => {
   /**
-   * Does the search term contain an OpenSearch "phrase" (ie. "Joan and Bob")
-   *
    * Reference: https://www.elastic.co/guide/en/elasticsearch/reference/7.17/query-dsl-query-string-query.html#query-string-query-notes
    */
-  const hasPhrase = term.includes(`"`);
-
-  /** Phrase search terms are passed directly, but regular search adds some forgiveness */
-  const queryTerm = hasPhrase ? term : `${term}~1 | ${term}*`;
-
   return {
     query_string: {
       /**
@@ -39,7 +32,7 @@ const buildSearchPart = (term: string) => {
        * https://github.com/nulib/meadow/blob/deploy/staging/app/priv/elasticsearch/v2/settings/work.json
        */
       fields: ["title^5", "all_text", "all_controlled_labels", "all_ids"],
-      query: queryTerm,
+      query: term,
     },
   };
 };


### PR DESCRIPTION
## What does this do?
Updates Search to eliminate fuzziness and get more accurate results.   It allows for direct pass through searches for "power searching" as well.

This is part one of being able to add future auto suggest and "did you mean..." capabilities.

## How to test
Try the following searches and they should return expected results (previously returned no results).

```
title:(carol AND kathy)
_exists_:title
NOT _exists_:title
NOT title:(carol OR kathy)
```