### PR TITLE
Update dcapi-types to v2.0.0-rc.5

### DIFF
--- a/components/SharedLink/SharedLink.test.tsx
+++ b/components/SharedLink/SharedLink.test.tsx
@@ -153,6 +153,7 @@ const work: Work = {
   },
   file_sets: [
     {
+      accession_number: "inu-dil-12b39039-68af-4a31-8b04-1b025d95a0b8",
       duration: null,
       height: 4050,
       id: "7ad42e60-a8b6-444d-b4cf-f53f9c2756f6",

--- a/mocks/sample-work1.ts
+++ b/mocks/sample-work1.ts
@@ -36,6 +36,7 @@ export const sampleWork1: Work = {
   description: ["Ima description"],
   file_sets: [
     {
+      accession_number: "inu-dil-50575a78-a47a-4a07-939f-6e1d6a9d7065",
       duration: 20,
       height: 1000,
       id: "93d75ffe-20d8-48ea-9206-8db9114f2731",

--- a/mocks/sample-work2.ts
+++ b/mocks/sample-work2.ts
@@ -36,6 +36,7 @@ export const sampleWork2: Work = {
   description: ["Ima cool description"],
   file_sets: [
     {
+      accession_number: "inu-dil-50575a78-a47a-4a07-939f-6e1d6a9d7065",
       duration: null,
       height: 1000,
       id: "93d75ffe-20d8-48ea-9206-8db9114f2731",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
         "@honeybadger-io/js": "^4.9.2",
         "@honeybadger-io/webpack": "^4.8.2",
         "@iiif/parser": "^1.0.10",
-        "@nulib/dcapi-types": "^2.0.0-rc.4",
+        "@nulib/dcapi-types": "^2.0.0-rc.5",
         "@nulib/design-system": "^1.6.2",
         "@radix-ui/colors": "^0.1.8",
         "@radix-ui/react-accordion": "^1.0.1",
@@ -1999,9 +1999,9 @@
       }
     },
     "node_modules/@nulib/dcapi-types": {
-      "version": "2.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@nulib/dcapi-types/-/dcapi-types-2.0.0-rc.4.tgz",
-      "integrity": "sha512-vA1gAHusP9xE8NWEnPdKM0t8UsN8bcgw5a1j7/8fGekl2mgb/6H2F10J0bJ9MslfvLVsA1YFoW9yaV7OxbOzMg=="
+      "version": "2.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@nulib/dcapi-types/-/dcapi-types-2.0.0-rc.5.tgz",
+      "integrity": "sha512-z4GqJk+V6eRQkF5k7jfebUsAZx/rrb1lFGrbeUXB0Hz3GmbwYwRWS1CovpHz6Cvz12/I/z5HNl0C/QM5u/ucqA=="
     },
     "node_modules/@nulib/design-system": {
       "version": "1.6.2",
@@ -15059,9 +15059,9 @@
       }
     },
     "@nulib/dcapi-types": {
-      "version": "2.0.0-rc.4",
-      "resolved": "https://registry.npmjs.org/@nulib/dcapi-types/-/dcapi-types-2.0.0-rc.4.tgz",
-      "integrity": "sha512-vA1gAHusP9xE8NWEnPdKM0t8UsN8bcgw5a1j7/8fGekl2mgb/6H2F10J0bJ9MslfvLVsA1YFoW9yaV7OxbOzMg=="
+      "version": "2.0.0-rc.5",
+      "resolved": "https://registry.npmjs.org/@nulib/dcapi-types/-/dcapi-types-2.0.0-rc.5.tgz",
+      "integrity": "sha512-z4GqJk+V6eRQkF5k7jfebUsAZx/rrb1lFGrbeUXB0Hz3GmbwYwRWS1CovpHz6Cvz12/I/z5HNl0C/QM5u/ucqA=="
     },
     "@nulib/design-system": {
       "version": "1.6.2",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@honeybadger-io/js": "^4.9.2",
     "@honeybadger-io/webpack": "^4.8.2",
     "@iiif/parser": "^1.0.10",
-    "@nulib/dcapi-types": "^2.0.0-rc.4",
+    "@nulib/dcapi-types": "^2.0.0-rc.5",
     "@nulib/design-system": "^1.6.2",
     "@radix-ui/colors": "^0.1.8",
     "@radix-ui/react-accordion": "^1.0.1",


### PR DESCRIPTION
## What does this do?

- Updates the dcapi-types package to v2.0.0-rc.5
- There is no visual change in this PR, though it adds `accession_number` to file set arrays in tests/mocks