### PR TITLE
Only include Reading Room message on restricted Works. Update README

### DIFF
--- a/components/Facets/Filter/GroupList.test.tsx
+++ b/components/Facets/Filter/GroupList.test.tsx
@@ -81,10 +81,10 @@ describe("FacetsGroupList component", () => {
      * Looks like Radix puts this active state data attribute
      * on the element.... good for testing against:)
      */
-    const tabActive = await screen.findAllByRole("tab", { exact: true });
+    const tabActive = await screen.findAllByRole("tab");
     expect(tabActive[0].dataset.state).toEqual("active");
 
-    const tabInactive = await screen.findAllByRole("tab", { exact: true });
+    const tabInactive = await screen.findAllByRole("tab");
     expect(tabInactive[1].dataset.state).toEqual("inactive");
   });
 

--- a/components/Work/ViewerWrapper.test.tsx
+++ b/components/Work/ViewerWrapper.test.tsx
@@ -23,28 +23,36 @@ describe("WorkViewerWrapper", () => {
     });
   });
 
-  it("renders an announcement when in the Reading Room", async () => {
-    render(
-      <UserContext.Provider value={userContextValue}>
-        <WorkViewerWrapper manifestId="http://testing.com" />
-      </UserContext.Provider>
-    );
-
-    expect(screen.queryByText(readingRoomMessage)).not.toBeInTheDocument();
-
+  it("renders an announcement when in the Reading Room only when the Work is protected", async () => {
     const readingUserContext = { ...userContextValue };
     readingUserContext.user.isReadingRoom = true;
 
     render(
       <UserContext.Provider value={readingUserContext}>
-        <WorkViewerWrapper manifestId="http://testing.com" />
+        <WorkViewerWrapper isWorkRestricted={true} manifestId="http://testing.com" />
       </UserContext.Provider>
     );
 
     expect(
-      await screen.findByText(
-        /You have access to Work because you are in the reading room/i
-      )
+      await screen.findByText(readingRoomMessage)
     ).toBeInTheDocument();
+
+  });
+
+  it("does not render an announcement when in the Reading Room and the Work is not restricted", async () => {
+    const readingUserContext = { ...userContextValue };
+    readingUserContext.user.isReadingRoom = true;
+
+    render(
+      <UserContext.Provider value={readingUserContext}>
+        <WorkViewerWrapper isWorkRestricted={false} manifestId="http://testing.com" />
+      </UserContext.Provider>
+    );
+
+    let el;
+    await waitFor(() => {
+       el = screen.queryByText(readingRoomMessage);
+    })
+    expect(el).toBeNull();
   });
 });

--- a/components/Work/ViewerWrapper.tsx
+++ b/components/Work/ViewerWrapper.tsx
@@ -25,9 +25,10 @@ export const CloverIIIF: React.ComponentType<{
 
 interface WrapperProps {
   manifestId: Work["iiif_manifest"];
+  isWorkRestricted?: boolean;
 }
 
-const WorkViewerWrapper: React.FC<WrapperProps> = ({ manifestId }) => {
+const WorkViewerWrapper: React.FC<WrapperProps> = ({ manifestId, isWorkRestricted }) => {
   const userAuth = React.useContext(UserContext);
 
   const customTheme = {
@@ -67,7 +68,7 @@ const WorkViewerWrapper: React.FC<WrapperProps> = ({ manifestId }) => {
           options={options}
         />
       )}
-      {userAuth?.user?.isReadingRoom && (
+      {isWorkRestricted && userAuth?.user?.isReadingRoom && (
         <Announcement>
           <AnnouncementContent>
             <IconInfo />

--- a/lib/dc-api.ts
+++ b/lib/dc-api.ts
@@ -14,6 +14,7 @@ async function apiGetRequest<R>(
   obj: ApiGetRequestParams
 ): Promise<R | undefined> {
   const { url } = obj;
+
   try {
     const response = await axios({
       url,

--- a/pages/collections/[id].tsx
+++ b/pages/collections/[id].tsx
@@ -59,10 +59,15 @@ const Collection: NextPage = () => {
       const id = router.query.id;
       if (!id || Array.isArray(id)) return;
       const data = await getCollection(id);
+
+      // This is not preferred, but auth is only respected client side
+      // so need this for items to display in Reading Room
+      if (!data) return router.push("/404");
+
       setCollection(data);
     }
     router.isReady && getData();
-  }, [router.isReady, router.query.id]);
+  }, [router, router.isReady, router.query.id]);
 
   /** Get dependant data */
   useEffect(() => {
@@ -202,11 +207,6 @@ const Collection: NextPage = () => {
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const id = context?.params?.id;
   const collection = await getCollection(id as string);
-
-  if (typeof collection === "undefined")
-    return {
-      notFound: true,
-    };
 
   /** Add values to GTM's dataLayer object */
   const dataLayer = buildDataLayer({


### PR DESCRIPTION
## What does this do?
Only displays the "You're see this in the Reading Room because....etc" message when a Work is restricted.

This also reverts the server-side 404 check for Work and Collection pages, to allow access in Reading Room.  With the server side check (no auth), the API was returning no items (as it should) for auth protected works and collections.

## How to test
1. Log into a Reading Room machine via Microsoft Remote Desktop
2. View both a Public and Institution (or Private) Work

Notice the message, or absence of. 