### PR TITLE
Block sending empty messages to chat endpoint

### DIFF
--- a/components/Chat/Chat.tsx
+++ b/components/Chat/Chat.tsx
@@ -25,7 +25,7 @@ const Chat = ({ totalResults }: { totalResults?: number }) => {
   const [streamedAnswer, setStreamedAnswer] = useState("");
 
   useEffect(() => {
-    if (!sameQuestionExists && isConnected && authToken) {
+    if (!sameQuestionExists && isConnected && authToken && searchTerm) {
       const preparedQuestion = prepareQuestion(searchTerm, authToken);
       sendMessage(preparedQuestion);
     }


### PR DESCRIPTION
## What does this do?
Handles a scenario where empty search values were being passed to the endpoint (causing issues in the API).  The `Chat` component now guards against this by checking for a search term value.

## How to test
1. Open the Network tab of your browser and navigate to the Websocket (WS) tab to inspect traffic.
2. Try searching with Gen AI enabled with both empty and non-empty search terms. 
3. Notice in the websocket logs, the `question` property will never be an empty string.

![image](https://github.com/nulib/dc-nextjs/assets/3020266/b8d02b47-e0f8-4407-8f9e-49ebfa40e6b6)

For developers, you can also do a quick console log, or put a breakpoint in this function to check as well:

https://github.com/nulib/dc-nextjs/blob/a6ddf55afd3e0815fe7b31e88c2305eaf5524c54/hooks/useChatSocket.ts#L63-L67
