### PR TITLE
Production push

### DIFF
--- a/pages/collections/[id].tsx
+++ b/pages/collections/[id].tsx
@@ -211,7 +211,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   /** Add values to GTM's dataLayer object */
   const dataLayer = buildDataLayer({
     adminset: "",
-    collections: collection?.title,
+    collections: (collection?.title as string) || "",
     creatorsContributors: "",
     isLoggedIn: false,
     pageTitle: (collection?.title as string) || "",


### PR DESCRIPTION
Revert the NextJS dependency to an earlier version.  Current version was breaking hard reloads on Work and Collection pages, for some reason.  Not sure why.