### PR TITLE
Retain search query param between route searches

### DIFF
--- a/components/Facets/Filter/Submit.tsx
+++ b/components/Facets/Filter/Submit.tsx
@@ -17,7 +17,7 @@ const FacetsFilterSubmit: React.FC<FacetsFilterSubmitProps> = ({
   const {
     query: { q },
   } = router;
-  const { urlFacets } = useQueryParams();
+  const { ai, urlFacets } = useQueryParams();
 
   const {
     filterDispatch,
@@ -34,6 +34,7 @@ const FacetsFilterSubmit: React.FC<FacetsFilterSubmitProps> = ({
       ...(q && { q }),
       ...urlFacets,
       ...userFacetsUnsubmitted,
+      ...(ai && { ai }),
     };
 
     router.push({

--- a/components/Facets/UserFacets/UserFacets.tsx
+++ b/components/Facets/UserFacets/UserFacets.tsx
@@ -1,4 +1,5 @@
 import * as Dropdown from "@radix-ui/react-dropdown-menu";
+
 import {
   DropdownContent,
   DropdownToggle,
@@ -6,6 +7,7 @@ import {
 } from "./UserFacets.styled";
 import React, { useRef } from "react";
 import { useEffect, useState } from "react";
+
 import FacetsCurrentUserValue from "@/components/Facets/UserFacets/Value";
 import { IconChevronDown } from "@/components/Shared/SVG/Icons";
 import { UrlFacets } from "@/types/context/filter-context";
@@ -29,13 +31,15 @@ const FacetsCurrentUser: React.FC<FacetsCurrentUserProps> = ({
   screen,
   urlFacets,
 }) => {
-  const [currentOptions, setCurrentOptions] = useState<CurrentFacet[]>([]);
-  const [isOpen, setIsOpen] = useState(false);
   const router = useRouter();
+
   const { filterDispatch, filterState } = useFilterState();
   const {
     searchState: { searchFixed },
   } = useSearchState();
+
+  const [currentOptions, setCurrentOptions] = useState<CurrentFacet[]>([]);
+  const [isOpen, setIsOpen] = useState(false);
 
   const dropdownRef = useRef<HTMLButtonElement>(null);
   const handleOpenChange = (status: boolean) => setIsOpen(status);
@@ -84,7 +88,7 @@ const FacetsCurrentUser: React.FC<FacetsCurrentUserProps> = ({
     if (instance && facets) {
       const { id, value } = instance;
       const {
-        query: { q },
+        query: { q, ai },
       } = router;
       const newObj: UrlFacets = { ...facets };
 
@@ -93,7 +97,11 @@ const FacetsCurrentUser: React.FC<FacetsCurrentUserProps> = ({
       if (screen === "search")
         router.push({
           pathname: "/search",
-          query: { ...(q && { q }), ...newObj },
+          query: {
+            ...(q && { q }),
+            ...newObj,
+            ...(ai && { ai }),
+          },
         });
 
       if (screen === "modal")

--- a/components/Search/GenerativeAIToggle.test.tsx
+++ b/components/Search/GenerativeAIToggle.test.tsx
@@ -38,6 +38,10 @@ const withSearchProvider = (
 };
 
 describe("GenerativeAIToggle", () => {
+  beforeEach(() => {
+    mockRouter.setCurrentUrl("/");
+  });
+
   it("renders the generative AI toggle UI and toggles state for a logged in user", async () => {
     const user = userEvent.setup();
     render(
@@ -64,7 +68,7 @@ describe("GenerativeAIToggle", () => {
     expect(tooltip).toBeInTheDocument();
   });
 
-  it("renders the generative AI dialog for a non-logged in user", async () => {
+  it("renders a login dialog for a non-logged-in user when generative ai checkbox is checked", async () => {
     const user = userEvent.setup();
     const nonLoggedInUser = {
       user: {
@@ -113,5 +117,27 @@ describe("GenerativeAIToggle", () => {
 
     const checkbox = screen.getByRole("checkbox");
     expect(checkbox).toHaveAttribute("data-state", "checked");
+  });
+
+  it("sets a query param in the URL when generative AI checkbox is clicked", async () => {
+    const user = userEvent.setup();
+
+    mockRouter.setCurrentUrl("/");
+    render(
+      withUserProvider(
+        withSearchProvider(
+          <GenerativeAIToggle isSearchActive={false} />,
+          defaultSearchState
+        )
+      )
+    );
+
+    await user.click(screen.getByRole("checkbox"));
+
+    expect(mockRouter).toMatchObject({
+      asPath: "/?ai=true",
+      pathname: "/",
+      query: { ai: "true" },
+    });
   });
 });

--- a/context/search-context.tsx
+++ b/context/search-context.tsx
@@ -7,7 +7,6 @@ type Action =
       type: "updateAggregations";
       aggregations: ApiResponseAggregation | undefined;
     }
-  | { type: "updateGenerativeAI"; isGenerativeAI: boolean }
   | { type: "updateSearch"; q: string }
   | { type: "updateSearchFixed"; searchFixed: boolean };
 
@@ -20,7 +19,6 @@ type SearchProviderProps = {
 
 const defaultState: SearchContextStore = {
   aggregations: {},
-  isGenerativeAI: false,
   searchFixed: false,
 };
 
@@ -34,12 +32,6 @@ function searchReducer(state: State, action: Action) {
       return {
         ...state,
         aggregations: action.aggregations,
-      };
-    }
-    case "updateGenerativeAI": {
-      return {
-        ...state,
-        isGenerativeAI: action.isGenerativeAI,
       };
     }
     case "updateSearch": {

--- a/hooks/useQueryParams.ts
+++ b/hooks/useQueryParams.ts
@@ -7,16 +7,23 @@ export default function useQueryParams() {
   const { isReady, query } = useRouter();
   const [urlFacets, setUrlFacets] = React.useState<UrlFacets>({});
   const [searchTerm, setSearchTerm] = React.useState<string>();
+  const [ai, setAi] = React.useState<string>();
 
   React.useEffect(() => {
     if (!isReady) return;
 
     const obj = parseUrlFacets(query);
     const q = (query.q ? query.q : "") as string;
+    const ai = (query.ai ? query.ai : "") as string;
 
     setUrlFacets(obj);
     setSearchTerm(q);
+    setAi(ai);
   }, [isReady, query]);
 
-  return { searchTerm, urlFacets };
+  return {
+    ai,
+    searchTerm,
+    urlFacets,
+  };
 }

--- a/lib/utils/facet-helpers.ts
+++ b/lib/utils/facet-helpers.ts
@@ -1,5 +1,6 @@
 import { ALL_FACETS, FACETS } from "@/lib/constants/facets-model";
 import { FacetsGroup, FacetsInstance } from "@/types/components/facets";
+
 import { UrlFacets } from "@/types/context/filter-context";
 
 /**
@@ -26,6 +27,10 @@ export function facetRegex(str?: string) {
   return `.*${pattern}.*`;
 }
 
+export const getAllFacetIds = () => {
+  return ALL_FACETS.facets.map((facet) => facet.id);
+};
+
 export const getFacetById = (id: string): FacetsInstance | undefined => {
   return ALL_FACETS.facets.find((facet) => facet.id === id);
 };
@@ -41,15 +46,17 @@ export const getFacetGroup = (id: string): FacetsGroup | undefined => {
 type NextJSRouterQuery = NodeJS.Dict<string[] | string>;
 export const parseUrlFacets = (routerQuery: NextJSRouterQuery) => {
   if (!routerQuery) return {};
-  const obj: UrlFacets = {};
+  const urlFacets: UrlFacets = {};
+
+  const allFacetIds = getAllFacetIds();
 
   for (const [key, value] of Object.entries(routerQuery)) {
-    if (!["q", "page"].includes(key)) {
+    if (allFacetIds.includes(key)) {
       if (key && value) {
-        obj[key] = Array.isArray(value) ? value : [value];
+        urlFacets[key] = Array.isArray(value) ? value : [value];
       }
     }
   }
 
-  return obj;
+  return urlFacets;
 };

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -29,8 +29,8 @@ import { getWork } from "@/lib/work-helpers";
 import { loadDefaultStructuredData } from "@/lib/json-ld";
 import { parseUrlFacets } from "@/lib/utils/facet-helpers";
 import { pluralize } from "@/lib/utils/count-helpers";
+import useQueryParams from "@/hooks/useQueryParams";
 import { useRouter } from "next/router";
-import { useSearchState } from "@/context/search-context";
 
 type RequestState = {
   data: ApiSearchResponse | null;
@@ -42,9 +42,9 @@ const SearchPage: NextPage = () => {
   const size = 40;
   const router = useRouter();
 
-  const { searchState } = useSearchState();
   const { user } = React.useContext(UserContext);
-  const showChatResponse = user?.isLoggedIn && searchState.isGenerativeAI;
+  const { ai } = useQueryParams();
+  const showChatResponse = user?.isLoggedIn && ai;
 
   const [requestState, setRequestState] = useState<RequestState>({
     data: null,

--- a/types/context/search-context.ts
+++ b/types/context/search-context.ts
@@ -2,7 +2,6 @@ import { ApiResponseAggregation } from "@/types/api/response";
 
 export interface SearchContextStore {
   aggregations?: ApiResponseAggregation;
-  isGenerativeAI: boolean;
   searchFixed: boolean;
 }
 


### PR DESCRIPTION
## What does this do?
When initiating a search from any route in the application, if the "Use Generative AI" checkbox is checked, the Search route will now retain this value and immediately kick into AI Search.  Also retains value on page refreshes.

For code changes, it makes the following adjustments:
- Removes user selection of "use generative ai" from Search Context, and moves this to a query param in URL
- In general cleans up previous implementations of extracting and applying facet values as query params

This seems like it smooths out the UX.  If we want to take it further, we could push tracking user selection of "use generative ai" to `localStorage`.

## How to test
1. Go to any route except an individual Collection page.  
2. Check "Use Generative AI", enter a search term and submit.
3. Search page should immediately kick off the AI Search