### PR TITLE
Update Clover to support native video poster on placeholderCanvas.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@radix-ui/react-switch": "^1.0.1",
         "@radix-ui/react-tabs": "^1.0.1",
         "@samvera/bloom-iiif": "^0.5.0",
-        "@samvera/clover-iiif": "^1.14.2",
+        "@samvera/clover-iiif": "^1.15.0",
         "@samvera/image-downloader": "^1.1.6",
         "@samvera/nectar-iiif": "^0.0.20",
         "@stitches/react": "^1.2.6",
@@ -2918,9 +2918,9 @@
       }
     },
     "node_modules/@samvera/clover-iiif": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/@samvera/clover-iiif/-/clover-iiif-1.14.3.tgz",
-      "integrity": "sha512-T6wMt39GiDGUPFoQHi7peANfk65RY8Pkazo6V8EUrjmE0J7/HVFZXLPFvXkmnwoZaWLKKuVHeO4nkWUzJqTsUQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@samvera/clover-iiif/-/clover-iiif-1.15.0.tgz",
+      "integrity": "sha512-5sB7BoOOVnxLUs8Z3qc9Crgy5IUBqrNPvOweP22ma7oqgRUT2T4HNnkVbkLbTTWE6oKmVdyEPFBWSpJRW35UYA==",
       "dependencies": {
         "@iiif/vault": "^0.9.19",
         "@iiif/vault-helpers": "^0.9.11",
@@ -16029,9 +16029,9 @@
       }
     },
     "@samvera/clover-iiif": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/@samvera/clover-iiif/-/clover-iiif-1.14.3.tgz",
-      "integrity": "sha512-T6wMt39GiDGUPFoQHi7peANfk65RY8Pkazo6V8EUrjmE0J7/HVFZXLPFvXkmnwoZaWLKKuVHeO4nkWUzJqTsUQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@samvera/clover-iiif/-/clover-iiif-1.15.0.tgz",
+      "integrity": "sha512-5sB7BoOOVnxLUs8Z3qc9Crgy5IUBqrNPvOweP22ma7oqgRUT2T4HNnkVbkLbTTWE6oKmVdyEPFBWSpJRW35UYA==",
       "requires": {
         "@iiif/vault": "^0.9.19",
         "@iiif/vault-helpers": "^0.9.11",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@radix-ui/react-switch": "^1.0.1",
     "@radix-ui/react-tabs": "^1.0.1",
     "@samvera/bloom-iiif": "^0.5.0",
-    "@samvera/clover-iiif": "^1.14.2",
+    "@samvera/clover-iiif": "^1.15.0",
     "@samvera/image-downloader": "^1.1.6",
     "@samvera/nectar-iiif": "^0.0.20",
     "@stitches/react": "^1.2.6",


### PR DESCRIPTION
## What does this do?

Simply updates our Clover dependency to support the `poster` attribute on `<video>` elements if a the Manifest canvas has a `placeholderCanvas`. Currently, our API does not support this but eventually it will?