### PR TITLE
Debug GTM VirtualPageView events, add `collections` data to `/collections/*` routes.

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -7,6 +7,7 @@ import {
   camptonExtraBold,
   camptonExtraLight,
 } from "@/styles/fonts";
+
 import type { AppProps } from "next/app";
 import Head from "next/head";
 import { ObjectLiteral } from "@/types";
@@ -44,19 +45,27 @@ function MyApp({ Component, pageProps }: MyAppProps) {
     getData();
   }, []);
 
-  {
-    /** Add GTM (Google Tag Manager) data */
-  }
   React.useEffect(() => {
     if (typeof window !== "undefined" && mounted) {
-      const payload = {
-        event: "VirtualPageView",
-        // @ts-ignore
-        ...pageProps.dataLayer,
-        isLoggedIn: user?.isLoggedIn,
-      };
+      const { dataLayer } = pageProps;
+
       // @ts-ignore
-      window.dataLayer?.push(payload);
+      if (dataLayer?.pageTitle) {
+        const payload = {
+          ...pageProps.dataLayer,
+          isLoggedIn: user?.isLoggedIn,
+        };
+
+        // send pageProps to dataLayer
+        // @ts-ignore
+        window.dataLayer?.push(payload);
+
+        // send VirtualPageView event to dataLayer
+        // @ts-ignore
+        window.dataLayer?.push({
+          event: "VirtualPageView",
+        });
+      }
     }
   }, [mounted, pageProps, user]);
 

--- a/pages/collections/[id].tsx
+++ b/pages/collections/[id].tsx
@@ -211,7 +211,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   /** Add values to GTM's dataLayer object */
   const dataLayer = buildDataLayer({
     adminset: "",
-    collections: "",
+    collections: collection?.title,
     creatorsContributors: "",
     isLoggedIn: false,
     pageTitle: (collection?.title as string) || "",


### PR DESCRIPTION
## What does this do?

In the end, this doesn't do too much, but does:

1. add the previously omitted title to a `/collections/*` route dataLayer payload.
2. add basic defensiveness around the dataLayer.push, checking for a page title
3. breaks up the dataLayer.push into two steps so that the `event` for only comes after data has been defined

Steps 2 and 3 will be watched over the next few days to test their effect.