### PR TITLE
Update DC API types.

### DIFF
--- a/components/SharedLink/SharedLink.test.tsx
+++ b/components/SharedLink/SharedLink.test.tsx
@@ -155,6 +155,7 @@ const work: Work = {
   file_sets: [
     {
       accession_number: "inu-dil-12b39039-68af-4a31-8b04-1b025d95a0b8",
+      description: "Something",
       duration: null,
       height: 4050,
       id: "7ad42e60-a8b6-444d-b4cf-f53f9c2756f6",

--- a/mocks/sample-work1.ts
+++ b/mocks/sample-work1.ts
@@ -37,6 +37,7 @@ export const sampleWork1: Work = {
   file_sets: [
     {
       accession_number: "inu-dil-50575a78-a47a-4a07-939f-6e1d6a9d7065",
+      description: "Something",
       duration: 20,
       height: 1000,
       id: "93d75ffe-20d8-48ea-9206-8db9114f2731",

--- a/mocks/sample-work2.ts
+++ b/mocks/sample-work2.ts
@@ -37,6 +37,7 @@ export const sampleWork2: Work = {
   file_sets: [
     {
       accession_number: "inu-dil-50575a78-a47a-4a07-939f-6e1d6a9d7065",
+      description: "Something",
       duration: null,
       height: 1000,
       id: "93d75ffe-20d8-48ea-9206-8db9114f2731",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@iiif/parser": "^1.0.10",
         "@next/bundle-analyzer": "^13.1.6",
         "@next/font": "^13.1.6",
-        "@nulib/dcapi-types": "^2.0.0-rc.5",
+        "@nulib/dcapi-types": "^2.0.0",
         "@nulib/design-system": "^1.6.2",
         "@radix-ui/colors": "^0.1.8",
         "@radix-ui/react-accordion": "^1.0.1",
@@ -2001,9 +2001,9 @@
       }
     },
     "node_modules/@nulib/dcapi-types": {
-      "version": "2.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@nulib/dcapi-types/-/dcapi-types-2.0.0-rc.5.tgz",
-      "integrity": "sha512-z4GqJk+V6eRQkF5k7jfebUsAZx/rrb1lFGrbeUXB0Hz3GmbwYwRWS1CovpHz6Cvz12/I/z5HNl0C/QM5u/ucqA=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@nulib/dcapi-types/-/dcapi-types-2.0.0.tgz",
+      "integrity": "sha512-noTdZRZE/pEDsA1pRPRgTLhyQpI+QaEqCCwRmKqf7PejuJXeF9bsG3RkNWXXbqZKpw+qx4C6aCf835uE2mx+Hw=="
     },
     "node_modules/@nulib/design-system": {
       "version": "1.6.2",
@@ -15305,9 +15305,9 @@
       }
     },
     "@nulib/dcapi-types": {
-      "version": "2.0.0-rc.5",
-      "resolved": "https://registry.npmjs.org/@nulib/dcapi-types/-/dcapi-types-2.0.0-rc.5.tgz",
-      "integrity": "sha512-z4GqJk+V6eRQkF5k7jfebUsAZx/rrb1lFGrbeUXB0Hz3GmbwYwRWS1CovpHz6Cvz12/I/z5HNl0C/QM5u/ucqA=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@nulib/dcapi-types/-/dcapi-types-2.0.0.tgz",
+      "integrity": "sha512-noTdZRZE/pEDsA1pRPRgTLhyQpI+QaEqCCwRmKqf7PejuJXeF9bsG3RkNWXXbqZKpw+qx4C6aCf835uE2mx+Hw=="
     },
     "@nulib/design-system": {
       "version": "1.6.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@iiif/parser": "^1.0.10",
     "@next/bundle-analyzer": "^13.1.6",
     "@next/font": "^13.1.6",
-    "@nulib/dcapi-types": "^2.0.0-rc.5",
+    "@nulib/dcapi-types": "^2.0.0",
     "@nulib/design-system": "^1.6.2",
     "@radix-ui/colors": "^0.1.8",
     "@radix-ui/react-accordion": "^1.0.1",


### PR DESCRIPTION
## What does this do?

This brings dc-nextjs up to date for the `@nulib/dcapi-types` package. Some mocks and tests required updating, otherwise nothing big.