### PR TITLE
Add canvas type helper, show download only for images.

### DIFF
--- a/components/Work/ActionsDialog/DownloadAndShare.test.tsx
+++ b/components/Work/ActionsDialog/DownloadAndShare.test.tsx
@@ -43,7 +43,7 @@ describe("DownloadAndShare", () => {
     );
     expect(screen.getByText("Embed Viewer")).toBeInTheDocument();
     expect(screen.getByText(embedWarningText)).toBeInTheDocument();
-    expect(screen.getByText("Download and Embed")).toBeInTheDocument();
+    expect(screen.getByText("Download and Embed Images")).toBeInTheDocument();
   });
 
   it("renders download but not embed HTML for a private, unpublished work", async () => {

--- a/lib/iiif/manifest-helpers.ts
+++ b/lib/iiif/manifest-helpers.ts
@@ -1,4 +1,9 @@
-import { Annotation, AnnotationBody, Canvas } from "@iiif/presentation-3";
+import {
+  Annotation,
+  AnnotationBody,
+  Canvas,
+  ContentResource,
+} from "@iiif/presentation-3";
 
 interface MetadataInput {
   label: string;
@@ -33,4 +38,21 @@ export const getInfoResponse = (canvas: Canvas) => {
   }
 
   return infoResponse;
+};
+
+export const getAnnotationBodyType = (canvas: Canvas) => {
+  let annotationBodyType;
+
+  if (
+    canvas.items &&
+    canvas.items[0] &&
+    canvas.items[0].items &&
+    canvas.items[0].items[0]
+  ) {
+    const annotation: Annotation = canvas.items[0].items[0];
+    const body = annotation.body as ContentResource;
+    if (body && body.type) annotationBodyType = body.type;
+  }
+
+  return annotationBodyType;
 };


### PR DESCRIPTION
## What does this do?

This adds in functionality to check for the Canvas (fileset) type of each item in our IIIF Manifests that represent works.

If the Canvas type is `Image` and there are any images, then these items will be mapped and rendered under the **Download and Embed Images** section.

This can be previewed at https://preview-3898-av-download.d2v1qbdeix3nr2.amplifyapp.com/search

### Case: Video Work with (2) Video (1) Image
https://preview-3898-av-download.d2v1qbdeix3nr2.amplifyapp.com/items/9d67f8c5-1a2e-4fbd-8471-4a1afa7d6e5a

![image](https://github.com/nulib/dc-nextjs/assets/7376450/431f905a-a051-4650-ba0f-ea06462d6e76)

### Case: Video Work with (1) Video
https://preview-3898-av-download.d2v1qbdeix3nr2.amplifyapp.com/items/b65de0cc-9776-4466-bb97-8364f9e7d367

![image](https://github.com/nulib/dc-nextjs/assets/7376450/535b3451-fe38-45cb-9c5a-b8f92d2b04a1)

### Case: Image Work with (2) Image
https://preview-3898-av-download.d2v1qbdeix3nr2.amplifyapp.com/items/de86f437-6246-4ced-ab38-a2ce346afac5

![image](https://github.com/nulib/dc-nextjs/assets/7376450/fa784b3b-6295-4d6a-ad1f-817a984307cd)


