### PR TITLE
Tell `next/image` not to proxy and optimize.

### DIFF
--- a/components/Figure/Figure.tsx
+++ b/components/Figure/Figure.tsx
@@ -51,6 +51,7 @@ const Figure: React.FC<FigureProps & FigureVariants> = (props) => {
             sizes={srcSetSizes}
             src={lqip.toString()}
             priority={true}
+            unoptimized={true}
           />
           <FigureImage
             alt={title}
@@ -60,6 +61,7 @@ const Figure: React.FC<FigureProps & FigureVariants> = (props) => {
             onError={handleOnError}
             sizes={srcSetSizes}
             src={src}
+            unoptimized={true}
           />
         </FigurePlaceholder>
       </FigureImageWrapper>

--- a/components/Grid/Item.test.tsx
+++ b/components/Grid/Item.test.tsx
@@ -35,7 +35,7 @@ describe("GridItem component", () => {
     render(<GridItem item={mockItem as SearchShape} />);
 
     expect(screen.getByAltText(mockItem.title).getAttribute("src")).toContain(
-      encodeURIComponent(mockItem.thumbnail)
+      mockItem.thumbnail
     );
   });
 
@@ -44,12 +44,10 @@ describe("GridItem component", () => {
 
     expect(
       screen.getByAltText(mockItem.title).getAttribute("src")
-    ).not.toContain(encodeURIComponent(mockItem.thumbnail));
+    ).not.toContain(mockItem.thumbnail);
 
     expect(screen.getByAltText(mockItem.title).getAttribute("src")).toContain(
-      encodeURIComponent(
-        "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/b92874a0-72b7-4479-979e-38860c412a13/square/512,/0/default.jpg"
-      )
+      "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/b92874a0-72b7-4479-979e-38860c412a13/square/512,/0/default.jpg"
     );
   });
 });


### PR DESCRIPTION
## What does this do?

This updates our `next/image` components to not attempt to optimize the src files. Previously Next was funneling our original `src` thumbnails through some optimization process and outputting them as `.webp` files. We should now be going direct to source for these and not having a ambiguous Next middleware handling this. File size on the user end will be a little larger but we should no longer have the reading room issue.

Checkout the preview branch build here:
https://preview-3675-reading-room-thumbnails.d2v1qbdeix3nr2.amplifyapp.com/search

Before: (current Production)
![image](https://user-images.githubusercontent.com/7376450/219666600-79f78842-8ec1-4af5-899d-d3ddcfaac948.png)

After: ([preview branch](https://preview-3675-reading-room-thumbnails.d2v1qbdeix3nr2.amplifyapp.com/search))
![image](https://user-images.githubusercontent.com/7376450/219666868-92026f00-c3d0-48e8-8675-1a5b34d94bf1.png)


