### PR TITLE
Update APA and MLA citation dates for a Work

### DIFF
--- a/components/Work/ActionsDialog/Cite.test.tsx
+++ b/components/Work/ActionsDialog/Cite.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, within } from "@testing-library/react";
+
 import WorkDialogCite from "@/components/Work/ActionsDialog/Cite";
 import { WorkProvider } from "@/context/work-context";
 import { sampleWork1 } from "@/mocks/sample-work1";
@@ -13,17 +14,19 @@ describe("WorkDialogCite", () => {
   }
   it("renders thumbnail column content", async () => {
     setup();
+
     const div = screen.getByTestId("actions-dialog-aside");
+
     expect(within(div).getByAltText(`${sampleWork1.title}`));
     expect(within(div).getByText(sampleWork1.work_type as string));
   });
 
   it("renders expected metadata content", () => {
     const { ark, terms_of_use, title } = sampleWork1;
-
     const metadataValues = [ark, terms_of_use, title];
 
     setup();
+
     const div = screen.getByTestId("metadata");
 
     // <dt>s
@@ -47,6 +50,26 @@ describe("WorkDialogCite", () => {
 
   it("renders copy links for all metadata", () => {
     setup();
+
     expect(screen.getAllByText(/copy/i).length).toEqual(7);
+  });
+
+  it("renders today's date (date accessed) in MLA and APA Formats", () => {
+    setup();
+
+    const div = screen.getByTestId("metadata");
+    const today = new Date().toDateString();
+
+    const apaFormatEl = within(div).getByText(
+      `University Archives, Northwestern University Libraries. (${today}). Hawking dental products in outdoor market, Cuernavaca, Mexico, Retrieved from http://localhost/items/c16029ff-d027-496a-98b7-6f259395a8f7`,
+      { exact: false }
+    );
+    const mlaFormatEl = within(div).getByText(
+      `University Archives, Northwestern University Libraries. "Hawking dental products in outdoor market, Cuernavaca, Mexico", Jim Roberts Photographs, 1968-1972 ${today}. http://localhost/items/c16029ff-d027-496a-98b7-6f259395a8f7`,
+      { exact: false }
+    );
+
+    expect(apaFormatEl).toBeVisible();
+    expect(mlaFormatEl).toBeVisible();
   });
 });

--- a/components/Work/ActionsDialog/Cite.tsx
+++ b/components/Work/ActionsDialog/Cite.tsx
@@ -2,6 +2,7 @@ import {
   ActionsDialogStyled,
   Content,
 } from "@/components/Work/ActionsDialog/ActionsDialog.styled";
+
 import ActionsDialogAside from "@/components/Work/ActionsDialog/Aside";
 import CopyText from "@/components/Shared/CopyText";
 import { DefinitionListWrapper } from "@/components/Shared/DefinitionList.styled";
@@ -30,9 +31,9 @@ const WorkDialogCite: React.FC = () => {
   const dateObj: Date = new Date(create_date);
   const formattedDate = dateObj.toDateString();
   const itemLink = `${window.location.origin}/items/${id}`;
-  const apaFormat = `${library_unit}, ${nul}. (${formattedDate}). ${title}, Retrieved from ${itemLink}`;
+  const apaFormat = `${library_unit}, ${nul}. (${today}). ${title}, Retrieved from ${itemLink}`;
   const chicagoTurabianFormat = `${library_unit}, ${nul}. "${title}", ${collection_title} Accessed ${today}. ${itemLink}`;
-  const mlaFormat = `${library_unit}, ${nul}. "${title}", ${collection_title} ${formattedDate}. ${window.location.origin}/items/${id}`;
+  const mlaFormat = `${library_unit}, ${nul}. "${title}", ${collection_title} ${today}. ${window.location.origin}/items/${id}`;
   const wikiCitation = `<ref name=NUL>{{cite web | url=${itemLink} | title= ${title} (${formattedDate}) }} |author=Digital Collections, ${nul} |accessdate=${today} |publisher=${nul}, ${library_unit}}}</ref>`;
 
   const metadata = [


### PR DESCRIPTION
## What does this do?

Updates the APA and MLA citation dates to be current (accessed) date instead of "date created".

(Today is April 18, 2024)

![image](https://github.com/nulib/dc-nextjs/assets/3020266/eb129e55-d472-4eef-9835-e2a5a09409d0)


