### PR TITLE
Update dependencies including Clover to fix video Chapters bug

### DIFF
--- a/components/Clover/ViewerWrapper.tsx
+++ b/components/Clover/ViewerWrapper.tsx
@@ -2,7 +2,10 @@ import {
   AnnouncementContent,
   ViewerWrapperStyled,
 } from "@/components/Clover/ViewerWrapper.styled";
-import type { CloverViewerProps, ViewerConfigOptions } from "@samvera/clover-iiif";
+import type {
+  CloverViewerProps,
+  ViewerConfigOptions,
+} from "@samvera/clover-iiif";
 
 import Announcement from "@/components/Shared/Announcement";
 import { IconInfo } from "@/components/Shared/SVG/Icons";

--- a/components/Facets/WorkType/WorkType.tsx
+++ b/components/Facets/WorkType/WorkType.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { FACETS_WORK_TYPE } from "@/lib/constants/facets-model";
 import RadioGroup from "./RadioGroup";
-import { WorkType } from "@nulib/dcapi-types";
+import { type WorkType } from "@nulib/dcapi-types";
 import useQueryParams from "@/hooks/useQueryParams";
 import { useRouter } from "next/router";
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,17 +24,17 @@
         "@radix-ui/react-select": "^2.0.0",
         "@radix-ui/react-switch": "^1.0.1",
         "@radix-ui/react-tabs": "^1.0.1",
-        "@samvera/clover-iiif": "2.4.0-rc.0",
+        "@samvera/clover-iiif": "^2.4.0",
         "@samvera/image-downloader": "^1.1.6",
         "@stitches/react": "^1.2.6",
         "axios": "^1.2.2",
-        "framer-motion": "^10.2.5",
+        "framer-motion": "^11.0.12",
         "jsonwebtoken": "^9.0.0",
         "next": "^13.5.6",
         "react": "^18.2.0",
         "react-content-loader": "^6.2.0",
         "react-dom": "^18.2.0",
-        "react-error-boundary": "^4.0.4",
+        "react-error-boundary": "^4.0.13",
         "react-masonry-css": "^1.0.16",
         "react-share": "^5.0.3",
         "swiper": "^9.4.1"
@@ -54,7 +54,7 @@
         "babel-jest": "^29.6.2",
         "cypress": "^12.4.0",
         "eslint": "^8.47.0",
-        "eslint-config-next": "^14.0.3",
+        "eslint-config-next": "^14.1.3",
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-cypress": "^2.12.1",
         "eslint-plugin-testing-library": "^6.0.1",
@@ -64,7 +64,7 @@
         "next-router-mock": "^0.9.1-beta.0",
         "prettier": "^3.0.1",
         "ts-jest": "^29.0.5",
-        "typescript": "^5.0.4"
+        "typescript": "^5.4.2"
       },
       "optionalDependencies": {
         "fsevents": "^2.3.2"
@@ -708,6 +708,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
       "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@emotion/memoize": "0.7.4"
       }
@@ -716,7 +717,8 @@
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
       "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
@@ -1939,9 +1941,9 @@
       "integrity": "sha512-Yac/bV5sBGkkEXmAX5FWPS9Mmo2rthrOPRQQNfycJPkjUAUclomCPH7QFVCDQ4Mp2k2K1SSM6m0zrxYrOwtFQw=="
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-14.1.0.tgz",
-      "integrity": "sha512-x4FavbNEeXx/baD/zC/SdrvkjSby8nBn8KcCREqk6UuwvwoAPZmaV8TFCAuo/cpovBRTIY67mHhe86MQQm/68Q==",
+      "version": "14.1.3",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-14.1.3.tgz",
+      "integrity": "sha512-VCnZI2cy77Yaj3L7Uhs3+44ikMM1VD/fBMwvTBb3hIaTIuqa+DmG4dhUDq+MASu3yx97KhgsVJbsas0XuiKyww==",
       "dev": true,
       "dependencies": {
         "glob": "10.3.10"
@@ -3416,9 +3418,9 @@
       "dev": true
     },
     "node_modules/@samvera/clover-iiif": {
-      "version": "2.4.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@samvera/clover-iiif/-/clover-iiif-2.4.0-rc.0.tgz",
-      "integrity": "sha512-DRVlLAG40NpevgVuxpLHwP/COayf72Nac7WJQDvuvX/8CnNMHN9BMUW59efGXWfvXfheCWRXCw9KM1KHy1oSJA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@samvera/clover-iiif/-/clover-iiif-2.4.0.tgz",
+      "integrity": "sha512-RwzvbtsbT3RsISyIl4/7MMTM+diRhte2ANiQQ//sAJOz5ahBS8No/fmtBHxwSgvTR/LZWSLoSwEA77zr7IypXQ==",
       "dependencies": {
         "@iiif/parser": "^1.1.2",
         "@iiif/vault": "^0.9.22",
@@ -6779,12 +6781,12 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-14.1.0.tgz",
-      "integrity": "sha512-SBX2ed7DoRFXC6CQSLc/SbLY9Ut6HxNB2wPTcoIWjUMd7aF7O/SIE7111L8FdZ9TXsNV4pulUDnfthpyPtbFUg==",
+      "version": "14.1.3",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-14.1.3.tgz",
+      "integrity": "sha512-sUCpWlGuHpEhI0pIT0UtdSLJk5Z8E2DYinPTwsBiWaSYQomchdl0i60pjynY48+oXvtyWMQ7oE+G3m49yrfacg==",
       "dev": true,
       "dependencies": {
-        "@next/eslint-plugin-next": "14.1.0",
+        "@next/eslint-plugin-next": "14.1.3",
         "@rushstack/eslint-patch": "^1.3.3",
         "@typescript-eslint/parser": "^5.4.2 || ^6.0.0",
         "eslint-import-resolver-node": "^0.3.6",
@@ -7987,20 +7989,21 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "10.18.0",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.18.0.tgz",
-      "integrity": "sha512-oGlDh1Q1XqYPksuTD/usb0I70hq95OUzmL9+6Zd+Hs4XV0oaISBa/UUMSjYiq6m8EUF32132mOJ8xVZS+I0S6w==",
+      "version": "11.0.12",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.0.12.tgz",
+      "integrity": "sha512-1VW4pk+4EH8RwWHdqntWTwF9peranyHn/BczvMzF9TGh/FwMKxoRZzkig8Nak9BQA8GymfIyCGo5adXwRuXDXA==",
       "dependencies": {
         "tslib": "^2.4.0"
       },
-      "optionalDependencies": {
-        "@emotion/is-prop-valid": "^0.8.2"
-      },
       "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
         "react": "^18.0.0",
         "react-dom": "^18.0.0"
       },
       "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
         "react": {
           "optional": true
         },
@@ -13113,9 +13116,9 @@
       }
     },
     "node_modules/react-error-boundary": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-4.0.12.tgz",
