### PR TITLE
Add support for License facet

### DIFF
--- a/components/Work/Metadata.tsx
+++ b/components/Work/Metadata.tsx
@@ -2,6 +2,7 @@ import {
   LinkItemStyled,
   MetadataStyled,
 } from "@/components/Work/Metadata.styled";
+
 import { DC_URL } from "@/lib/constants/endpoints";
 import Link from "next/link";
 import { MetadataItem } from "@iiif/presentation-3";
@@ -25,9 +26,7 @@ export const ValueAsListItem: React.FC<ValueAsListItemProps> = ({
   return (
     <LinkItemStyled>
       {searchParam ? (
-        <Link href={search.concat(encodeURIComponent(value))}>
-          {value}
-        </Link>
+        <Link href={search.concat(encodeURIComponent(value))}>{value}</Link>
       ) : (
         <span dangerouslySetInnerHTML={{ __html: value }} />
       )}

--- a/lib/constants/facets-model.ts
+++ b/lib/constants/facets-model.ts
@@ -48,6 +48,11 @@ export const ALL_FACETS: FacetsList = {
       label: "Language",
     },
     {
+      field: "license.label",
+      id: "license",
+      label: "License",
+    },
+    {
       field: "rights_statement.label",
       id: "rightsStatement",
       label: "Rights Statement",
@@ -120,6 +125,11 @@ export const FACETS_CREATOR: FacetsGroup = {
 
 export const FACETS_RIGHTS_USAGE: FacetsGroup = {
   facets: [
+    {
+      field: "license.label",
+      id: "license",
+      label: "License",
+    },
     {
       field: "rights_statement.label",
       id: "rightsStatement",

--- a/lib/constants/works.ts
+++ b/lib/constants/works.ts
@@ -43,6 +43,10 @@ const WORK_METADATA_LABELS: WorkMetadata[] = [
     searchParam: "language",
   },
   {
+    label: "License",
+    searchParam: "license",
+  },
+  {
     label: "Location",
   },
   {

--- a/mocks/private-unpublished-work.ts
+++ b/mocks/private-unpublished-work.ts
@@ -297,6 +297,7 @@ export const mockPrivateUnpublishedWorkManifest: Manifest = {
         none: ["Midnight"],
       },
       thumbnail: [
+        // @ts-ignore
         {
           id: "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/62adb94b-36d9-4f6f-bd18-ae4e7f3e7ba0/full/!300,300/0/default.jpg",
           type: "Image",
@@ -355,6 +356,7 @@ export const mockPrivateUnpublishedWorkManifest: Manifest = {
         none: ["Album"],
       },
       thumbnail: [
+        // @ts-ignore
         {
           id: "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/592022f6-3dc1-4f17-a412-42c025ceae93/full/!300,300/0/default.jpg",
           type: "Image",


### PR DESCRIPTION
## What does this do
Supports `license` as a linkable facet field for metadata on a Work.   

License will also appear in the Filter Dialog on the Search page.

![image](https://github.com/nulib/dc-nextjs/assets/3020266/5227ca75-e34a-429a-bf14-9bf601c295bd)


## How to test
1. Go to Search page and notice License is now available as a Filter option.
2. On a Work page, if `license` is set for a Work, it will appear as a clickable link in the Work's metadata display (Update to DC API v2 must be live on Staging first)

