### PR TITLE
Push a new search AI dataLayer variable on the Search page to GTM

### DIFF
--- a/lib/ga/data-layer.ts
+++ b/lib/ga/data-layer.ts
@@ -4,6 +4,7 @@ interface DataLayer {
   adminset?: string;
   collections?: string | null;
   creatorsContributors?: Array<string> | string;
+  isUsingAI?: boolean;
   isLoggedIn?: boolean;
   pageTitle: string;
   rightsStatement?: string | null;
@@ -15,6 +16,7 @@ const defaultDataLayer = {
   adminset: "",
   collections: "",
   creatorsContributors: "",
+  isUsingAI: false,
   isLoggedIn: false,
   pageTitle: "",
   rightsStatement: "",

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -1,5 +1,6 @@
 import * as Tabs from "@radix-ui/react-tabs";
 
+import { GetServerSideProps, NextPage } from "next";
 import {
   NoResultsMessage,
   ResultsMessage,
@@ -21,7 +22,6 @@ import Heading from "@/components/Heading/Heading";
 import Icon from "@/components/Shared/Icon";
 import { IconSparkles } from "@/components/Shared/SVG/Icons";
 import Layout from "@/components/layout";
-import { NextPage } from "next";
 import { PRODUCTION_URL } from "@/lib/constants/endpoints";
 import PaginationAltCounts from "@/components/Search/PaginationAltCounts";
 import SearchOptions from "@/components/Search/Options";
@@ -280,8 +280,12 @@ const SearchPage: NextPage = () => {
   );
 };
 
-export async function getStaticProps() {
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const { query } = context;
+  const isUsingAI = query?.ai === "true";
+
   const dataLayer = buildDataLayer({
+    isUsingAI,
     pageTitle: "Search page",
   });
 
@@ -293,6 +297,6 @@ export async function getStaticProps() {
   return {
     props: { dataLayer, openGraphData },
   };
-}
+};
 
 export default SearchPage;


### PR DESCRIPTION
## What does this do?
When a user is on the Search page, a clicks the Gen AI checkbox toggle, the GTM `VirtualPageEvent` will capture a new `isUsingAI` dataLayer variable indicating a user is using AI chat.

## How to test
1. Navigate to Search page, leaving AI checkbox unchecked.
2. In browser console, inspect `window.dataLayer`.  Note `isUsingAI` value is `false`
3. Click the AI checkbox toggle
4. In browser console, inspect `window.dataLayer`.  Note `isUsingAI` value is `true`

OR test via GTM Preview for the `dc.northwestern.edu(next.js)` account