### PR TITLE
Update Clover, fixing minor accessibility issues.

### DIFF
--- a/components/Clover/SliderWrapper.tsx
+++ b/components/Clover/SliderWrapper.tsx
@@ -11,6 +11,10 @@ const StyledSliderIIIFWrapper = styled("div", {
   position: "relative",
   zIndex: "0",
 
+  ".clover-slider-header-view-all": {
+    color: "$white",
+  },
+
   ".swiper-slide[data-type='collection']": {
     display: "none",
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@radix-ui/react-select": "^1.0.0",
         "@radix-ui/react-switch": "^1.0.1",
         "@radix-ui/react-tabs": "^1.0.1",
-        "@samvera/clover-iiif": "^2.0.2",
+        "@samvera/clover-iiif": "^2.1.1",
         "@samvera/image-downloader": "^1.1.6",
         "@stitches/react": "^1.2.6",
         "axios": "^1.2.2",
@@ -3254,9 +3254,9 @@
       "dev": true
     },
     "node_modules/@samvera/clover-iiif": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@samvera/clover-iiif/-/clover-iiif-2.1.0.tgz",
-      "integrity": "sha512-IsvAJjPdB0WhAOQp/1uAwuqz884omP4GuDkpe7iuWObnF3NuqJOeMocfckn1Ss3Q3FrZmhWZ6+xDOEd4M76Kow==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@samvera/clover-iiif/-/clover-iiif-2.1.1.tgz",
+      "integrity": "sha512-QDdbHWPF9AIjcA2MojjspSWE9zRYhWaJimxGT+9w29MklKfFf1clLA0+JfOAgNAZ1VFLH9PFeT4vRvYxffq0YA==",
       "dependencies": {
         "@iiif/parser": "^1.1.2",
         "@iiif/vault": "^0.9.22",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@radix-ui/react-select": "^1.0.0",
     "@radix-ui/react-switch": "^1.0.1",
     "@radix-ui/react-tabs": "^1.0.1",
-    "@samvera/clover-iiif": "^2.0.2",
+    "@samvera/clover-iiif": "^2.1.1",
     "@samvera/image-downloader": "^1.1.6",
     "@stitches/react": "^1.2.6",
     "axios": "^1.2.2",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -47,8 +47,6 @@ function MyApp({ Component, pageProps }: MyAppProps) {
 
   React.useEffect(() => {
     if (typeof window !== "undefined" && mounted) {
-      const { dataLayer } = pageProps;
-
       const payload = {
         ...pageProps.dataLayer,
         isLoggedIn: user?.isLoggedIn,


### PR DESCRIPTION
- This small fix brings the accessibility work from #4070 into Digital Collections.
-  It also incorporates the alignment issue of the Clover Viewer options if a `showTitle` is false and the Toggle or IIIF Badge are present.
- Finally, more clean up on the GTM dataLayer, removing an unused deconstructed const. 