### PR TITLE
Update @nulib/dcapi-types to v2.1.0.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@iiif/parser": "^1.0.10",
         "@next/bundle-analyzer": "^13.1.6",
         "@next/font": "^13.1.6",
-        "@nulib/dcapi-types": "^2.0.0",
+        "@nulib/dcapi-types": "^2.1.0",
         "@nulib/design-system": "^1.6.2",
         "@radix-ui/colors": "^0.1.8",
         "@radix-ui/react-accordion": "^1.0.1",
@@ -1917,9 +1917,9 @@
       }
     },
     "node_modules/@nulib/dcapi-types": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@nulib/dcapi-types/-/dcapi-types-2.0.0.tgz",
-      "integrity": "sha512-noTdZRZE/pEDsA1pRPRgTLhyQpI+QaEqCCwRmKqf7PejuJXeF9bsG3RkNWXXbqZKpw+qx4C6aCf835uE2mx+Hw=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nulib/dcapi-types/-/dcapi-types-2.1.0.tgz",
+      "integrity": "sha512-CV0dS65nbjivA/U2Ibgz0kTXzxg4doN96x8YRW7AnzRz0ftDH1DIWsuiTX1xpx3mRQagFFRxiUHp829s2tWT8w=="
     },
     "node_modules/@nulib/design-system": {
       "version": "1.6.2",
@@ -15875,9 +15875,9 @@
       }
     },
     "@nulib/dcapi-types": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@nulib/dcapi-types/-/dcapi-types-2.0.0.tgz",
-      "integrity": "sha512-noTdZRZE/pEDsA1pRPRgTLhyQpI+QaEqCCwRmKqf7PejuJXeF9bsG3RkNWXXbqZKpw+qx4C6aCf835uE2mx+Hw=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nulib/dcapi-types/-/dcapi-types-2.1.0.tgz",
+      "integrity": "sha512-CV0dS65nbjivA/U2Ibgz0kTXzxg4doN96x8YRW7AnzRz0ftDH1DIWsuiTX1xpx3mRQagFFRxiUHp829s2tWT8w=="
     },
     "@nulib/design-system": {
       "version": "1.6.2",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@iiif/parser": "^1.0.10",
     "@next/bundle-analyzer": "^13.1.6",
     "@next/font": "^13.1.6",
-    "@nulib/dcapi-types": "^2.0.0",
+    "@nulib/dcapi-types": "^2.1.0",
     "@nulib/design-system": "^1.6.2",
     "@radix-ui/colors": "^0.1.8",
     "@radix-ui/react-accordion": "^1.0.1",


### PR DESCRIPTION
## What does this do?

Simply updates the  @nulib/dcapi-types to the latest.

## How should we review?

No Breakage? Looks good? The types updates themselves don't impact how we're using it in DC. 