### PR TITLE
Update Clover to address Audio player zIndex bug.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@radix-ui/react-switch": "^1.0.1",
         "@radix-ui/react-tabs": "^1.0.1",
         "@samvera/bloom-iiif": "^0.5.0",
-        "@samvera/clover-iiif": "^1.14.1",
+        "@samvera/clover-iiif": "^1.14.2",
         "@samvera/image-downloader": "^1.1.6",
         "@samvera/nectar-iiif": "^0.0.20",
         "@stitches/react": "^1.2.6",
@@ -2987,9 +2987,9 @@
       }
     },
     "node_modules/@samvera/clover-iiif": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@samvera/clover-iiif/-/clover-iiif-1.14.1.tgz",
-      "integrity": "sha512-5VcR/UnWn17PJVDmmS0VzNf0POYqfhoW88LZ2WH8CZUhVSihNnqBcUO2qhPPxhGcAKnOGYy2TPTQit7vMSHILg==",
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/@samvera/clover-iiif/-/clover-iiif-1.14.2.tgz",
+      "integrity": "sha512-4iEAWIy0/j6i5UD9YlAM6RAUj0MidDz9h74X+FsgczcsqRMVMgCQuV8z24kRpUC77t+N8OgM3ARPkwUEBCNHTA==",
       "dependencies": {
         "@iiif/vault": "^0.9.19",
         "@iiif/vault-helpers": "^0.9.11",
@@ -16070,9 +16070,9 @@
       }
     },
     "@samvera/clover-iiif": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@samvera/clover-iiif/-/clover-iiif-1.14.1.tgz",
-      "integrity": "sha512-5VcR/UnWn17PJVDmmS0VzNf0POYqfhoW88LZ2WH8CZUhVSihNnqBcUO2qhPPxhGcAKnOGYy2TPTQit7vMSHILg==",
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/@samvera/clover-iiif/-/clover-iiif-1.14.2.tgz",
+      "integrity": "sha512-4iEAWIy0/j6i5UD9YlAM6RAUj0MidDz9h74X+FsgczcsqRMVMgCQuV8z24kRpUC77t+N8OgM3ARPkwUEBCNHTA==",
       "requires": {
         "@iiif/vault": "^0.9.19",
         "@iiif/vault-helpers": "^0.9.11",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@radix-ui/react-switch": "^1.0.1",
     "@radix-ui/react-tabs": "^1.0.1",
     "@samvera/bloom-iiif": "^0.5.0",
-    "@samvera/clover-iiif": "^1.14.1",
+    "@samvera/clover-iiif": "^1.14.2",
     "@samvera/image-downloader": "^1.1.6",
     "@samvera/nectar-iiif": "^0.0.20",
     "@stitches/react": "^1.2.6",


### PR DESCRIPTION
## What does this do? 

This updates Clover to fix a zIndex issue related the the `<AudioVisualizer>` `canvas` element overlapping the `video` element and the browser native controls.

See https://preview-3806-clover-audio-bug.d2v1qbdeix3nr2.amplifyapp.com/items/ad830181-b658-4e74-9045-d073d2fb830e