### PR TITLE
Replace iiif.stack.rdc.library with iiif.dc.library

### DIFF
--- a/cypress/fixtures/item/manifest1.json
+++ b/cypress/fixtures/item/manifest1.json
@@ -16,7 +16,7 @@
                   "@context": "http://iiif.io/api/image/2/context.json",
                   "@id": "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/907c8fde-38a3-4a72-8ea4-0a35605d1ab7"
                 },
-                "@id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/76c26a0a-0454-48d8-a225-9fc26735315b/full/pct:10/0/default.jpg",
+                "@id": "https://iiif.dc.library.northwestern.edu/iiif/2/76c26a0a-0454-48d8-a225-9fc26735315b/full/pct:10/0/default.jpg",
                 "@type": "dctypes:Image"
               },
               "@type": "oa:Annotation"

--- a/cypress/fixtures/search/response1.js
+++ b/cypress/fixtures/search/response1.js
@@ -14,7 +14,7 @@
    * This is a static image in DC Production that we assume will always be available
    */
   const thumbnailUrl =
-    "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/76c26a0a-0454-48d8-a225-9fc26735315b/full/pct:10/0/default.jpg";
+    "https://iiif.dc.library.northwestern.edu/iiif/2/76c26a0a-0454-48d8-a225-9fc26735315b/full/pct:10/0/default.jpg";
   
     const awsMockManifestUrl =
     "https://yt8thudrak.execute-api.us-east-1.amazonaws.com/manifests";

