### PR TITLE
Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ Digital Collections v2 (DCv2) is a UI application for discovering and interactin
 - [AWS Amplify](https://aws.amazon.com/amplify/) Hosting environment
 - [OpenSearch](https://opensearch.org/) Search index
 
+### Dependency Notes
+
+The following dependencies should be "pinned" or held behind `@latest` versions
+
+- `next`: We've experienced issues with the AWS Amplify build process when using `@latest` versions of NextJS. To be safe, in general we should pin NextJS to >= 1 minor versions behind `next@latest`.
+- `@elastic/elasticsearch`: To match the version of `OpenSearch` our app uses.
+- `swiper`
+- `@honeybadger-io/js`
+- `@iiif/presentation-3`
+
 ## Development Environments
 
 ### Local


### PR DESCRIPTION
## What does this do?
Updates the README to note our strategy for keeping NextJS >= 1 version behind `next@latest`. The idea is this will give some buffer space between AWS Amplify catching up to NextJS's latest features.

@mbklein When making note of pinned dependencies, curious if we really need to pin Honeybadger?