### PR TITLE
Update hybrid search pipeline.

### DIFF
--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -96,7 +96,6 @@ const SearchPage: NextPage = () => {
         const { page, q } = router.query;
         const urlFacets = parseUrlFacets(router.query);
         const requestUrl = new URL(DC_API_SEARCH_URL);
-        const pipeline = process.env.NEXT_PUBLIC_OPENSEARCH_PIPELINE;
 
         // If there is a "similar" facet, get the work and set the state
         if (urlFacets?.similar) {
@@ -120,9 +119,13 @@ const SearchPage: NextPage = () => {
 
         // Request as a "hybrid" OpensSearch query
         // @ts-expect-error - 'hybrid' is not in Elasticsearch package types
-        if (!!body?.query?.hybrid && pipeline) {
-          requestUrl.searchParams.append("search_pipeline", pipeline);
+        if (!!body?.query?.hybrid) {
+          requestUrl.searchParams.append(
+            "search_pipeline",
+            "dc-v2-work-pipeline"
+          );
         }
+
         const response = await apiPostRequest<ApiSearchResponse>({
           body,
           url: requestUrl.toString(),


### PR DESCRIPTION
I'm unsure if I am doing this correctly. The NEXT_PUBLIC_OPENSEARCH_PIPELINE was always `undefined` and I'm not sure what it should have been leaning on for me so I have rewritten this a bit.

```tsx
if (!!body?.query?.hybrid) {
  requestUrl.searchParams.append(
    "search_pipeline",
    "dc-v2-work-pipeline"
  );
}
```

Seems to do the trick... is there a reason we would want this to be an environmental variable?

![image](https://github.com/nulib/dc-nextjs/assets/7376450/eefa55a3-cca8-4c72-8d99-061a4df65e16)
