### PR TITLE
Address encoding of subject within the related collection helper.

### DIFF
--- a/lib/work-helpers.ts
+++ b/lib/work-helpers.ts
@@ -34,17 +34,17 @@ export function getWorkSliders(work: Work) {
 
   /** Collection slider */
   if (work.collection) {
-    const collectionLabel = work.collection.title;
+    const encodedCollectionLabel = encodeURIComponent(work.collection.title);
     const collectionSummary = `Collection`;
     workSliderUrls.push(
-      `${DC_API_SEARCH_URL}?query=collection.id:"${work.collection.id}"&collectionLabel=${collectionLabel}&collectionSummary=${collectionSummary}&as=iiif`
+      `${DC_API_SEARCH_URL}?query=collection.id:"${work.collection.id}"&collectionLabel=${encodedCollectionLabel}&collectionSummary=${collectionSummary}&as=iiif`
     );
   }
 
   /** More Like This */
-  const similarLabel = `Similar to ${work.title}`;
+  const encodedSimilarLabel = encodeURIComponent(`Similar to ${work.title}`);
   workSliderUrls.push(
-    `${DCAPI_ENDPOINT}/works/${work.id}/similar?collectionLabel=More Like This&collectionSummary=${similarLabel}&as=iiif`
+    `${DCAPI_ENDPOINT}/works/${work.id}/similar?collectionLabel=More Like This&collectionSummary=${encodedSimilarLabel}&as=iiif`
   );
 
   /**
@@ -55,8 +55,9 @@ export function getWorkSliders(work: Work) {
     const subjects = shuffle(work?.subject.map((s) => s.label)).slice(0, 2);
 
     subjects.forEach((subject: string) => {
+      const encodedSubject = encodeURIComponent(subject);
       workSliderUrls.push(
-        `${DC_API_SEARCH_URL}?query=subject.label:"${subject}"&collectionLabel=${subject}&collectionSummary=Subject&as=iiif`
+        `${DC_API_SEARCH_URL}?query=subject.label:"${encodedSubject}"&collectionLabel=${encodedSubject}&collectionSummary=Subject&as=iiif`
       );
     });
   }


### PR DESCRIPTION
## What does this do?

This patches an issue where the subject was not being properly URI encoded when being appended to the the Collection URI. While, I feel like this entire helper could use some cleanup, I opted for the quick fix in encoding subject.

See: https://devbox.library.northwestern.edu:3000/items/ef5f341f-50cc-4ff3-a84c-7f13ac0d1afa where the Sliders render even though the subject "Adam & Eve" is present.

![image](https://user-images.githubusercontent.com/7376450/235665972-fa93bdb2-1f44-4cc5-9b35-ec4343c66c49.png)
