### PR TITLE
Add a Radix UI AlertDialog component

### DIFF
--- a/components/Search/GenerativeAI.styled.ts
+++ b/components/Search/GenerativeAI.styled.ts
@@ -28,20 +28,6 @@ const GenerativeAIToggleWrapper = styled("div", {
   },
 });
 
-const GenerativeAIDialogMessage = styled("p", {});
-
-const FlexBody = styled("div", {
-  display: "flex",
-  flexDirection: "column",
-  justifyContent: "space-between",
-  width: "100%",
-});
-
-const DialogButtonRow = styled("div", {
-  display: "flex",
-  justifyContent: "flex-end",
-});
-
 const TooltipTrigger = styled(Tooltip.Trigger, {
   background: "transparent",
   border: "none",
@@ -51,11 +37,4 @@ const TooltipContent = styled(Tooltip.Content, {
   zIndex: 2,
 });
 
-export {
-  DialogButtonRow,
-  FlexBody,
-  GenerativeAIDialogMessage,
-  GenerativeAIToggleWrapper,
-  TooltipContent,
-  TooltipTrigger,
-};
+export { GenerativeAIToggleWrapper, TooltipContent, TooltipTrigger };

--- a/components/Search/GenerativeAIToggle.tsx
+++ b/components/Search/GenerativeAIToggle.tsx
@@ -5,20 +5,16 @@ import {
   CheckboxRoot as CheckboxRootStyled,
 } from "@/components/Shared/Checkbox.styled";
 import {
-  DialogButtonRow,
-  FlexBody,
-  GenerativeAIDialogMessage,
   GenerativeAIToggleWrapper,
   TooltipContent,
   TooltipTrigger,
 } from "@/components/Search/GenerativeAI.styled";
 import { TooltipArrow, TooltipBody } from "../Shared/Tooltip.styled";
 
-import { Button } from "@nulib/design-system";
-import GenerativeAIDialog from "@/components/Shared/Dialog";
 import { IconCheck } from "@/components/Shared/SVG/Icons";
 import { IconInfo } from "@/components/Shared/SVG/Icons";
 import React from "react";
+import SharedAlertDialog from "../Shared/AlertDialog";
 import useGenerativeAISearchToggle from "@/hooks/useGenerativeAISearchToggle";
 
 function GenerativeAITooltip() {
@@ -69,27 +65,14 @@ export default function GenerativeAIToggle({
         <GenerativeAITooltip />
       </GenerativeAIToggleWrapper>
 
-      <div style={{ display: "flex" }}>
-        <GenerativeAIDialog
-          isOpen={dialog.isOpen}
-          title={dialog.title}
-          handleCloseClick={closeDialog}
-          size="small"
-        >
-          <FlexBody>
-            <GenerativeAIDialogMessage>
-              You must be logged in with a Northwestern NetID to use the
-              Generative AI search feature.
-            </GenerativeAIDialogMessage>
-            <DialogButtonRow>
-              <Button isPrimary onClick={handleLogin}>
-                Login
-              </Button>
-              <Button onClick={closeDialog}>Cancel</Button>
-            </DialogButtonRow>
-          </FlexBody>
-        </GenerativeAIDialog>
-      </div>
+      <SharedAlertDialog
+        isOpen={dialog.isOpen}
+        cancel={{ label: "Cancel", onClick: closeDialog }}
+        action={{ label: "Login", onClick: handleLogin }}
+      >
+        You must be logged in with a Northwestern NetID to use the Generative AI
+        search feature.
+      </SharedAlertDialog>
     </>
   );
 }

--- a/components/Shared/AlertDialog.styled.ts
+++ b/components/Shared/AlertDialog.styled.ts
@@ -1,0 +1,61 @@
+import * as AlertDialog from "@radix-ui/react-alert-dialog";
+
+import { styled } from "@/stitches.config";
+
+/* eslint sort-keys: 0 */
+
+const AlertDialogOverlay = styled(AlertDialog.Overlay, {
+  background: "rgba(0 0 0 / 0.382)",
+  position: "fixed",
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+  display: "grid",
+  placeItems: "center",
+  overflowY: "auto",
+  zIndex: "1",
+});
+
+const AlertDialogContent = styled(AlertDialog.Content, {
+  backgroundColor: "white",
+  borderRadius: 6,
+  boxShadow:
+    "hsl(206 22% 7% / 35%) 0px 10px 38px -10px, hsl(206 22% 7% / 20%) 0px 10px 20px -15px",
+  position: "fixed",
+  top: "50%",
+  left: "50%",
+  transform: "translate(-50%, -50%)",
+  width: "90vw",
+  maxWidth: "500px",
+  maxHeight: "85vh",
+  padding: 25,
+  zIndex: "2",
+
+  "&:focus": { outline: "none" },
+});
+
+const AlertDialogTitle = styled(AlertDialog.Title, {
+  fontSize: "$gr4",
+  lineHeight: "1.5rem",
+  padding: "0",
+  margin: "0",
+  color: "$black50",
+  fontWeight: "400",
+});
+
+const AlertDialogButtonRow = styled("div", {
+  display: "flex",
+  justifyContent: "flex-end",
+
+  "& > *:not(:last-child)": {
+    marginRight: "$gr3",
+  },
+});
+
+export {
+  AlertDialogButtonRow,
+  AlertDialogContent,
+  AlertDialogOverlay,
+  AlertDialogTitle,
+};

--- a/components/Shared/AlertDialog.test.tsx
+++ b/components/Shared/AlertDialog.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+
+import React from "react";
+import SharedAlertDialog from "./AlertDialog";
+
+const defaultProps = {
+  action: { label: "Login", onClick: jest.fn() },
+  cancel: { label: "Cancel", onClick: jest.fn() },
+  isOpen: true,
+  title: "Title",
+};
+
+describe("SharedAlertDialog", () => {
+  it("renders the primary components", () => {
+    render(<SharedAlertDialog {...defaultProps}>Content</SharedAlertDialog>);
+
+    expect(screen.getByText("Content")).toBeInTheDocument();
+    expect(screen.getByRole("heading")).toHaveTextContent(defaultProps.title);
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Login" })).toBeInTheDocument();
+  });
+
+  it("calls the cancel and action callback functions", () => {
+    render(<SharedAlertDialog {...defaultProps}>Content</SharedAlertDialog>);
+
+    screen.getByRole("button", { name: "Cancel" }).click();
+    expect(defaultProps.cancel.onClick).toHaveBeenCalled();
+
+    screen.getByRole("button", { name: "Login" }).click();
+    expect(defaultProps.action.onClick).toHaveBeenCalled();
+  });
+});

--- a/components/Shared/AlertDialog.tsx
+++ b/components/Shared/AlertDialog.tsx
@@ -1,0 +1,61 @@
+import * as AlertDialog from "@radix-ui/react-alert-dialog";
+
+import {
+  AlertDialogButtonRow,
+  AlertDialogContent,
+  AlertDialogOverlay,
+  AlertDialogTitle,
+} from "@/components/Shared/AlertDialog.styled";
+
+import { Button } from "@nulib/design-system";
+import { ReactNode } from "react";
+
+type DialogButton = {
+  label: string;
+  onClick: () => void;
+};
+
+interface SharedAlertDialogProps {
+  children: ReactNode;
+  action: DialogButton;
+  cancel?: DialogButton;
+  isOpen: boolean;
+  size?: "small" | "large";
+  title?: string;
+}
+
+export default function SharedAlertDialog({
+  children,
+  action,
+  cancel,
+  isOpen,
+  title,
+}: SharedAlertDialogProps) {
+  const cancelLabel = cancel?.label || "Cancel";
+
+  return (
+    <AlertDialog.Root open={isOpen}>
+      <AlertDialog.Portal>
+        <AlertDialogOverlay />
+        <AlertDialogContent>
+          {title && <AlertDialogTitle>{title}</AlertDialogTitle>}
+
+          <AlertDialog.Description>{children}</AlertDialog.Description>
+          <AlertDialogButtonRow>
+            {cancel && (
+              <Button isText onClick={cancel?.onClick}>
+                {cancelLabel}
+              </Button>
+            )}
+
+            <AlertDialog.Action asChild>
+              <Button isPrimary onClick={action.onClick}>
+                {action.label}
+              </Button>
+            </AlertDialog.Action>
+          </AlertDialogButtonRow>
+        </AlertDialogContent>
+      </AlertDialog.Portal>
+    </AlertDialog.Root>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@nulib/design-system": "^1.6.2",
         "@radix-ui/colors": "^3.0.0",
         "@radix-ui/react-accordion": "^1.0.1",
+        "@radix-ui/react-alert-dialog": "^1.0.5",
         "@radix-ui/react-aspect-ratio": "^1.0.1",
         "@radix-ui/react-checkbox": "^1.0.1",
         "@radix-ui/react-dialog": "^1.0.2",
@@ -2200,6 +2201,34 @@
         "@radix-ui/react-id": "1.0.1",
         "@radix-ui/react-primitive": "1.0.3",
         "@radix-ui/react-use-controllable-state": "1.0.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-alert-dialog": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.0.5.tgz",
+      "integrity": "sha512-OrVIOcZL0tl6xibeuGt5/+UxoT2N27KCFOPjFyfXMnchxSHZ/OW7cCX2nGlIYJrbHK/fczPcFzAwvNBB6XBNMA==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-dialog": "1.0.5",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-slot": "1.0.2"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@nulib/design-system": "^1.6.2",
     "@radix-ui/colors": "^3.0.0",
     "@radix-ui/react-accordion": "^1.0.1",
+    "@radix-ui/react-alert-dialog": "^1.0.5",
     "@radix-ui/react-aspect-ratio": "^1.0.1",
     "@radix-ui/react-checkbox": "^1.0.1",
     "@radix-ui/react-dialog": "^1.0.2",


### PR DESCRIPTION
## What does this do?
Replaces our forced use of the previous `SharedDialog` component, originally intended to display large content.  DC needed a more traditional "Alert Dialog" for user interactions such as letting a user know they must be logged in when toggling "Use Generative AI" in search.

![image](https://github.com/nulib/dc-nextjs/assets/3020266/4aaba9f9-6a35-4c68-ae7f-95b3de4897c3)

Pulled in [Radix UI Alert Dialog](https://www.radix-ui.com/primitives/docs/components/alert-dialog) for the job, and customized to match the app.

## How to test
- Click the "Use Generative AI" checkbox in the primary Search bar, and notice the new Dialog UI.
