### PR TITLE
Use neural search with AI Chat searching

### DIFF
--- a/components/Facets/Filter/Modal.tsx
+++ b/components/Facets/Filter/Modal.tsx
@@ -1,4 +1,5 @@
 import * as Dialog from "@radix-ui/react-dialog";
+
 import {
   FilterBody,
   FilterBodyInner,
@@ -7,6 +8,7 @@ import {
   FilterHeader,
 } from "@/components/Facets/Filter/Filter.styled";
 import React, { useEffect, useState } from "react";
+
 import { ApiSearchRequestBody } from "@/types/api/request";
 import { ApiSearchResponse } from "@/types/api/response";
 import { DC_API_SEARCH_URL } from "@/lib/constants/endpoints";

--- a/lib/utils/get-url-search-params.ts
+++ b/lib/utils/get-url-search-params.ts
@@ -15,3 +15,8 @@ export function getUrlSearchParams(url: string) {
 
   return paramsObj;
 }
+
+export function isAiChatActive() {
+  const urlParams = new URLSearchParams(window.location.search);
+  return urlParams.get("ai") === "true";
+}


### PR DESCRIPTION
## What does this do?
Updates the OpenSearch query object to use a `hybrid` search (using `neural`), when a user is searching via AI Chat.

## How to test?
*Note it's a little tough to test UI search results against limited staging data*

- Update your local `miscellany` repo for env variables needed for `hybrid` search
- Perform a regular and Chat AI search.  
- Inspect the request body, and notice when using AI Chat search (if a search term is provided), the request payload should resemble something like:
- The Search results should visually appear as expected, but the paginated results will be calculated differently by the API

```jsx
{
   ...
    "query": {
        "hybrid": {
            "queries": [
                {
                    "bool": {
                        "must": [
                            {
                                "query_string": {
                                    "fields": [
                                        "title^5",
                                        "all_text",
                                        "all_controlled_labels",
                                        "all_ids"
                                    ],
                                    "query": "Do we have music by Mozart?"
                                }
                            }
                        ]
                    }
                },
                {
                    "neural": {
                        "embedding": {
                            "k": 40,
                            "model_id": NEXT_PUBLIC_OPENSEARCH_MODEL_ID,
                            "query_text": "Do we have music by Mozart?"
                        }
                    }
                }
            ]
        }
    },
    "size": 40
}
```