### PR TITLE
Restricted access email link includes Work Id

### DIFF
--- a/components/Work/RestrictedDisplay.test.tsx
+++ b/components/Work/RestrictedDisplay.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@/test-utils";
+
 import WorkRestrictedDisplay from "@/components/Work/RestrictedDisplay";
 
 describe("WorkRestrictedDisplay component", () => {
@@ -7,5 +8,11 @@ describe("WorkRestrictedDisplay component", () => {
     expect(screen.getByTestId("restricted-display"));
     expect(screen.getByTestId("bg-image"));
     expect(screen.getByTestId("announcement"));
+  });
+
+  it("displays the work id in the email link subject", () => {
+    render(<WorkRestrictedDisplay thumbnail="foobar.jpg" workId="12345" />);
+    const emailLink = screen.getByText("repository@northwestern.edu");
+    expect(emailLink).toHaveAttribute("href", expect.stringContaining("12345"));
   });
 });

--- a/components/Work/RestrictedDisplay.tsx
+++ b/components/Work/RestrictedDisplay.tsx
@@ -1,15 +1,15 @@
 import Announcement from "@/components/Shared/Announcement";
 import BlurredBgImage from "@/components/Shared/BlurredBgImage";
-import CopyText from "@/components/Shared/CopyText";
 import { DCAPI_ENDPOINT } from "@/lib/constants/endpoints";
 import Link from "next/link";
 import React from "react";
 
 interface Props {
   thumbnail: string | null;
+  workId?: string;
 }
 
-const WorkRestrictedDisplay: React.FC<Props> = ({ thumbnail }) => {
+const WorkRestrictedDisplay: React.FC<Props> = ({ thumbnail, workId }) => {
   return (
     <div data-testid="restricted-display">
       {thumbnail && (
@@ -34,10 +34,15 @@ const WorkRestrictedDisplay: React.FC<Props> = ({ thumbnail }) => {
         </p>
         <p>
           If you are not a member of the Northwestern Community, email{" "}
-          <CopyText
-            textPrompt="repository@northwestern.edu"
-            textToCopy="repository@northwestern.edu"
-          />{" "}
+          <a
+            target="_blank"
+            rel="noreferrer"
+            href={`mailto:repository@northwestern.edu?subject=${encodeURIComponent(
+              `Work ID: ${workId} access request`
+            )}`}
+          >
+            repository@northwestern.edu
+          </a>{" "}
           to request access. Please include a short description of your research
           needs.
         </p>

--- a/pages/items/[id].tsx
+++ b/pages/items/[id].tsx
@@ -101,7 +101,10 @@ const WorkPage: NextPage<WorkPageProps> = ({
                 />
               )}
               {work && !isReadingRoom && isWorkRestricted && (
-                <WorkRestrictedDisplay thumbnail={work.thumbnail} />
+                <WorkRestrictedDisplay
+                  thumbnail={work.thumbnail}
+                  workId={work.id}
+                />
               )}
               <Container>
                 {work && (


### PR DESCRIPTION
## What does this do?
Replaces the email link (currently just copies the email address), to a hyperlink with `mailto:` which populates the email "Subject" with a message: "Work ID: XYX access request".

![image](https://user-images.githubusercontent.com/3020266/234692297-08450804-b56d-4b30-8838-87ab647752fe.png)

![image](https://user-images.githubusercontent.com/3020266/234692486-d2c29d00-b5cf-4a19-b055-5a73cb3e0fe4.png)

## How to test
Click on the email link for a Private Work (when not logged in), and it should open your email client with Subject pre-filled.