-      "integrity": "sha512-kJdxdEYlb7CPC1A0SeUY38cHpjuu6UkvzKiAmqmOFL21VRfMhOcWxTCBgLVCO0VEMh9JhFNcVaXlV4/BTpiwOA==",
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-4.0.13.tgz",
+      "integrity": "sha512-b6PwbdSv8XeOSYvjt8LpgpKrZ0yGdtZokYwkwV2wlcZbxgopHX/hgPl5VgpnoVOWd868n1hktM8Qm4b+02MiLQ==",
       "dependencies": {
         "@babel/runtime": "^7.12.5"
       },
@@ -14750,9 +14753,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
+      "integrity": "sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -35,17 +35,17 @@
     "@radix-ui/react-select": "^2.0.0",
     "@radix-ui/react-switch": "^1.0.1",
     "@radix-ui/react-tabs": "^1.0.1",
-    "@samvera/clover-iiif": "2.4.0-rc.0",
+    "@samvera/clover-iiif": "^2.4.0",
     "@samvera/image-downloader": "^1.1.6",
     "@stitches/react": "^1.2.6",
     "axios": "^1.2.2",
-    "framer-motion": "^10.2.5",
+    "framer-motion": "^11.0.12",
     "jsonwebtoken": "^9.0.0",
     "next": "^13.5.6",
     "react": "^18.2.0",
     "react-content-loader": "^6.2.0",
     "react-dom": "^18.2.0",
-    "react-error-boundary": "^4.0.4",
+    "react-error-boundary": "^4.0.13",
     "react-masonry-css": "^1.0.16",
     "react-share": "^5.0.3",
     "swiper": "^9.4.1"
@@ -65,7 +65,7 @@
     "babel-jest": "^29.6.2",
     "cypress": "^12.4.0",
     "eslint": "^8.47.0",
-    "eslint-config-next": "^14.0.3",
+    "eslint-config-next": "^14.1.3",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-cypress": "^2.12.1",
     "eslint-plugin-testing-library": "^6.0.1",
@@ -75,7 +75,7 @@
     "next-router-mock": "^0.9.1-beta.0",
     "prettier": "^3.0.1",
     "ts-jest": "^29.0.5",
-    "typescript": "^5.0.4"
+    "typescript": "^5.4.2"
   },
   "optionalDependencies": {
     "fsevents": "^2.3.2"

--- a/pages/collections/[id].tsx
+++ b/pages/collections/[id].tsx
@@ -23,11 +23,12 @@ import {
   getTopMetadataAggs,
 } from "@/lib/collection-helpers";
 import { useEffect, useState } from "react";
+
 import { ApiResponseBucket } from "@/types/api/response";
-import { Collection } from "@nulib/dcapi-types";
 import CollectionTabsExplore from "@/components/Collection/Tabs/Explore";
 import CollectionTabsMetadata from "@/components/Collection/Tabs/Metadata";
 import CollectionTabsOrganization from "@/components/Collection/Tabs/Organization";
+import { Collection as CollectionType } from "@nulib/dcapi-types";
 import Container from "@/components/Shared/Container";
 import Facts from "@/components/Shared/Facts";
 import Head from "next/head";
@@ -41,7 +42,7 @@ import { useRouter } from "next/router";
 
 const Collection: NextPage = () => {
   const router = useRouter();
-  const [collection, setCollection] = useState<Collection>();
+  const [collection, setCollection] = useState<CollectionType>();
   const [metadata, setMetadata] = useState<ApiResponseBucket[]>([]);
   const [series, setSeries] = useState<GenericAggsReturn[]>([]);
   const [topMetadata, setTopMetadata] = useState<GetTopMetadataAggsReturn[]>(


### PR DESCRIPTION
## What does this do?
Updates Clover dependency to `2.4.0` which fixes DC's Video Work Type, Chapters-missing bug:

https://github.com/nulib/repodev_planning_and_docs/issues/4586

