### PR TITLE
Facets filter button becomes fixed only after scrolling past chat response UI elements

### DIFF
--- a/components/Facets/Facets.tsx
+++ b/components/Facets/Facets.tsx
@@ -1,24 +1,39 @@
 import { FacetExtras, StyledFacets, Width, Wrapper } from "./Facets.styled";
-import React, { useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 
 import Container from "@/components/Shared/Container";
 import FacetsFilter from "@/components/Facets/Filter/Filter";
 import SearchPublicOnlyWorks from "@/components/Search/PublicOnlyWorks";
 import WorkType from "@/components/Facets/WorkType/WorkType";
-import { useSearchState } from "@/context/search-context";
 
 const Facets: React.FC = () => {
-  const {
-    searchState: { searchFixed },
-  } = useSearchState();
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const [isFixed, setIsFixed] = useState<boolean>(false);
 
   const facetsRef = useRef<HTMLDivElement>(null);
 
+  useEffect(() => {
+    const handleResize = () => {
+      if (wrapperRef.current) {
+        const rect = wrapperRef.current.getBoundingClientRect();
+        setIsFixed(rect.top < 70);
+      }
+    };
+
+    handleResize();
+
+    window.addEventListener("scroll", handleResize);
+
+    return () => {
+      window.removeEventListener("scroll", handleResize);
+    };
+  }, []);
+
   return (
-    <Wrapper data-filter-fixed={searchFixed}>
+    <Wrapper ref={wrapperRef} data-filter-fixed={isFixed}>
       <Container
         className="facets-ui-container"
-        maxWidth={searchFixed ? facetsRef.current?.clientWidth : undefined}
+        maxWidth={isFixed ? facetsRef.current?.clientWidth : undefined}
       >
         <StyledFacets data-testid="facets-ui-wrapper" ref={facetsRef}>
           <Width ref={facetsRef} />

--- a/hooks/useGenerativeAISearchToggle.ts
+++ b/hooks/useGenerativeAISearchToggle.ts
@@ -25,10 +25,11 @@ export default function useGenerativeAISearchToggle() {
   // If the "ai" query param is present and the user is not logged in on
   // initial load, show the dialog
   useEffect(() => {
-    if (isAiQueryParam && !user?.isLoggedIn) {
-      setDialog((prevDialog) => ({ ...prevDialog, isOpen: true }));
+    if (!user) return;
+    if (isAiQueryParam) {
+      setDialog((prevDialog) => ({ ...prevDialog, isOpen: !user?.isLoggedIn }));
     }
-  }, [isAiQueryParam, user?.isLoggedIn]);
+  }, [isAiQueryParam, user]);
 
   function goToLocation() {
     const currentUrl = `${window.location.origin}${router.asPath}`;


### PR DESCRIPTION
## What does this do?
Removes the Facets Filter button from relying upon the Fixed Search bar to trigger it's own fixed position in the center of the screen.  Instead, there's now a scroll event listener, and if the Filter element gets within a range of the top of the viewport (hardcoded for now to 70px), this calculation will trigger the Filter element's position on the screen.

<img width="1223" alt="image" src="https://github.com/nulib/dc-nextjs/assets/3020266/dbd12dbf-7278-43fb-8759-6a1033f1168f">

<img width="1219" alt="image" src="https://github.com/nulib/dc-nextjs/assets/3020266/a958e057-30c1-4ac5-9e4c-d84c58635a29">

## How to test
Perform a Chat AI search, and notice the placement of the Filter button when scrolling up and down the page.