### PR TITLE
Tune hybrid search results to meet expected results.

### DIFF
--- a/lib/queries/builder.ts
+++ b/lib/queries/builder.ts
@@ -49,8 +49,19 @@ export function buildQuery(obj: BuildQueryProps) {
       hybrid: {
         queries: [
           {
-            bool: {
-              must,
+            query_string: {
+              /**
+               * Reference available index keys/vars:
+               * https://github.com/nulib/meadow/blob/deploy/staging/app/priv/elasticsearch/v2/settings/work.json
+               */
+              fields: [
+                "title^5",
+                // "all_text", // we feel like neural should handle the all_text part
+                "all_controlled_labels",
+                "all_ids^5", // boost the all_ids field
+              ],
+              query: term,
+              default_operator: "AND",
             },
           },
           {

--- a/lib/queries/builder.ts
+++ b/lib/queries/builder.ts
@@ -70,6 +70,11 @@ export function buildQuery(obj: BuildQueryProps) {
                 k: size || 20,
                 model_id: process.env.NEXT_PUBLIC_OPENSEARCH_MODEL_ID,
                 query_text: term, // if term has no value, the API returns a 400 error
+                filter: {
+                  bool: {
+                    filter: buildFacetFilters(urlFacets),
+                  },
+                },
               },
             },
           },


### PR DESCRIPTION
This tunes our hybrid search responses by adding `default_operator: "AND"`, boosting the `all_ids` field, and removing the `all_text` field. We also are now including facet filtering in our responses.

_Note that this does not yet update account for the issue where aggregation response counts need to match expectations of neural search requests. This means the results shown in the grid are expected, however the counts on the facet options are not true to neural results._