--- a/cypress/fixtures/search/response1.json
+++ b/cypress/fixtures/search/response1.json
@@ -2,7 +2,7 @@
   "data": [
     {
       "accession_number": "0.680069183",
-      "thumbnail": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/76c26a0a-0454-48d8-a225-9fc26735315b/full/pct:10/0/default.jpg",
+      "thumbnail": "https://iiif.dc.library.northwestern.edu/iiif/2/76c26a0a-0454-48d8-a225-9fc26735315b/full/pct:10/0/default.jpg",
       "iiif_manifest": "https://yt8thudrak.execute-api.us-east-1.amazonaws.com/manifests/1",
       "work_type": "Image",
       "id": "1",
@@ -10,7 +10,7 @@
     },
     {
       "accession_number": "Accession:JR_150_35",
-      "thumbnail": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/76c26a0a-0454-48d8-a225-9fc26735315b/full/pct:10/0/default.jpg",
+      "thumbnail": "https://iiif.dc.library.northwestern.edu/iiif/2/76c26a0a-0454-48d8-a225-9fc26735315b/full/pct:10/0/default.jpg",
       "iiif_manifest": "https://yt8thudrak.execute-api.us-east-1.amazonaws.com/manifests/2",
       "work_type": "Image",
       "id": "2",
@@ -18,7 +18,7 @@
     },
     {
       "accession_number": "Voyager:58249",
-      "thumbnail": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/76c26a0a-0454-48d8-a225-9fc26735315b/full/pct:10/0/default.jpg",
+      "thumbnail": "https://iiif.dc.library.northwestern.edu/iiif/2/76c26a0a-0454-48d8-a225-9fc26735315b/full/pct:10/0/default.jpg",
       "iiif_manifest": "https://yt8thudrak.execute-api.us-east-1.amazonaws.com/manifests/3",
       "work_type": "Image",
       "id": "3",
@@ -34,7 +34,7 @@
     },
     {
       "accession_number": "2022_03_24_02",
-      "thumbnail": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/76c26a0a-0454-48d8-a225-9fc26735315b/full/pct:10/0/default.jpg",
+      "thumbnail": "https://iiif.dc.library.northwestern.edu/iiif/2/76c26a0a-0454-48d8-a225-9fc26735315b/full/pct:10/0/default.jpg",
       "iiif_manifest": "https://yt8thudrak.execute-api.us-east-1.amazonaws.com/manifests/5",
       "work_type": "Video",
       "id": "5",

--- a/lib/constants/endpoints.ts
+++ b/lib/constants/endpoints.ts
@@ -4,7 +4,7 @@ const DCAPI_PRODUCTION_ENDPOINT =
 const DC_API_SEARCH_URL = `${DCAPI_ENDPOINT}/search`;
 const DC_URL = process.env.NEXT_PUBLIC_DC_URL;
 const IIIF_IMAGE_SERVICE_ENDPOINT =
-  "https://iiif.stack.rdc.library.northwestern.edu/iiif/2";
+  "https://iiif.dc.library.northwestern.edu/iiif/2";
 const PRODUCTION_URL = "https://digitalcollections.library.northwestern.edu";
 
 export {

--- a/lib/constants/homepage.ts
+++ b/lib/constants/homepage.ts
@@ -41,7 +41,7 @@ export const defaultCollection: HeroCollection = {
   },
   items: [
     {
-      id: "https://iiif.stack.rdc.library.northwestern.edu/public/72/98/fd/ce/-a/dc/1-/45/01/-9/e1/4-/9e/8b/d9/85/e1/49-manifest.json",
+      id: "https://iiif.dc.library.northwestern.edu/public/72/98/fd/ce/-a/dc/1-/45/01/-9/e1/4-/9e/8b/d9/85/e1/49-manifest.json",
       type: "Collection",
       label: { none: ["Edward S. Curtis's The North American Indian"] },
       summary: {
@@ -49,12 +49,12 @@ export const defaultCollection: HeroCollection = {
       },
       thumbnail: [
         {
-          id: `https://iiif.stack.rdc.library.northwestern.edu/iiif/2/440bcf10-a7ee-4824-a1fb-e505cad222df/210,210,2650,1720/1536,/0/default.jpg`,
+          id: `https://iiif.dc.library.northwestern.edu/iiif/2/440bcf10-a7ee-4824-a1fb-e505cad222df/210,210,2650,1720/1536,/0/default.jpg`,
           type: "Image",
           format: "image/jpeg",
           service: [
             {
-              id: "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/440bcf10-a7ee-4824-a1fb-e505cad222df",
+              id: "https://iiif.dc.library.northwestern.edu/iiif/2/440bcf10-a7ee-4824-a1fb-e505cad222df",
               profile: "http://iiif.io/api/image/2/level2.json",
               type: "ImageService2",
             },
@@ -72,7 +72,7 @@ export const defaultCollection: HeroCollection = {
       nul_hero_region: "210,210,2650,1720",
     },
     {
-      id: "https://iiif.stack.rdc.library.northwestern.edu/public/72/98/fd/ce/-a/dc/1-/45/01/-9/e1/4-/9e/8b/d9/85/e1/49-manifest2.json",
+      id: "https://iiif.dc.library.northwestern.edu/public/72/98/fd/ce/-a/dc/1-/45/01/-9/e1/4-/9e/8b/d9/85/e1/49-manifest2.json",
       type: "Collection",
       label: { none: ["Berkeley Folk Music Festival"] },
       summary: {
@@ -80,12 +80,12 @@ export const defaultCollection: HeroCollection = {
       },
       thumbnail: [
         {
-          id: "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/6877a6d9-1580-421d-ba51-e44b97f746a2/full/2000,/0/default.jpg",
+          id: "https://iiif.dc.library.northwestern.edu/iiif/2/6877a6d9-1580-421d-ba51-e44b97f746a2/full/2000,/0/default.jpg",
           type: "Image",
           format: "image/jpeg",
           service: [
             {
-              id: "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/6877a6d9-1580-421d-ba51-e44b97f746a2",
+              id: "https://iiif.dc.library.northwestern.edu/iiif/2/6877a6d9-1580-421d-ba51-e44b97f746a2",
               profile: "http://iiif.io/api/image/2/level2.json",
               type: "ImageService2",
             },
@@ -102,7 +102,7 @@ export const defaultCollection: HeroCollection = {
       ],
     },
     {
-      id: "https://iiif.stack.rdc.library.northwestern.edu/public/72/98/fd/ce/-a/dc/1-/45/01/-9/e1/4-/9e/8b/d9/85/e1/49-manifest3.json",
+      id: "https://iiif.dc.library.northwestern.edu/public/72/98/fd/ce/-a/dc/1-/45/01/-9/e1/4-/9e/8b/d9/85/e1/49-manifest3.json",
       type: "Collection",
       label: {
         none: ["Athletic Department Football Films"],
@@ -126,18 +126,18 @@ export const defaultCollection: HeroCollection = {
       ],
     },
     {
-      id: "https://iiif.stack.rdc.library.northwestern.edu/public/05/2b/b6/f0/-b/6f/5-/45/90/-9/51/b-/ff/df/49/ff/af/03-manifest.json",
+      id: "https://iiif.dc.library.northwestern.edu/public/05/2b/b6/f0/-b/6f/5-/45/90/-9/51/b-/ff/df/49/ff/af/03-manifest.json",
       type: "Collection",
       label: { none: ["Commedia dell'Arte: The Masks of Antonio Fava"] },
       summary: { none: ['Pulcinella "Stronzo" o "Arcigno"'] },
       thumbnail: [
         {
-          id: "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/0d3531f0-2d7f-4e53-bb07-8019f94e44da/full/1600,/0/default.jpg",
+          id: "https://iiif.dc.library.northwestern.edu/iiif/2/0d3531f0-2d7f-4e53-bb07-8019f94e44da/full/1600,/0/default.jpg",
           type: "Image",
           format: "image/jpeg",
           service: [
             {
-              id: "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/0d3531f0-2d7f-4e53-bb07-8019f94e44da",
+              id: "https://iiif.dc.library.northwestern.edu/iiif/2/0d3531f0-2d7f-4e53-bb07-8019f94e44da",
               profile: "http://iiif.io/api/image/2/level2.json",
               type: "ImageService2",
             },
@@ -154,7 +154,7 @@ export const defaultCollection: HeroCollection = {
       ],
     },
     {
-      id: "https://iiif.stack.rdc.library.northwestern.edu/public/72/98/fd/ce/-a/dc/1-/45/01/-9/e1/4-/9e/8b/d9/85/e1/49-manifest4.json",
+      id: "https://iiif.dc.library.northwestern.edu/public/72/98/fd/ce/-a/dc/1-/45/01/-9/e1/4-/9e/8b/d9/85/e1/49-manifest4.json",
       type: "Collection",
       label: { none: ["Jim Roberts Photographs"] },
       summary: {
@@ -162,12 +162,12 @@ export const defaultCollection: HeroCollection = {
       },
       thumbnail: [
         {
-          id: "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/175c24b7-a5b7-4dfc-b01e-92bb075e360c/full/1496,/0/default.jpg",
+          id: "https://iiif.dc.library.northwestern.edu/iiif/2/175c24b7-a5b7-4dfc-b01e-92bb075e360c/full/1496,/0/default.jpg",
           type: "Image",
           format: "image/jpeg",
           service: [
             {
-              id: "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/175c24b7-a5b7-4dfc-b01e-92bb075e360c",
+              id: "https://iiif.dc.library.northwestern.edu/iiif/2/175c24b7-a5b7-4dfc-b01e-92bb075e360c",
               profile: "http://iiif.io/api/image/2/level2.json",
               type: "ImageService2",
             },
@@ -184,18 +184,18 @@ export const defaultCollection: HeroCollection = {
       ],
     },
     {
-      id: "https://iiif.stack.rdc.library.northwestern.edu/public/05/2b/b6/f0/-b/6f/5-/45/90/-9/51/b-/ff/df/49/ff/af/03-manifest2.json",
+      id: "https://iiif.dc.library.northwestern.edu/public/05/2b/b6/f0/-b/6f/5-/45/90/-9/51/b-/ff/df/49/ff/af/03-manifest2.json",
       type: "Collection",
       label: { none: ["World War II Poster Collection"] },
       summary: { none: ["A careless word-- a needless sinking"] },
       thumbnail: [
         {
-          id: "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/b725ab5e-8bc1-4bcc-9f9c-7c90db4e7e69/100,450,1600,1200/800,/0/default.jpg",
+          id: "https://iiif.dc.library.northwestern.edu/iiif/2/b725ab5e-8bc1-4bcc-9f9c-7c90db4e7e69/100,450,1600,1200/800,/0/default.jpg",
           type: "Image",
           format: "image/jpeg",
           service: [
             {
-              id: "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/b725ab5e-8bc1-4bcc-9f9c-7c90db4e7e69",
+              id: "https://iiif.dc.library.northwestern.edu/iiif/2/b725ab5e-8bc1-4bcc-9f9c-7c90db4e7e69",
               profile: "http://iiif.io/api/image/2/level2.json",
               type: "ImageService2",
             },
@@ -226,7 +226,7 @@ export const defaultCollection: HeroCollection = {
           format: "image/jpeg",
           service: [
             {
-              id: "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/37a27b1d-ea5a-4bbe-b38a-fcd2f5904f25",
+              id: "https://iiif.dc.library.northwestern.edu/iiif/2/37a27b1d-ea5a-4bbe-b38a-fcd2f5904f25",
               profile: "http://iiif.io/api/image/2/level2.json",
               type: "ImageService2",
             },
@@ -249,12 +249,12 @@ export const defaultCollection: HeroCollection = {
 export const overviewThumbnails: Array<IIIFExternalWebResource[]> = [
   [
     {
-      id: "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/999a8522-aa7a-4c49-a4a1-25165be91b05/full/461,/0/default.jpg",
+      id: "https://iiif.dc.library.northwestern.edu/iiif/2/999a8522-aa7a-4c49-a4a1-25165be91b05/full/461,/0/default.jpg",
       type: "Image",
       format: "image/jpeg",
       service: [
         {
-          id: "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/092b31cb-810a-4ab8-8d65-7cf9a61ca2fe",
+          id: "https://iiif.dc.library.northwestern.edu/iiif/2/092b31cb-810a-4ab8-8d65-7cf9a61ca2fe",
           profile: "http://iiif.io/api/image/2/level2.json",
           type: "ImageService2",
         },
@@ -265,12 +265,12 @@ export const overviewThumbnails: Array<IIIFExternalWebResource[]> = [
   ],
   [
     {
-      id: "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/acdaef88-f938-4b9c-b388-4748b85d8150//full/384,/0/default.jpg",
+      id: "https://iiif.dc.library.northwestern.edu/iiif/2/acdaef88-f938-4b9c-b388-4748b85d8150//full/384,/0/default.jpg",
       type: "Image",
       format: "image/jpeg",
       service: [
         {
-          id: "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/acdaef88-f938-4b9c-b388-4748b85d8150",
+          id: "https://iiif.dc.library.northwestern.edu/iiif/2/acdaef88-f938-4b9c-b388-4748b85d8150",
           profile: "http://iiif.io/api/image/2/level2.json",
           type: "ImageService2",
         },
@@ -281,12 +281,12 @@ export const overviewThumbnails: Array<IIIFExternalWebResource[]> = [
   ],
   [
     {
-      id: "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/999a8522-aa7a-4c49-a4a1-25165be91b05/full/618,/0/default.jpg",
+      id: "https://iiif.dc.library.northwestern.edu/iiif/2/999a8522-aa7a-4c49-a4a1-25165be91b05/full/618,/0/default.jpg",
       type: "Image",
       format: "image/jpeg",
       service: [
         {
-          id: "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/999a8522-aa7a-4c49-a4a1-25165be91b05",
+          id: "https://iiif.dc.library.northwestern.edu/iiif/2/999a8522-aa7a-4c49-a4a1-25165be91b05",
           profile: "http://iiif.io/api/image/2/level2.json",
           type: "ImageService2",
         },
@@ -297,12 +297,12 @@ export const overviewThumbnails: Array<IIIFExternalWebResource[]> = [
   ],
   [
     {
-      id: "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/70b391d0-51ef-429d-9c3c-3488e7a331fd/full/384,/0/default.jpg",
+      id: "https://iiif.dc.library.northwestern.edu/iiif/2/70b391d0-51ef-429d-9c3c-3488e7a331fd/full/384,/0/default.jpg",
       type: "Image",
       format: "image/jpeg",
       service: [
         {
-          id: "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/70b391d0-51ef-429d-9c3c-3488e7a331fd",
+          id: "https://iiif.dc.library.northwestern.edu/iiif/2/70b391d0-51ef-429d-9c3c-3488e7a331fd",
           profile: "http://iiif.io/api/image/2/level2.json",
           type: "ImageService2",
         },
@@ -323,12 +323,12 @@ export const overviewThumbnails: Array<IIIFExternalWebResource[]> = [
   ],
   [
     {
-      id: "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/83aa87d5-0e0a-4733-9133-a53fb00c3b5a/full/446,/0/default.jpg",
+      id: "https://iiif.dc.library.northwestern.edu/iiif/2/83aa87d5-0e0a-4733-9133-a53fb00c3b5a/full/446,/0/default.jpg",
       type: "Image",
       format: "image/jpeg",
       service: [
         {
-          id: "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/83aa87d5-0e0a-4733-9133-a53fb00c3b5a",
+          id: "https://iiif.dc.library.northwestern.edu/iiif/2/83aa87d5-0e0a-4733-9133-a53fb00c3b5a",
           profile: "http://iiif.io/api/image/2/level2.json",
           type: "ImageService2",
         },

--- a/next.config.js
+++ b/next.config.js
@@ -51,7 +51,7 @@ module.exports = withBundleAnalyzer({
     domains: [
       "dcapi.rdc.library.northwestern.edu",
       "dcapi.rdc-staging.library.northwestern.edu",
-      "iiif.stack.rdc.library.northwestern.edu",
+      "iiif.dc.library.northwestern.edu",
       "iiif.dc.library.northwestern.edu",
       "api.dc.library.northwestern.edu",
     ],

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -20,7 +20,7 @@ import { UnorderedListStyled } from "@/components/Shared/UnorderedList";
 import { buildDataLayer } from "@/lib/ga/data-layer";
 import { loadDefaultStructuredData } from "@/lib/json-ld";
 
-const baseUrl = "https://iiif.stack.rdc.library.northwestern.edu/iiif/2";
+const baseUrl = "https://iiif.dc.library.northwestern.edu/iiif/2";
 
 const featuredCollections: PhotoFeatureProps[] = [
   {

--- a/public/fixtures/iiif/collection/football.json
+++ b/public/fixtures/iiif/collection/football.json
@@ -26,12 +26,12 @@
       "summary": { "none": ["Video"] },
       "thumbnail": [
         {
-          "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/posters/b287374d-c6eb-48bc-ad38-43533fe32926/full/200,/0/default.jpg",
+          "id": "https://iiif.dc.library.northwestern.edu/iiif/2/posters/b287374d-c6eb-48bc-ad38-43533fe32926/full/200,/0/default.jpg",
           "type": "Image",
           "format": "image/jpeg",
           "service": [
             {
-              "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/posters/b287374d-c6eb-48bc-ad38-43533fe32926",
+              "id": "https://iiif.dc.library.northwestern.edu/iiif/2/posters/b287374d-c6eb-48bc-ad38-43533fe32926",
               "profile": "http://iiif.io/api/image/2/level2.json",
               "type": "ImageService2"
             }
@@ -56,12 +56,12 @@
       "summary": { "none": ["Video"] },
       "thumbnail": [
         {
-          "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/posters/df13396b-46e6-47e0-aa60-3b7a7b0585f4/full/200,/0/default.jpg",
+          "id": "https://iiif.dc.library.northwestern.edu/iiif/2/posters/df13396b-46e6-47e0-aa60-3b7a7b0585f4/full/200,/0/default.jpg",
           "type": "Image",
           "format": "image/jpeg",
           "service": [
             {
-              "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/posters/df13396b-46e6-47e0-aa60-3b7a7b0585f4",
+              "id": "https://iiif.dc.library.northwestern.edu/iiif/2/posters/df13396b-46e6-47e0-aa60-3b7a7b0585f4",
               "profile": "http://iiif.io/api/image/2/level2.json",
               "type": "ImageService2"
             }
@@ -80,18 +80,18 @@
       ]
     },
     {
-      "id": "https://iiif.stack.rdc.library.northwestern.edu/public/iiif3/ee/50/c5/57/-1/60/b-/42/e3/-9/35/3-/99/eb/83/ac/bd/8b-manifest.json",
+      "id": "https://iiif.dc.library.northwestern.edu/public/iiif3/ee/50/c5/57/-1/60/b-/42/e3/-9/35/3-/99/eb/83/ac/bd/8b-manifest.json",
       "type": "Manifest",
       "label": { "none": ["Northwestern Football vs. Wisconsin, 1973"] },
       "summary": { "none": ["Video"] },
       "thumbnail": [
         {
-          "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/posters/d184195b-2a7a-4faa-8221-d6c761441d26/full/200,/0/default.jpg",
+          "id": "https://iiif.dc.library.northwestern.edu/iiif/2/posters/d184195b-2a7a-4faa-8221-d6c761441d26/full/200,/0/default.jpg",
           "type": "Image",
           "format": "image/jpeg",
           "service": [
             {
-              "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/posters/d184195b-2a7a-4faa-8221-d6c761441d26",
+              "id": "https://iiif.dc.library.northwestern.edu/iiif/2/posters/d184195b-2a7a-4faa-8221-d6c761441d26",
               "profile": "http://iiif.io/api/image/2/level2.json",
               "type": "ImageService2"
             }
@@ -110,18 +110,18 @@
       ]
     },
     {
-      "id": "https://iiif.stack.rdc.library.northwestern.edu/public/iiif3/0c/a4/55/c5/-3/b5/f-/40/89/-a/21/9-/c1/c2/71/b5/b8/bc-manifest.json",
+      "id": "https://iiif.dc.library.northwestern.edu/public/iiif3/0c/a4/55/c5/-3/b5/f-/40/89/-a/21/9-/c1/c2/71/b5/b8/bc-manifest.json",
       "type": "Manifest",
       "label": { "none": ["Northwestern Football vs. Notre Dame, 1935"] },
       "summary": { "none": ["Video"] },
       "thumbnail": [
         {
-          "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/posters/2a429d80-e696-470f-b88d-935cfb24b01d/full/200,/0/default.jpg",
+          "id": "https://iiif.dc.library.northwestern.edu/iiif/2/posters/2a429d80-e696-470f-b88d-935cfb24b01d/full/200,/0/default.jpg",
           "type": "Image",
           "format": "image/jpeg",
           "service": [
             {
-              "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/posters/2a429d80-e696-470f-b88d-935cfb24b01d",
+              "id": "https://iiif.dc.library.northwestern.edu/iiif/2/posters/2a429d80-e696-470f-b88d-935cfb24b01d",
               "profile": "http://iiif.io/api/image/2/level2.json",
               "type": "ImageService2"
             }
@@ -140,18 +140,18 @@
       ]
     },
     {
-      "id": "https://iiif.stack.rdc.library.northwestern.edu/public/iiif3/2d/cb/09/a7/-5/db/c-/44/a9/-b/40/7-/4d/8a/dc/d2/0e/12-manifest.json",
+      "id": "https://iiif.dc.library.northwestern.edu/public/iiif3/2d/cb/09/a7/-5/db/c-/44/a9/-b/40/7-/4d/8a/dc/d2/0e/12-manifest.json",
       "type": "Manifest",
       "label": { "none": ["Northwestern Football vs. Purdue, 1931"] },
       "summary": { "none": ["Video"] },
       "thumbnail": [
         {
-          "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/posters/49668e48-8d55-4e33-a6be-adc8a44edd74/full/200,/0/default.jpg",
+          "id": "https://iiif.dc.library.northwestern.edu/iiif/2/posters/49668e48-8d55-4e33-a6be-adc8a44edd74/full/200,/0/default.jpg",
           "type": "Image",
           "format": "image/jpeg",
           "service": [
             {
-              "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/posters/49668e48-8d55-4e33-a6be-adc8a44edd74",
+              "id": "https://iiif.dc.library.northwestern.edu/iiif/2/posters/49668e48-8d55-4e33-a6be-adc8a44edd74",
               "profile": "http://iiif.io/api/image/2/level2.json",
               "type": "ImageService2"
             }
@@ -170,18 +170,18 @@
       ]
     },
     {
-      "id": "https://iiif.stack.rdc.library.northwestern.edu/public/iiif3/1b/58/2d/e6/-3/95/8-/4f/f8/-9/d3/c-/98/98/3a/83/4a/93-manifest.json",
+      "id": "https://iiif.dc.library.northwestern.edu/public/iiif3/1b/58/2d/e6/-3/95/8-/4f/f8/-9/d3/c-/98/98/3a/83/4a/93-manifest.json",
       "type": "Manifest",
       "label": { "none": ["Northwestern Football vs. Iowa, 1976"] },
       "summary": { "none": ["Video"] },
       "thumbnail": [
         {
-          "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/posters/2c5b2a7c-cf15-4bc0-b181-bc909f17fefa/full/200,/0/default.jpg",
+          "id": "https://iiif.dc.library.northwestern.edu/iiif/2/posters/2c5b2a7c-cf15-4bc0-b181-bc909f17fefa/full/200,/0/default.jpg",
           "type": "Image",
           "format": "image/jpeg",
           "service": [
             {
-              "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/posters/2c5b2a7c-cf15-4bc0-b181-bc909f17fefa",
+              "id": "https://iiif.dc.library.northwestern.edu/iiif/2/posters/2c5b2a7c-cf15-4bc0-b181-bc909f17fefa",
               "profile": "http://iiif.io/api/image/2/level2.json",
               "type": "ImageService2"
             }
@@ -200,18 +200,18 @@
       ]
     },
     {
-      "id": "https://iiif.stack.rdc.library.northwestern.edu/public/iiif3/74/aa/4b/9c/-e/60/d-/48/0a/-a/e3/5-/5e/1a/90/c9/57/d8-manifest.json",
+      "id": "https://iiif.dc.library.northwestern.edu/public/iiif3/74/aa/4b/9c/-e/60/d-/48/0a/-a/e3/5-/5e/1a/90/c9/57/d8-manifest.json",
       "type": "Manifest",
       "label": { "none": ["Northwestern Football vs. Michigan, 1987"] },
       "summary": { "none": ["Video"] },
       "thumbnail": [
         {
-          "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/posters/ccf35071-c43a-42b1-bac7-7cec3a7f8de0/full/200,/0/default.jpg",
+          "id": "https://iiif.dc.library.northwestern.edu/iiif/2/posters/ccf35071-c43a-42b1-bac7-7cec3a7f8de0/full/200,/0/default.jpg",
           "type": "Image",
           "format": "image/jpeg",
           "service": [
             {
-              "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/posters/ccf35071-c43a-42b1-bac7-7cec3a7f8de0",
+              "id": "https://iiif.dc.library.northwestern.edu/iiif/2/posters/ccf35071-c43a-42b1-bac7-7cec3a7f8de0",
               "profile": "http://iiif.io/api/image/2/level2.json",
               "type": "ImageService2"
             }

--- a/public/fixtures/iiif/collection/masks.json
+++ b/public/fixtures/iiif/collection/masks.json
@@ -20,18 +20,18 @@
   ],
   "items": [
     {
-      "id": "https://iiif.stack.rdc.library.northwestern.edu/public/72/98/fd/ce/-a/dc/1-/45/01/-9/e1/4-/9e/8b/d9/85/e1/49-manifest.json",
+      "id": "https://iiif.dc.library.northwestern.edu/public/72/98/fd/ce/-a/dc/1-/45/01/-9/e1/4-/9e/8b/d9/85/e1/49-manifest.json",
       "type": "Manifest",
       "label": { "none": ["Pantalone classico"] },
       "summary": { "none": ["Image"] },
       "thumbnail": [
         {
-          "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/180682c9-dfaf-4881-b7b6-1f2f21092d4f/full/200,/0/default.jpg",
+          "id": "https://iiif.dc.library.northwestern.edu/iiif/2/180682c9-dfaf-4881-b7b6-1f2f21092d4f/full/200,/0/default.jpg",
           "type": "Image",
           "format": "image/jpeg",
           "service": [
             {
-              "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/180682c9-dfaf-4881-b7b6-1f2f21092d4f",
+              "id": "https://iiif.dc.library.northwestern.edu/iiif/2/180682c9-dfaf-4881-b7b6-1f2f21092d4f",
               "profile": "http://iiif.io/api/image/2/level2.json",
               "type": "ImageService2"
             }
@@ -50,18 +50,18 @@
       ]
     },
     {
-      "id": "https://iiif.stack.rdc.library.northwestern.edu/public/a0/37/a4/fb/-a/dd/4-/40/af/-8/ad/d-/9a/02/e5/57/34/71-manifest.json",
+      "id": "https://iiif.dc.library.northwestern.edu/public/a0/37/a4/fb/-a/dd/4-/40/af/-8/ad/d-/9a/02/e5/57/34/71-manifest.json",
       "type": "Manifest",
       "label": { "none": ["Francatrippa"] },
       "summary": { "none": ["Image"] },
       "thumbnail": [
         {
-          "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/42d07b28-083e-4dfb-a3e9-88f2dfc3a571/full/200,/0/default.jpg",
+          "id": "https://iiif.dc.library.northwestern.edu/iiif/2/42d07b28-083e-4dfb-a3e9-88f2dfc3a571/full/200,/0/default.jpg",
           "type": "Image",
           "format": "image/jpeg",
           "service": [
             {
-              "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/42d07b28-083e-4dfb-a3e9-88f2dfc3a571",
+              "id": "https://iiif.dc.library.northwestern.edu/iiif/2/42d07b28-083e-4dfb-a3e9-88f2dfc3a571",
               "profile": "http://iiif.io/api/image/2/level2.json",
               "type": "ImageService2"
             }
@@ -80,18 +80,18 @@
       ]
     },
     {
-      "id": "https://iiif.stack.rdc.library.northwestern.edu/public/05/2b/b6/f0/-b/6f/5-/45/90/-9/51/b-/ff/df/49/ff/af/03-manifest.json",
+      "id": "https://iiif.dc.library.northwestern.edu/public/05/2b/b6/f0/-b/6f/5-/45/90/-9/51/b-/ff/df/49/ff/af/03-manifest.json",
       "type": "Manifest",
       "label": { "none": ["Pulcinella \"Stronzo\" o \"Arcigno\""] },
       "summary": { "none": ["Image"] },
       "thumbnail": [
         {
-          "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/0d3531f0-2d7f-4e53-bb07-8019f94e44da/full/200,/0/default.jpg",
+          "id": "https://iiif.dc.library.northwestern.edu/iiif/2/0d3531f0-2d7f-4e53-bb07-8019f94e44da/full/200,/0/default.jpg",
           "type": "Image",
           "format": "image/jpeg",
           "service": [
             {
-              "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/0d3531f0-2d7f-4e53-bb07-8019f94e44da",
+              "id": "https://iiif.dc.library.northwestern.edu/iiif/2/0d3531f0-2d7f-4e53-bb07-8019f94e44da",
               "profile": "http://iiif.io/api/image/2/level2.json",
               "type": "ImageService2"
             }
@@ -110,18 +110,18 @@
       ]
     },
     {
-      "id": "https://iiif.stack.rdc.library.northwestern.edu/public/71/15/33/79/-4/28/3-/43/be/-8/b0/f-/4e/7e/3b/fd/a2/75-manifest.json",
+      "id": "https://iiif.dc.library.northwestern.edu/public/71/15/33/79/-4/28/3-/43/be/-8/b0/f-/4e/7e/3b/fd/a2/75-manifest.json",
       "type": "Manifest",
       "label": { "none": ["Zagna \"lunga\""] },
       "summary": { "none": ["Image"] },
       "thumbnail": [
         {
-          "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/44d0ad4d-6a0d-4632-82a3-b6ab8fd4e5b7/full/200,/0/default.jpg",
+          "id": "https://iiif.dc.library.northwestern.edu/iiif/2/44d0ad4d-6a0d-4632-82a3-b6ab8fd4e5b7/full/200,/0/default.jpg",
           "type": "Image",
           "format": "image/jpeg",
           "service": [
             {
-              "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/44d0ad4d-6a0d-4632-82a3-b6ab8fd4e5b7",
+              "id": "https://iiif.dc.library.northwestern.edu/iiif/2/44d0ad4d-6a0d-4632-82a3-b6ab8fd4e5b7",
               "profile": "http://iiif.io/api/image/2/level2.json",
               "type": "ImageService2"
             }
@@ -140,18 +140,18 @@
       ]
     },
     {
-      "id": "https://iiif.stack.rdc.library.northwestern.edu/public/8b/04/ee/13/-e/69/6-/4b/eb/-8/a3/3-/a9/d1/1c/de/e5/9b-manifest.json",
+      "id": "https://iiif.dc.library.northwestern.edu/public/8b/04/ee/13/-e/69/6-/4b/eb/-8/a3/3-/a9/d1/1c/de/e5/9b-manifest.json",
       "type": "Manifest",
       "label": { "none": ["Grande Zanni"] },
       "summary": { "none": ["Image"] },
       "thumbnail": [
         {
-          "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/04f87867-903f-465f-81b8-c41a1d6957fa/full/200,/0/default.jpg",
+          "id": "https://iiif.dc.library.northwestern.edu/iiif/2/04f87867-903f-465f-81b8-c41a1d6957fa/full/200,/0/default.jpg",
           "type": "Image",
           "format": "image/jpeg",
           "service": [
             {
-              "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/04f87867-903f-465f-81b8-c41a1d6957fa",
+              "id": "https://iiif.dc.library.northwestern.edu/iiif/2/04f87867-903f-465f-81b8-c41a1d6957fa",
               "profile": "http://iiif.io/api/image/2/level2.json",
               "type": "ImageService2"
             }
@@ -170,18 +170,18 @@
       ]
     },
     {
-      "id": "https://iiif.stack.rdc.library.northwestern.edu/public/a3/c6/40/28/-d/1d/c-/4e/97/-8/2b/b-/1e/23/af/95/f5/e3-manifest.json",
+      "id": "https://iiif.dc.library.northwestern.edu/public/a3/c6/40/28/-d/1d/c-/4e/97/-8/2b/b-/1e/23/af/95/f5/e3-manifest.json",
       "type": "Manifest",
       "label": { "none": ["Bravazzo"] },
       "summary": { "none": ["Image"] },
       "thumbnail": [
         {
-          "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/38062d63-cbf3-421f-ba74-49081beb2ff6/full/200,/0/default.jpg",
+          "id": "https://iiif.dc.library.northwestern.edu/iiif/2/38062d63-cbf3-421f-ba74-49081beb2ff6/full/200,/0/default.jpg",
           "type": "Image",
           "format": "image/jpeg",
           "service": [
             {
-              "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/38062d63-cbf3-421f-ba74-49081beb2ff6",
+              "id": "https://iiif.dc.library.northwestern.edu/iiif/2/38062d63-cbf3-421f-ba74-49081beb2ff6",
               "profile": "http://iiif.io/api/image/2/level2.json",
               "type": "ImageService2"
             }
@@ -200,18 +200,18 @@
       ]
     },
     {
-      "id": "https://iiif.stack.rdc.library.northwestern.edu/public/eb/b4/94/ad/-1/d5/6-/4a/d4/-9/77/2-/f2/28/06/7d/5a/79-manifest.json",
+      "id": "https://iiif.dc.library.northwestern.edu/public/eb/b4/94/ad/-1/d5/6-/4a/d4/-9/77/2-/f2/28/06/7d/5a/79-manifest.json",
       "type": "Manifest",
       "label": { "none": ["Arlecchino \"Scimmia\""] },
       "summary": { "none": ["Image"] },
       "thumbnail": [
         {
-          "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/47ba6136-4c7f-48a5-9bfb-11c2f86026f8/full/200,/0/default.jpg",
+          "id": "https://iiif.dc.library.northwestern.edu/iiif/2/47ba6136-4c7f-48a5-9bfb-11c2f86026f8/full/200,/0/default.jpg",
           "type": "Image",
           "format": "image/jpeg",
           "service": [
             {
-              "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/47ba6136-4c7f-48a5-9bfb-11c2f86026f8",
+              "id": "https://iiif.dc.library.northwestern.edu/iiif/2/47ba6136-4c7f-48a5-9bfb-11c2f86026f8",
               "profile": "http://iiif.io/api/image/2/level2.json",
               "type": "ImageService2"
             }
@@ -230,18 +230,18 @@
       ]
     },
     {
-      "id": "https://iiif.stack.rdc.library.northwestern.edu/public/2d/e0/35/5c/-8/e4/8-/44/78/-9/3a/f-/8c/bd/14/37/bd/16-manifest.json",
+      "id": "https://iiif.dc.library.northwestern.edu/public/2d/e0/35/5c/-8/e4/8-/44/78/-9/3a/f-/8c/bd/14/37/bd/16-manifest.json",
       "type": "Manifest",
       "label": { "none": ["Pulcinella \"tiepolano\""] },
       "summary": { "none": ["Image"] },
       "thumbnail": [
         {
-          "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/3d42aceb-73ad-44cc-817e-459993a50be6/full/200,/0/default.jpg",
+          "id": "https://iiif.dc.library.northwestern.edu/iiif/2/3d42aceb-73ad-44cc-817e-459993a50be6/full/200,/0/default.jpg",
           "type": "Image",
           "format": "image/jpeg",
           "service": [
             {
-              "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/3d42aceb-73ad-44cc-817e-459993a50be6",
+              "id": "https://iiif.dc.library.northwestern.edu/iiif/2/3d42aceb-73ad-44cc-817e-459993a50be6",
               "profile": "http://iiif.io/api/image/2/level2.json",
               "type": "ImageService2"
             }
@@ -260,18 +260,18 @@
       ]
     },
     {
-      "id": "https://iiif.stack.rdc.library.northwestern.edu/public/f9/12/a5/81/-d/9e/8-/43/d6/-a/7c/8-/a8/d4/6e/ff/75/17-manifest.json",
+      "id": "https://iiif.dc.library.northwestern.edu/public/f9/12/a5/81/-d/9e/8-/43/d6/-a/7c/8-/a8/d4/6e/ff/75/17-manifest.json",
       "type": "Manifest",
       "label": { "none": ["Dottor Plus Quam Perfectus"] },
       "summary": { "none": ["Image"] },
       "thumbnail": [
         {
-          "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/156b56cf-fcc5-457c-86cc-5f806b7c280a/full/200,/0/default.jpg",
+          "id": "https://iiif.dc.library.northwestern.edu/iiif/2/156b56cf-fcc5-457c-86cc-5f806b7c280a/full/200,/0/default.jpg",
           "type": "Image",
           "format": "image/jpeg",
           "service": [
             {
-              "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/156b56cf-fcc5-457c-86cc-5f806b7c280a",
+              "id": "https://iiif.dc.library.northwestern.edu/iiif/2/156b56cf-fcc5-457c-86cc-5f806b7c280a",
               "profile": "http://iiif.io/api/image/2/level2.json",
               "type": "ImageService2"
             }

--- a/public/fixtures/iiif/manifest/ohio-state-1937.json
+++ b/public/fixtures/iiif/manifest/ohio-state-1937.json
@@ -4,21 +4,21 @@
     {
       "annotations": [
         {
-          "id": "https://iiif.stack.rdc.library.northwestern.edu/public/iiif3/cf/4e/33/36/-1/02/5-/4f/0f/-a/63/5-/53/64/fd/ed/f9/d5-manifest.json/canvas/df13396b-46e6-47e0-aa60-3b7a7b0585f4/annotation_page/a1",
+          "id": "https://iiif.dc.library.northwestern.edu/public/iiif3/cf/4e/33/36/-1/02/5-/4f/0f/-a/63/5-/53/64/fd/ed/f9/d5-manifest.json/canvas/df13396b-46e6-47e0-aa60-3b7a7b0585f4/annotation_page/a1",
           "items": [
             {
               "body": {
                 "format": "text/vtt",
-                "id": "https://iiif.stack.rdc.library.northwestern.edu/public/vtt/df/13/39/6b/-4/6e/6-/47/e0/-a/a6/0-/3b/7a/7b/05/85/f4/df13396b-46e6-47e0-aa60-3b7a7b0585f4.vtt",
+                "id": "https://iiif.dc.library.northwestern.edu/public/vtt/df/13/39/6b/-4/6e/6-/47/e0/-a/a6/0-/3b/7a/7b/05/85/f4/df13396b-46e6-47e0-aa60-3b7a7b0585f4.vtt",
                 "label": {
                   "en": ["Chapters"]
                 },
                 "language": "en",
                 "type": "Text"
               },
-              "id": "https://iiif.stack.rdc.library.northwestern.edu/public/iiif3/cf/4e/33/36/-1/02/5-/4f/0f/-a/63/5-/53/64/fd/ed/f9/d5-manifest.json/canvas/df13396b-46e6-47e0-aa60-3b7a7b0585f4/annotation_page/1/annotation/2",
+              "id": "https://iiif.dc.library.northwestern.edu/public/iiif3/cf/4e/33/36/-1/02/5-/4f/0f/-a/63/5-/53/64/fd/ed/f9/d5-manifest.json/canvas/df13396b-46e6-47e0-aa60-3b7a7b0585f4/annotation_page/1/annotation/2",
               "motivation": "supplementing",
-              "target": "https://iiif.stack.rdc.library.northwestern.edu/public/iiif3/cf/4e/33/36/-1/02/5-/4f/0f/-a/63/5-/53/64/fd/ed/f9/d5-manifest.json/canvas/df13396b-46e6-47e0-aa60-3b7a7b0585f4",
+              "target": "https://iiif.dc.library.northwestern.edu/public/iiif3/cf/4e/33/36/-1/02/5-/4f/0f/-a/63/5-/53/64/fd/ed/f9/d5-manifest.json/canvas/df13396b-46e6-47e0-aa60-3b7a7b0585f4",
               "type": "Annotation"
             }
           ],
@@ -27,10 +27,10 @@
       ],
       "duration": 791.125,
       "height": 480,
-      "id": "https://iiif.stack.rdc.library.northwestern.edu/public/iiif3/cf/4e/33/36/-1/02/5-/4f/0f/-a/63/5-/53/64/fd/ed/f9/d5-manifest.json/canvas/df13396b-46e6-47e0-aa60-3b7a7b0585f4",
+      "id": "https://iiif.dc.library.northwestern.edu/public/iiif3/cf/4e/33/36/-1/02/5-/4f/0f/-a/63/5-/53/64/fd/ed/f9/d5-manifest.json/canvas/df13396b-46e6-47e0-aa60-3b7a7b0585f4",
       "items": [
         {
-          "id": "https://iiif.stack.rdc.library.northwestern.edu/public/iiif3/cf/4e/33/36/-1/02/5-/4f/0f/-a/63/5-/53/64/fd/ed/f9/d5-manifest.json/canvas/df13396b-46e6-47e0-aa60-3b7a7b0585f4/annotation_page/1",
+          "id": "https://iiif.dc.library.northwestern.edu/public/iiif3/cf/4e/33/36/-1/02/5-/4f/0f/-a/63/5-/53/64/fd/ed/f9/d5-manifest.json/canvas/df13396b-46e6-47e0-aa60-3b7a7b0585f4/annotation_page/1",
           "items": [
             {
               "body": {
@@ -41,9 +41,9 @@
                 "type": "Video",
                 "width": 2048
               },
-              "id": "https://iiif.stack.rdc.library.northwestern.edu/public/iiif3/cf/4e/33/36/-1/02/5-/4f/0f/-a/63/5-/53/64/fd/ed/f9/d5-manifest.json/canvas/df13396b-46e6-47e0-aa60-3b7a7b0585f4/annotation_page/1/annotation/1",
+              "id": "https://iiif.dc.library.northwestern.edu/public/iiif3/cf/4e/33/36/-1/02/5-/4f/0f/-a/63/5-/53/64/fd/ed/f9/d5-manifest.json/canvas/df13396b-46e6-47e0-aa60-3b7a7b0585f4/annotation_page/1/annotation/1",
               "motivation": "painting",
-              "target": "https://iiif.stack.rdc.library.northwestern.edu/public/iiif3/cf/4e/33/36/-1/02/5-/4f/0f/-a/63/5-/53/64/fd/ed/f9/d5-manifest.json/canvas/df13396b-46e6-47e0-aa60-3b7a7b0585f4",
+              "target": "https://iiif.dc.library.northwestern.edu/public/iiif3/cf/4e/33/36/-1/02/5-/4f/0f/-a/63/5-/53/64/fd/ed/f9/d5-manifest.json/canvas/df13396b-46e6-47e0-aa60-3b7a7b0585f4",
               "type": "Annotation"
             }
           ],
@@ -57,10 +57,10 @@
         {
           "format": "image/jpeg",
           "height": 300,
-          "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/posters/df13396b-46e6-47e0-aa60-3b7a7b0585f4/full/!300,300/0/default.jpg",
+          "id": "https://iiif.dc.library.northwestern.edu/iiif/2/posters/df13396b-46e6-47e0-aa60-3b7a7b0585f4/full/!300,300/0/default.jpg",
           "service": [
             {
-              "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/posters/df13396b-46e6-47e0-aa60-3b7a7b0585f4",
+              "id": "https://iiif.dc.library.northwestern.edu/iiif/2/posters/df13396b-46e6-47e0-aa60-3b7a7b0585f4",
               "profile": "http://iiif.io/api/image/2/level2.json",
               "type": "ImageService2"
             }
@@ -83,10 +83,10 @@
     {
       "duration": 470.792,
       "height": 480,
-      "id": "https://iiif.stack.rdc.library.northwestern.edu/public/iiif3/cf/4e/33/36/-1/02/5-/4f/0f/-a/63/5-/53/64/fd/ed/f9/d5-manifest.json/canvas/ddf29a36-3b5a-4685-a670-451cfc753fde",
+      "id": "https://iiif.dc.library.northwestern.edu/public/iiif3/cf/4e/33/36/-1/02/5-/4f/0f/-a/63/5-/53/64/fd/ed/f9/d5-manifest.json/canvas/ddf29a36-3b5a-4685-a670-451cfc753fde",
       "items": [
         {
-          "id": "https://iiif.stack.rdc.library.northwestern.edu/public/iiif3/cf/4e/33/36/-1/02/5-/4f/0f/-a/63/5-/53/64/fd/ed/f9/d5-manifest.json/canvas/ddf29a36-3b5a-4685-a670-451cfc753fde/annotation_page/1",
+          "id": "https://iiif.dc.library.northwestern.edu/public/iiif3/cf/4e/33/36/-1/02/5-/4f/0f/-a/63/5-/53/64/fd/ed/f9/d5-manifest.json/canvas/ddf29a36-3b5a-4685-a670-451cfc753fde/annotation_page/1",
           "items": [
             {
               "body": {
@@ -97,9 +97,9 @@
                 "type": "Video",
                 "width": 2048
               },
-              "id": "https://iiif.stack.rdc.library.northwestern.edu/public/iiif3/cf/4e/33/36/-1/02/5-/4f/0f/-a/63/5-/53/64/fd/ed/f9/d5-manifest.json/canvas/ddf29a36-3b5a-4685-a670-451cfc753fde/annotation_page/1/annotation/1",
+              "id": "https://iiif.dc.library.northwestern.edu/public/iiif3/cf/4e/33/36/-1/02/5-/4f/0f/-a/63/5-/53/64/fd/ed/f9/d5-manifest.json/canvas/ddf29a36-3b5a-4685-a670-451cfc753fde/annotation_page/1/annotation/1",
               "motivation": "painting",
-              "target": "https://iiif.stack.rdc.library.northwestern.edu/public/iiif3/cf/4e/33/36/-1/02/5-/4f/0f/-a/63/5-/53/64/fd/ed/f9/d5-manifest.json/canvas/ddf29a36-3b5a-4685-a670-451cfc753fde",
+              "target": "https://iiif.dc.library.northwestern.edu/public/iiif3/cf/4e/33/36/-1/02/5-/4f/0f/-a/63/5-/53/64/fd/ed/f9/d5-manifest.json/canvas/ddf29a36-3b5a-4685-a670-451cfc753fde",
               "type": "Annotation"
             }
           ],
@@ -113,10 +113,10 @@
         {
           "format": "image/jpeg",
           "height": 300,
-          "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/posters/ddf29a36-3b5a-4685-a670-451cfc753fde/full/!300,300/0/default.jpg",
+          "id": "https://iiif.dc.library.northwestern.edu/iiif/2/posters/ddf29a36-3b5a-4685-a670-451cfc753fde/full/!300,300/0/default.jpg",
           "service": [
             {
-              "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/posters/ddf29a36-3b5a-4685-a670-451cfc753fde",
+              "id": "https://iiif.dc.library.northwestern.edu/iiif/2/posters/ddf29a36-3b5a-4685-a670-451cfc753fde",
               "profile": "http://iiif.io/api/image/2/level2.json",
               "type": "ImageService2"
             }
@@ -139,10 +139,10 @@
     {
       "duration": 546.709,
       "height": 480,
-      "id": "https://iiif.stack.rdc.library.northwestern.edu/public/iiif3/cf/4e/33/36/-1/02/5-/4f/0f/-a/63/5-/53/64/fd/ed/f9/d5-manifest.json/canvas/70602b4e-ec3a-43ad-ad51-dd04c4e665ec",
+      "id": "https://iiif.dc.library.northwestern.edu/public/iiif3/cf/4e/33/36/-1/02/5-/4f/0f/-a/63/5-/53/64/fd/ed/f9/d5-manifest.json/canvas/70602b4e-ec3a-43ad-ad51-dd04c4e665ec",
       "items": [
         {
-          "id": "https://iiif.stack.rdc.library.northwestern.edu/public/iiif3/cf/4e/33/36/-1/02/5-/4f/0f/-a/63/5-/53/64/fd/ed/f9/d5-manifest.json/canvas/70602b4e-ec3a-43ad-ad51-dd04c4e665ec/annotation_page/1",
+          "id": "https://iiif.dc.library.northwestern.edu/public/iiif3/cf/4e/33/36/-1/02/5-/4f/0f/-a/63/5-/53/64/fd/ed/f9/d5-manifest.json/canvas/70602b4e-ec3a-43ad-ad51-dd04c4e665ec/annotation_page/1",
           "items": [
             {
               "body": {
@@ -153,9 +153,9 @@
                 "type": "Video",
                 "width": 2048
               },
-              "id": "https://iiif.stack.rdc.library.northwestern.edu/public/iiif3/cf/4e/33/36/-1/02/5-/4f/0f/-a/63/5-/53/64/fd/ed/f9/d5-manifest.json/canvas/70602b4e-ec3a-43ad-ad51-dd04c4e665ec/annotation_page/1/annotation/1",
+              "id": "https://iiif.dc.library.northwestern.edu/public/iiif3/cf/4e/33/36/-1/02/5-/4f/0f/-a/63/5-/53/64/fd/ed/f9/d5-manifest.json/canvas/70602b4e-ec3a-43ad-ad51-dd04c4e665ec/annotation_page/1/annotation/1",
               "motivation": "painting",
-              "target": "https://iiif.stack.rdc.library.northwestern.edu/public/iiif3/cf/4e/33/36/-1/02/5-/4f/0f/-a/63/5-/53/64/fd/ed/f9/d5-manifest.json/canvas/70602b4e-ec3a-43ad-ad51-dd04c4e665ec",
+              "target": "https://iiif.dc.library.northwestern.edu/public/iiif3/cf/4e/33/36/-1/02/5-/4f/0f/-a/63/5-/53/64/fd/ed/f9/d5-manifest.json/canvas/70602b4e-ec3a-43ad-ad51-dd04c4e665ec",
               "type": "Annotation"
             }
           ],
@@ -169,10 +169,10 @@
         {
           "format": "image/jpeg",
           "height": 300,
-          "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/posters/70602b4e-ec3a-43ad-ad51-dd04c4e665ec/full/!300,300/0/default.jpg",
+          "id": "https://iiif.dc.library.northwestern.edu/iiif/2/posters/70602b4e-ec3a-43ad-ad51-dd04c4e665ec/full/!300,300/0/default.jpg",
           "service": [
             {
-              "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/posters/70602b4e-ec3a-43ad-ad51-dd04c4e665ec",
+              "id": "https://iiif.dc.library.northwestern.edu/iiif/2/posters/70602b4e-ec3a-43ad-ad51-dd04c4e665ec",
               "profile": "http://iiif.io/api/image/2/level2.json",
               "type": "ImageService2"
             }

--- a/public/fixtures/iiif/manifest/wisconsin-1937.json
+++ b/public/fixtures/iiif/manifest/wisconsin-1937.json
@@ -4,10 +4,10 @@
     {
       "duration": 1486.542,
       "height": 480,
-      "id": "https://iiif.stack.rdc.library.northwestern.edu/public/iiif3/4b/19/3e/9d/-5/32/6-/42/08/-a/cf/6-/7d/a7/e3/6b/af/2c-manifest.json/canvas/b287374d-c6eb-48bc-ad38-43533fe32926",
+      "id": "https://iiif.dc.library.northwestern.edu/public/iiif3/4b/19/3e/9d/-5/32/6-/42/08/-a/cf/6-/7d/a7/e3/6b/af/2c-manifest.json/canvas/b287374d-c6eb-48bc-ad38-43533fe32926",
       "items": [
         {
-          "id": "https://iiif.stack.rdc.library.northwestern.edu/public/iiif3/4b/19/3e/9d/-5/32/6-/42/08/-a/cf/6-/7d/a7/e3/6b/af/2c-manifest.json/canvas/b287374d-c6eb-48bc-ad38-43533fe32926/annotation_page/1",
+          "id": "https://iiif.dc.library.northwestern.edu/public/iiif3/4b/19/3e/9d/-5/32/6-/42/08/-a/cf/6-/7d/a7/e3/6b/af/2c-manifest.json/canvas/b287374d-c6eb-48bc-ad38-43533fe32926/annotation_page/1",
           "items": [
             {
               "body": {
@@ -18,9 +18,9 @@
                 "type": "Video",
                 "width": 1920
               },
-              "id": "https://iiif.stack.rdc.library.northwestern.edu/public/iiif3/4b/19/3e/9d/-5/32/6-/42/08/-a/cf/6-/7d/a7/e3/6b/af/2c-manifest.json/canvas/b287374d-c6eb-48bc-ad38-43533fe32926/annotation_page/1/annotation/1",
+              "id": "https://iiif.dc.library.northwestern.edu/public/iiif3/4b/19/3e/9d/-5/32/6-/42/08/-a/cf/6-/7d/a7/e3/6b/af/2c-manifest.json/canvas/b287374d-c6eb-48bc-ad38-43533fe32926/annotation_page/1/annotation/1",
               "motivation": "painting",
-              "target": "https://iiif.stack.rdc.library.northwestern.edu/public/iiif3/4b/19/3e/9d/-5/32/6-/42/08/-a/cf/6-/7d/a7/e3/6b/af/2c-manifest.json/canvas/b287374d-c6eb-48bc-ad38-43533fe32926",
+              "target": "https://iiif.dc.library.northwestern.edu/public/iiif3/4b/19/3e/9d/-5/32/6-/42/08/-a/cf/6-/7d/a7/e3/6b/af/2c-manifest.json/canvas/b287374d-c6eb-48bc-ad38-43533fe32926",
               "type": "Annotation"
             }
           ],
@@ -34,10 +34,10 @@
         {
           "format": "image/jpeg",
           "height": 300,
-          "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/posters/b287374d-c6eb-48bc-ad38-43533fe32926/full/!300,300/0/default.jpg",
+          "id": "https://iiif.dc.library.northwestern.edu/iiif/2/posters/b287374d-c6eb-48bc-ad38-43533fe32926/full/!300,300/0/default.jpg",
           "service": [
             {
-              "id": "https://iiif.stack.rdc.library.northwestern.edu/iiif/2/posters/b287374d-c6eb-48bc-ad38-43533fe32926",
+              "id": "https://iiif.dc.library.northwestern.edu/iiif/2/posters/b287374d-c6eb-48bc-ad38-43533fe32926",
               "profile": "http://iiif.io/api/image/2/level2.json",
               "type": "ImageService2"
             }


### PR DESCRIPTION
The old IIIF base URL `https://iiif.stack.rdc.library.northwestern.edu/` is deprecated. Switching everything to `https://iiif.dc.library.northwestern.edu/`.