### PR TITLE
Update Clover, support `placeholderCanvas`.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@radix-ui/react-switch": "^1.0.1",
         "@radix-ui/react-tabs": "^1.0.1",
         "@samvera/bloom-iiif": "^0.5.0",
-        "@samvera/clover-iiif": "^1.13.2",
+        "@samvera/clover-iiif": "^1.14.1",
         "@samvera/image-downloader": "^1.1.6",
         "@samvera/nectar-iiif": "^0.0.20",
         "@stitches/react": "^1.2.6",
@@ -2987,11 +2987,12 @@
       }
     },
     "node_modules/@samvera/clover-iiif": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/@samvera/clover-iiif/-/clover-iiif-1.13.3.tgz",
-      "integrity": "sha512-VSGJCuBGfhuc1/TwP2NGupaErkdcSuffebgV4XADhQ4tQqZ5Ykx8Kx24o4XTp5DBn6cxauAoElumzQylKcxAnQ==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@samvera/clover-iiif/-/clover-iiif-1.14.1.tgz",
+      "integrity": "sha512-5VcR/UnWn17PJVDmmS0VzNf0POYqfhoW88LZ2WH8CZUhVSihNnqBcUO2qhPPxhGcAKnOGYy2TPTQit7vMSHILg==",
       "dependencies": {
         "@iiif/vault": "^0.9.19",
+        "@iiif/vault-helpers": "^0.9.11",
         "@nulib/design-system": "^1.6.0",
         "@radix-ui/react-collapsible": "^1.0.1",
         "@radix-ui/react-radio-group": "^1.1.0",
@@ -16069,11 +16070,12 @@
       }
     },
     "@samvera/clover-iiif": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/@samvera/clover-iiif/-/clover-iiif-1.13.3.tgz",
-      "integrity": "sha512-VSGJCuBGfhuc1/TwP2NGupaErkdcSuffebgV4XADhQ4tQqZ5Ykx8Kx24o4XTp5DBn6cxauAoElumzQylKcxAnQ==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@samvera/clover-iiif/-/clover-iiif-1.14.1.tgz",
+      "integrity": "sha512-5VcR/UnWn17PJVDmmS0VzNf0POYqfhoW88LZ2WH8CZUhVSihNnqBcUO2qhPPxhGcAKnOGYy2TPTQit7vMSHILg==",
       "requires": {
         "@iiif/vault": "^0.9.19",
+        "@iiif/vault-helpers": "^0.9.11",
         "@nulib/design-system": "^1.6.0",
         "@radix-ui/react-collapsible": "^1.0.1",
         "@radix-ui/react-radio-group": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@radix-ui/react-switch": "^1.0.1",
     "@radix-ui/react-tabs": "^1.0.1",
     "@samvera/bloom-iiif": "^0.5.0",
-    "@samvera/clover-iiif": "^1.13.2",
+    "@samvera/clover-iiif": "^1.14.1",
     "@samvera/image-downloader": "^1.1.6",
     "@samvera/nectar-iiif": "^0.0.20",
     "@stitches/react": "^1.2.6",


### PR DESCRIPTION
## What does this do?

This brings Clover up to date with latest.

Works rendered in clover now support:
- Canvases support `placeholderCanvas` for previewing (this won't work in DC until our API is updated as well)
- Canvas label lines are limited to lines and have an overflow ellipsis, these previously wrapped continuously.
- Controls are render in a responsive way in OpenSeadragon