### PR TITLE
Add permanent legacy-pid redirects.

### DIFF
--- a/pages/legacy-pid/[pid].tsx
+++ b/pages/legacy-pid/[pid].tsx
@@ -1,0 +1,47 @@
+import { ApiSearchResponse } from "@/types/api/response";
+import { DC_API_SEARCH_URL } from "@/lib/constants/endpoints";
+import { GetServerSideProps } from "next";
+import { ParsedUrlQuery } from "querystring";
+import { apiPostRequest } from "@/lib/dc-api";
+
+const LegacyPid = () => null;
+
+interface Params extends ParsedUrlQuery {
+  pid: string;
+}
+
+export const getServerSideProps: GetServerSideProps = async ({ params }) => {
+  const { pid } = params as Params;
+  const response = await apiPostRequest<ApiSearchResponse>({
+    body: {
+      _source: ["id"],
+      query: {
+        bool: {
+          must: [
+            {
+              match: {
+                legacy_identifier: pid,
+              },
+            },
+          ],
+        },
+      },
+      size: 1,
+    },
+    url: DC_API_SEARCH_URL,
+  });
+
+  if (!response?.data.length)
+    return {
+      notFound: true,
+    };
+
+  return {
+    redirect: {
+      destination: `/items/${response.data[0].id}`,
+      permanent: true,
+    },
+  };
+};
+
+export default LegacyPid;


### PR DESCRIPTION
## What does this do?

This adds a route within `/pages/legacy-pid` that will perform a query on the `pid` param, and redirect to the destination of the found work page. If nothing is found, a 404 is returned. Redirects are handled by next https://nextjs.org/docs/api-reference/data-fetching/get-server-side-props#redirect

## Review

To aid in review, I've set a work with a legacy identifier.

In staging, the  path of https://preview-3716-legacy-pids.d2v1qbdeix3nr2.amplifyapp.com/legacy-pid/nai.08.port.00000005.p will redirect to https://devbox.library.northwestern.edu:3000/items/fe1114f1-1e27-4a27-9842-2a5865a5ec67.

If you try an identifier that does not exist (https://preview-3716-legacy-pids.d2v1qbdeix3nr2.amplifyapp.com/legacy-pid/garbage), a 404 will return.