### PR TITLE
OpenSearch model config

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -74,12 +74,14 @@ resource "aws_amplify_app" "dc-next" {
   }
 
   environment_variables = {
-    ENV                           = var.environment_name
-    HONEYBADGER_API_KEY           = var.honeybadger_api_key
-    HONEYBADGER_ENV               = var.environment_name
-    NEXT_PUBLIC_DCAPI_ENDPOINT    = var.next_public_dcapi_endpoint
-    NEXT_PUBLIC_DC_URL            = var.next_public_dc_url
-    NEXT_PUBLIC_DC_SITEMAP_BUCKET = aws_s3_bucket_website_configuration.sitemap_website.website_endpoint
+    ENV                             = var.environment_name
+    HONEYBADGER_API_KEY             = var.honeybadger_api_key
+    HONEYBADGER_ENV                 = var.environment_name
+    NEXT_PUBLIC_DCAPI_ENDPOINT      = var.next_public_dcapi_endpoint
+    NEXT_PUBLIC_DC_URL              = var.next_public_dc_url
+    NEXT_PUBLIC_DC_SITEMAP_BUCKET   = aws_s3_bucket_website_configuration.sitemap_website.website_endpoint,
+    NEXT_PUBLIC_OPENSEARCH_MODEL_ID = var.next_public_opensearch_model_id,
+    NEXT_PUBLIC_OPENSEARCH_PIPELINE = var.next_public_opensearch_pipeline
   }
 
   custom_rule {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -32,7 +32,7 @@ variable "environment_name" {
 }
 
 variable "honeybadger_api_key" {
-  type    = string
+  type = string
 }
 
 variable "next_public_dcapi_endpoint" {
@@ -43,6 +43,13 @@ variable "next_public_dc_url" {
   type = string
 }
 
+variable "next_public_opensearch_model_id" {
+  type = string
+}
+
+variable "next_public_opensearch_pipeline" {
+  type = string
+}
 
 variable "production_branch" {
   type = string


### PR DESCRIPTION
Adds two new vars:
- `NEXT_PUBLIC_OPENSEARCH_MODEL_ID`
- `NEXT_PUBLIC_OPENSEARCH_PIPELINE`

(Already applied on staging and prod)