### PR TITLE
Refine TextArea UX, overall header styling. 

### DIFF
--- a/components/Chat/Response/Response.styled.tsx
+++ b/components/Chat/Response/Response.styled.tsx
@@ -20,7 +20,6 @@ const StyledResponse = styled("section", {
 });
 
 const StyledResponseAside = styled("aside", {
-  // background: "linear-gradient(7deg, $white 0%, $gray6 100%)",
   width: "38.2%",
   flexShrink: 0,
   borderRadius: "inherit",
@@ -77,17 +76,24 @@ const StyledQuestion = styled("h3", {
   letterSpacing: "-0.012em",
   lineHeight: "1.35em",
   margin: "0",
-  padding: "0 0 $gr3 0",
+  padding: "0 0 $gr4 0",
   color: "$black",
 });
 
 const StyledStreamedAnswer = styled("article", {
   fontSize: "$gr3",
-  lineHeight: "1.7em",
+  lineHeight: "1.63em",
 
-  strong: {
+  "h1, h2, h3, h4, h5, h6, strong": {
     fontWeight: "400",
     fontFamily: "$northwesternSansBold",
+  },
+
+  a: {
+    textDecoration: "underline",
+    textDecorationThickness: "min(2px,max(1px,.05em))",
+    textUnderlineOffset: "calc(.05em + 2px)",
+    textDecorationColor: "$purple10",
   },
 
   "span.markdown-cursor": {

--- a/components/Clover/ViewerWrapper.styled.ts
+++ b/components/Clover/ViewerWrapper.styled.ts
@@ -5,10 +5,9 @@ import { styled } from "@/stitches.config";
 const ViewerWrapperStyled = styled("section", {
   position: "relative",
   zIndex: "1",
-  margin: "1px 0 0 0",
 
-  "[class*='-css']": {
-    boxShadow: "3px 3px 11px #0002",
+  ".clover-viewer-painting": {
+    background: "#f0f0f0",
   },
 
   "& label[for='information-toggle']": {

--- a/components/Facets/Facets.styled.ts
+++ b/components/Facets/Facets.styled.ts
@@ -49,7 +49,7 @@ const FacetExtras = styled("div", {
 const Wrapper = styled("div", {
   height: "38px",
   transition: "$dcScrollHeight",
-  margin: "$gr4 0",
+  margin: "0 0 $gr4",
 
   "@sm": {
     margin: "-$gr4 0 $gr4",

--- a/components/Facets/Filter/Clear.styled.ts
+++ b/components/Facets/Filter/Clear.styled.ts
@@ -26,6 +26,7 @@ const FilterClearStyled = styled("button", {
   variants: {
     isFixed: {
       true: {
+        backgroundColor: "$white",
         boxShadow: "2px 2px 5px #0002",
       },
     },

--- a/components/Facets/UserFacets/UserFacets.styled.ts
+++ b/components/Facets/UserFacets/UserFacets.styled.ts
@@ -1,11 +1,12 @@
 import * as Dropdown from "@radix-ui/react-dropdown-menu";
+
 import { styled } from "@/stitches.config";
 
 /* eslint sort-keys: 0 */
 
 const DropdownToggle = styled(Dropdown.Trigger, {
   display: "flex",
-  padding: "0 $gr2",
+  padding: "0 $gr1",
   border: "none",
   position: "relative",
   backgroundColor: "transparent",
@@ -21,7 +22,6 @@ const DropdownToggle = styled(Dropdown.Trigger, {
 
   svg: {
     width: "$gr4",
-    marginBottom: "-3px",
     color: "$purple120",
     transform: "rotate(0deg)",
     transition: "$dcAll",
@@ -41,7 +41,8 @@ const DropdownToggle = styled(Dropdown.Trigger, {
     height: "19px",
     borderRadius: "50%",
     marginTop: "-$gr4",
-    marginRight: "calc(-$gr3 + 4px)",
+    position: "absolute",
+    right: "-6px",
   },
 
   [`&:hover`]: {

--- a/components/Facets/WorkType/WorkType.styled.ts
+++ b/components/Facets/WorkType/WorkType.styled.ts
@@ -1,4 +1,5 @@
 import * as Radio from "@radix-ui/react-radio-group";
+
 import { styled } from "@/stitches.config";
 
 /* eslint sort-keys: 0 */

--- a/components/Header/Header.styled.ts
+++ b/components/Header/Header.styled.ts
@@ -1,4 +1,5 @@
 import { VariantProps, styled } from "@/stitches.config";
+
 import { ContainerStyled } from "@/components/Shared/Container";
 import { NavStyled } from "@/components/Nav/Nav.styled";
 import { SearchStyled } from "@/components/Search/Search.styled";
@@ -7,13 +8,14 @@ import { SearchStyled } from "@/components/Search/Search.styled";
 
 const Lockup = styled("div", {
   position: "relative",
-  padding: "$gr4 0 $gr5",
-  fontSize: "$gr6",
-  fontFamily: "$northwesternSansLight",
+  padding: "$gr4 0",
+  fontSize: "$gr5",
+  fontFamily: "$northwesternSansRegular",
   zIndex: "1",
+  color: "$purple",
 
   a: {
-    color: "$white !important",
+    color: "inherit !important",
     textDecoration: "none",
   },
 });
@@ -58,7 +60,6 @@ const MenuToggle = styled("button", {
 const PrimaryInner = styled("div", {
   display: "flex",
   flexGrow: "1",
-  alignItems: "center",
 
   "@sm": {
     "& nav": {
@@ -70,13 +71,14 @@ const PrimaryInner = styled("div", {
 const Primary = styled("div", {
   color: "$black",
   display: "flex",
+  alignItems: "flex-end",
+  justifyContent: "center",
   margin: "0 auto",
+  paddingBottom: "$gr4",
   zIndex: "1",
   transition: "$dcAll",
   position: "relative",
   top: "unset",
-  height: "$gr5",
-  boxShadow: "2px 2px 5px #0001",
 
   [`& ${ContainerStyled}`]: {
     display: "flex",
@@ -87,15 +89,13 @@ const Primary = styled("div", {
     transition: "$dcAll",
 
     [`& ${NavStyled}`]: {
-      backgroundColor: "$purple120",
-      fontSize: "$gr4",
+      fontSize: "$gr3",
       fontFamily: "$northwesternSansRegular",
       display: "flex",
       height: "$gr5",
-      boxShadow: "3px -3px 19px #fff1",
 
       a: {
-        color: "$white",
+        color: "$purple",
         display: "flex",
         height: "100%",
         justifyContent: "center",
@@ -123,13 +123,16 @@ const Primary = styled("div", {
   "&[data-search-fixed='true']": {
     zIndex: "2",
 
+    form: {
+      backgroundColor: "white",
+      boxShadow: "0px 5px 19px #0002",
+    },
+
     [`& ${ContainerStyled}`]: {
       position: "fixed",
       top: "0",
       maxWidth: "100%",
       padding: "0",
-      backgroundColor: "white",
-      boxShadow: "0px 3px 11px #0003",
       transition: "$dcAll",
 
       "> span": {
@@ -155,7 +158,7 @@ const Primary = styled("div", {
 
 const Super = styled("div", {
   position: "relative",
-  backgroundColor: "$purple120",
+  backgroundColor: "$purple",
   color: "$purple10",
   zIndex: "10",
 
@@ -196,23 +199,27 @@ const User = styled("span", {
 });
 
 const HeaderStyled = styled("header", {
-  backgroundColor: "$purple",
-  color: "$white",
   flexDirection: "column",
 
   variants: {
     isHero: {
       true: {
-        [`& ${Lockup}`]: {
-          textShadow: "1px 1px 3px #0003",
+        backgroundColor: "$purple",
+
+        [`& ${Super}`]: {
+          boxShadow: "0px 5px 19px #0002",
         },
 
-        [`& ${Primary}`]: {
-          boxShadow: "unset",
+        [`& ${Lockup}`]: {
+          color: "$white !important",
+        },
 
-          [`& ${SearchStyled}, & ${NavStyled}`]: {
-            boxShadow: "8px 8px 19px #0003",
-          },
+        [`& ${SearchStyled}`]: {
+          background: "$white",
+        },
+
+        [`& ${NavStyled} a`]: {
+          color: "$white !important",
         },
       },
     },

--- a/components/Header/Primary.tsx
+++ b/components/Header/Primary.tsx
@@ -1,9 +1,7 @@
 import { Primary, PrimaryInner } from "@/components/Header/Header.styled";
 import { useEffect, useRef, useState } from "react";
 
-import { AcademicN } from "@/components/Shared/SVG/Northwestern";
 import Container from "@/components/Shared/Container";
-import Heading from "@/components/Heading/Heading";
 import Link from "next/link";
 import Nav from "@/components/Nav/Nav";
 import Search from "@/components/Search/Search";
@@ -49,9 +47,6 @@ const HeaderPrimary: React.FC = () => {
         ref={primaryRef}
       >
         <Container>
-          <Heading as="span">
-            <AcademicN />
-          </Heading>
           <PrimaryInner>
             {!isCollectionPage && (
               <Search isSearchActive={handleIsSearchActive} />

--- a/components/Header/Super.tsx
+++ b/components/Header/Super.tsx
@@ -5,6 +5,7 @@ import {
   Super,
   User,
 } from "@/components/Header/Header.styled";
+
 import Container from "../Shared/Container";
 import { DCAPI_ENDPOINT } from "@/lib/constants/endpoints";
 import Link from "next/link";

--- a/components/Hero/Hero.styled.ts
+++ b/components/Hero/Hero.styled.ts
@@ -45,7 +45,7 @@ const HeroStyled = styled("div", {
         width: "100%",
         height: "300px",
         background:
-          "linear-gradient(173deg, $purple 0%, #4E2A84cc 19%, #0000 61.8%)",
+          "linear-gradient(180deg, $purple 0%, #4E2A84cc 19%, #0000 61.8%)",
         position: "absolute",
         zIndex: "1",
       },
@@ -90,8 +90,7 @@ const HeroStyled = styled("div", {
           display: "flex",
           width: "100%",
           height: "100%",
-          background:
-            "linear-gradient(7deg, #401F68cc 0%, #000a 20%, #0000 61.8%)",
+          background: "linear-gradient(0deg, #000a 0%, #000a 19%, #0000 50%)",
           position: "absolute",
           zIndex: "1",
           bottom: "0",

--- a/components/Homepage/Hero.styled.ts
+++ b/components/Homepage/Hero.styled.ts
@@ -24,11 +24,6 @@ export const HomepageHeroStyled = styled("div", {
 
       ".swiper-slide": {
         figure: {
-          "&::before": {
-            background:
-              "linear-gradient(7deg, #000a 0%, #000a 20%, #0000 61.8%)",
-          },
-
           figcaption: {
             alignItems: "flex-end",
             bottom: "$gr6",
@@ -40,11 +35,6 @@ export const HomepageHeroStyled = styled("div", {
             opacity: "1 !important",
           },
         },
-      },
-
-      ".swiper-wrapper::before": {
-        background:
-          "linear-gradient(173deg, $purple 0%, #4E2A84dd 12%, #0000 31%)",
       },
     },
   },

--- a/components/Search/GenerativeAI.styled.ts
+++ b/components/Search/GenerativeAI.styled.ts
@@ -8,7 +8,11 @@ const GenerativeAIToggleWrapper = styled("div", {
   color: "$black50",
   fontSize: "$gr2",
   display: "flex",
+  position: "relative",
+  flexDirection: "row",
+  flexWrap: "nowrap",
   flexShrink: "0",
+  height: "$gr5",
   alignItems: "center",
   marginRight: "$gr1",
 

--- a/components/Search/GenerativeAIToggle.test.tsx
+++ b/components/Search/GenerativeAIToggle.test.tsx
@@ -44,11 +44,7 @@ describe("GenerativeAIToggle", () => {
 
   it("renders the generative AI toggle UI and toggles state for a logged in user", async () => {
     const user = userEvent.setup();
-    render(
-      withUserProvider(
-        withSearchProvider(<GenerativeAIToggle isSearchActive={true} />)
-      )
-    );
+    render(withUserProvider(withSearchProvider(<GenerativeAIToggle />)));
 
     const label = screen.getByLabelText("Use Generative AI");
     const checkbox = screen.getByRole("checkbox");
@@ -61,7 +57,7 @@ describe("GenerativeAIToggle", () => {
   });
 
   it("renders the generative AI tooltip", () => {
-    render(withSearchProvider(<GenerativeAIToggle isSearchActive={true} />));
+    render(withSearchProvider(<GenerativeAIToggle />));
     // Target the svg icon itself
     const tooltip = screen.getByText("Information Circle");
 
@@ -79,7 +75,7 @@ describe("GenerativeAIToggle", () => {
 
     render(
       withUserProvider(
-        withSearchProvider(<GenerativeAIToggle isSearchActive={true} />),
+        withSearchProvider(<GenerativeAIToggle />),
         nonLoggedInUser
       )
     );
@@ -103,10 +99,7 @@ describe("GenerativeAIToggle", () => {
     mockRouter.setCurrentUrl("/search?ai=true");
     render(
       withUserProvider(
-        withSearchProvider(
-          <GenerativeAIToggle isSearchActive={true} />,
-          activeSearchState
-        )
+        withSearchProvider(<GenerativeAIToggle />, activeSearchState)
       )
     );
 
@@ -121,10 +114,7 @@ describe("GenerativeAIToggle", () => {
 
     render(
       withUserProvider(
-        withSearchProvider(
-          <GenerativeAIToggle isSearchActive={false} />,
-          defaultSearchState
-        )
+        withSearchProvider(<GenerativeAIToggle />, defaultSearchState)
       )
     );
 

--- a/components/Search/GenerativeAIToggle.tsx
+++ b/components/Search/GenerativeAIToggle.tsx
@@ -37,21 +37,13 @@ function GenerativeAITooltip() {
   );
 }
 
-type GenerativeAIToggleProps = {
-  isSearchActive: boolean;
-};
-
-export default function GenerativeAIToggle({
-  isSearchActive,
-}: GenerativeAIToggleProps) {
+export default function GenerativeAIToggle() {
   const { closeDialog, dialog, isChecked, handleCheckChange, handleLogin } =
     useGenerativeAISearchToggle();
 
   return (
     <>
-      <GenerativeAIToggleWrapper
-        {...(isSearchActive ? { css: { marginRight: "$gr5" } } : {})}
-      >
+      <GenerativeAIToggleWrapper data-testid="generative-ai-toggle">
         <CheckboxRootStyled
           checked={isChecked}
           id="isGenerativeAI"

--- a/components/Search/JumpTo.tsx
+++ b/components/Search/JumpTo.tsx
@@ -1,4 +1,3 @@
-import { Input, SearchStyled } from "./Search.styled";
 import React, {
   ChangeEvent,
   FocusEvent,
@@ -9,6 +8,7 @@ import React, {
 
 import { IconSearch } from "@/components/Shared/SVG/Icons";
 import SearchJumpToList from "@/components/Search/JumpToList";
+import { SearchStyled } from "./Search.styled";
 import Swiper from "swiper";
 
 interface SearchProps {
@@ -91,7 +91,8 @@ const SearchJumpTo: React.FC<SearchProps> = ({ isSearchActive }) => {
 
   return (
     <SearchStyled ref={formRef} data-testid="search-jump-to-form">
-      <Input
+      {/* temporarily setting to textarea for later refinement */}
+      <textarea
         placeholder="Search by keyword or phrase, ex: Berkeley Music Festival"
         onChange={handleSearchChange}
         onFocus={handleSearchFocus}

--- a/components/Search/Options.styled.tsx
+++ b/components/Search/Options.styled.tsx
@@ -69,34 +69,34 @@ const StyledOptionsTabs = styled("div", {
     flexGrow: "0",
     flexWrap: "nowrap",
     height: "38px",
-    boxShadow: "0px 3px 15px #0002",
     borderRadius: "50px",
     overflow: "hidden",
 
     button: {
       cursor: "pointer",
-      backgroundColor: "$purple",
+      backgroundColor: "transparent",
       border: "0",
-      color: "$white",
+      color: "$purple",
       fontFamily: "$northwesternSansRegular",
       fontSize: "$gr3",
       padding: "0 $gr3",
+      height: "2rem",
       transition: "$dcAll",
       whiteSpace: "nowrap",
       display: "flex",
       alignItems: "center",
 
       "&[data-state=active]": {
-        backgroundColor: "$purple",
+        color: "$black",
+        fontFamily: "$northwesternSansBold",
 
         [`& ${IconStyled}`]: {
-          color: "$purple30",
-          fill: "$purple30",
+          color: "$purple",
+          fill: "$purple",
         },
       },
 
       "&[data-state=inactive]": {
-        backgroundColor: "$white",
         color: "$black50",
 
         [`& ${IconStyled}`]: {
@@ -110,12 +110,11 @@ const StyledOptionsTabs = styled("div", {
       },
 
       "&:hover": {
-        backgroundColor: "$purple120",
-        color: "$white",
+        color: "$purple",
 
         [`& ${IconStyled}`]: {
-          color: "$white",
-          fill: "$white",
+          color: "$purple",
+          fill: "$purple",
         },
       },
     },
@@ -129,8 +128,7 @@ const StyledOptionsTabs = styled("div", {
 const StyledOptions = styled("div", {
   height: "38px",
   transition: "$dcScrollHeight",
-  padding: "$gr4 0 0",
-  margin: "0 0 $gr6",
+  margin: "0 0 $gr5",
 
   "@sm": {
     backgroundColor: "$gray6",
@@ -165,6 +163,10 @@ const StyledOptions = styled("div", {
       transform: "translate(-50%)",
       backfaceVisibility: "hidden",
       webkitFontSmoothing: "subpixel-antialiased",
+
+      [`& ${StyledOptionsTabs}`]: {
+        display: "none",
+      },
 
       "@sm": {
         top: "$gr5",

--- a/components/Search/Search.styled.ts
+++ b/components/Search/Search.styled.ts
@@ -7,11 +7,24 @@ const SearchStyled = styled("form", {
   display: "flex",
   flexShrink: "0",
   flexGrow: "1",
-  backgroundColor: "$white",
-  height: "$gr5",
-  marginRight: "$gr5",
-  boxShadow: "3px -3px 19px #fff1",
+  marginRight: "$gr4",
   transition: "$dcAll",
+  borderRadius: "3px",
+
+  variants: {
+    isFocused: {
+      true: {
+        backgroundColor: "$white !important",
+        boxShadow: "3px 3px 11px #0001",
+        outline: "2px solid $purple60",
+      },
+      false: {
+        backgroundColor: "#f0f0f0",
+        boxShadow: "none",
+        outline: "2px solid transparent",
+      },
+    },
+  },
 
   "@sm": {
     width: "100%",
@@ -22,10 +35,11 @@ const SearchStyled = styled("form", {
     marginRight: "$gr3",
   },
 
-  svg: {
+  "> svg": {
     position: "absolute",
     display: "flex",
     left: "0",
+    top: "3px",
     height: "$gr5",
     width: "$gr5",
     justifyContent: "center",
@@ -34,70 +48,34 @@ const SearchStyled = styled("form", {
     border: "none",
     backgroundColor: "transparent",
     zIndex: "0",
-    fill: "$black80",
-    padding: "$gr2",
-  },
-});
-
-const Input = styled("textarea", {
-  position: "relative",
-  display: "flex",
-  width: "100%",
-  border: "none",
-  backgroundColor: "transparent",
-  padding: "calc($gr4 / 2) $gr3 calc($gr4 / 2) $gr5",
-  fontSize: "$gr3",
-  zIndex: "1",
-  fontFamily: "$northwesternSansRegular",
-  lineHeight: "1.2rem",
-  resize: "none",
-
-  "&::placeholder": {
-    overflow: "hidden",
-    color: "$black80",
-    textOverflow: "ellipsis",
-    marginRight: "$gr5",
+    fill: "$black50",
+    padding: "15px",
   },
 });
 
 const Button = styled("button", {
   display: "flex",
-  justifyContent: "center",
-  alignItems: "center",
   border: "none",
-  backgroundColor: "$purple120",
-  padding: "0 $gr3 ",
+  backgroundColor: "$purple",
+  alignItems: "center",
+  padding: "0 $gr2",
+  margin: "7px",
+  height: "38px",
   color: "$white",
-  fontSize: "$gr4",
+  fontSize: "$gr3",
+  borderRadius: "3px",
   fontFamily: "$northwesternSansRegular",
   cursor: "pointer",
   textRendering: "optimizeLegibility",
-});
+  gap: "$gr1",
+  position: "relative",
 
-const Clear = styled("button", {
-  position: "absolute",
-  display: "flex",
-  right: "5rem",
-  height: "$gr5",
-  width: "calc($gr5 + $gr2)",
-  justifyContent: "center",
-  textAlign: "center",
-  alignItems: "center",
-  cursor: "pointer",
-  border: "none",
-  background: "linear-gradient(90deg, #fff0 0, #fff  38.2%)",
-  zIndex: "1",
-  fill: "$black80",
-
-  "&:focus, &:hover": {
-    fill: "$purple30",
-  },
-
-  svg: {
-    fill: "inherit",
-    padding: "$gr2",
-    marginLeft: "$gr2",
-    transition: "$dcAll",
+  "> svg": {
+    width: "$gr3",
+    height: "$gr3",
+    marginTop: "-2px",
+    fontFamily: "Times !important",
+    color: "$purple60",
   },
 });
 
@@ -144,24 +122,10 @@ const ResultsWrapper = styled("div", {
 
 const StyledResponseWrapper = styled("div", {
   padding: "0 0 $gr6",
-
-  variants: {
-    isAiResponse: {
-      true: {
-        background:
-          "linear-gradient(-5deg, $white calc(100% - 150px), $brightBlueB calc(100% + 100px))",
-      },
-      false: {
-        background: "inherit",
-      },
-    },
-  },
 });
 
 export {
   Button,
-  Clear,
-  Input,
   NoResultsMessage,
   ResultsMessage,
   ResultsWrapper,

--- a/components/Search/Search.test.tsx
+++ b/components/Search/Search.test.tsx
@@ -8,16 +8,6 @@ import userEvent from "@testing-library/user-event";
 
 const mockIsSearchActive = jest.fn();
 
-jest.mock("./GenerativeAIToggle", () => {
-  return function DummyGenerativeAIToggle(props: any) {
-    return (
-      <div data-testid="generative-ai-toggle">
-        {props.isSearchActive.toString()}
-      </div>
-    );
-  };
-});
-
 describe("Search component", () => {
   it("renders the search ui component", () => {
     render(<Search isSearchActive={() => ({})} />);
@@ -73,17 +63,9 @@ describe("Search component", () => {
     });
   });
 
-  it("renders the generative ai toggle component and correctly passes active search state down", async () => {
-    const user = userEvent.setup();
-    mockRouter.setCurrentUrl("/search");
-
+  it("renders the generative ai toggle component", async () => {
     render(<Search isSearchActive={mockIsSearchActive} />);
-    const wrapper = await screen.findByTestId("generative-ai-toggle");
-
-    expect(wrapper).toHaveTextContent("false");
-
-    await user.type(screen.getByRole("search"), "foo");
-    expect(wrapper).toHaveTextContent("true");
+    expect(screen.getByTestId("generative-ai-toggle")).toBeInTheDocument();
   });
 
   it("renders standard placeholder text for non AI search", () => {

--- a/components/Search/Search.tsx
+++ b/components/Search/Search.tsx
@@ -1,9 +1,5 @@
-import { Button, Clear, Input, SearchStyled } from "./Search.styled";
-import {
-  IconArrowForward,
-  IconClear,
-  IconSearch,
-} from "@/components/Shared/SVG/Icons";
+import { Button, SearchStyled } from "@/components/Search/Search.styled";
+import { IconArrowForward, IconSearch } from "@/components/Shared/SVG/Icons";
 import React, {
   ChangeEvent,
   FocusEvent,
@@ -14,6 +10,7 @@ import React, {
 } from "react";
 
 import GenerativeAIToggle from "./GenerativeAIToggle";
+import SearchTextArea from "@/components/Search/TextArea";
 import { UrlFacets } from "@/types/context/filter-context";
 import { getAllFacetIds } from "@/lib/utils/facet-helpers";
 import useQueryParams from "@/hooks/useQueryParams";
@@ -35,10 +32,6 @@ const Search: React.FC<SearchProps> = ({ isSearchActive }) => {
   const [isLoaded, setIsLoaded] = useState<boolean>(false);
   const [searchValue, setSearchValue] = useState<string>("");
   const [searchFocus, setSearchFocus] = useState<boolean>(false);
-
-  const placeholderText = ai
-    ? "What can I show you from our collections?"
-    : "Search by keyword or phrase, ex: Berkeley Music Festival";
 
   const handleSubmit = (
     e:
@@ -75,7 +68,7 @@ const Search: React.FC<SearchProps> = ({ isSearchActive }) => {
     });
   };
 
-  const handleSearchFocus = (e: FocusEvent) => {
+  const handleSearchFocus = (e: FocusEvent<HTMLTextAreaElement>) => {
     setSearchFocus(e.type === "focus");
   };
 
@@ -110,40 +103,28 @@ const Search: React.FC<SearchProps> = ({ isSearchActive }) => {
   }, [searchFocus, searchValue, isSearchActive]);
 
   return (
-    <>
-      <SearchStyled
-        ref={formRef}
-        onSubmit={handleSubmit}
-        data-testid="search-ui-component"
-      >
-        <Input
-          id="dc-search"
-          placeholder={placeholderText}
-          onChange={handleSearchChange}
-          onFocus={handleSearchFocus}
-          onBlur={handleSearchFocus}
-          ref={searchRef}
-          name="search"
-          role="search"
-          onKeyDown={(e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-            if (e.key === "Enter") {
-              e.preventDefault();
-              handleSubmit(e);
-            }
-          }}
-        />
-        {searchValue && (
-          <Clear onClick={clearSearchResults} type="reset">
-            <IconClear />
-          </Clear>
-        )}
-        <GenerativeAIToggle isSearchActive={!!searchValue} />
-        <Button type="submit" data-testid="submit-button">
-          Search <IconArrowForward />
-        </Button>
-        {isLoaded && <IconSearch />}
-      </SearchStyled>
-    </>
+    <SearchStyled
+      ref={formRef}
+      onSubmit={handleSubmit}
+      data-testid="search-ui-component"
+      isFocused={searchFocus}
+    >
+      <SearchTextArea
+        isAi={!!ai}
+        isFocused={searchFocus}
+        searchValue={searchValue}
+        handleSearchChange={handleSearchChange}
+        handleSearchFocus={handleSearchFocus}
+        handleSubmit={handleSubmit}
+        clearSearchResults={clearSearchResults}
+        ref={searchRef}
+      />
+      <GenerativeAIToggle />
+      <Button type="submit" data-testid="submit-button">
+        Search <IconArrowForward />
+      </Button>
+      {isLoaded && <IconSearch />}
+    </SearchStyled>
   );
 };
 

--- a/components/Search/TextArea.styled.ts
+++ b/components/Search/TextArea.styled.ts
@@ -1,0 +1,79 @@
+import { styled } from "@/stitches.config";
+
+/* eslint sort-keys: 0 */
+
+const Clear = styled("button", {
+  position: "absolute",
+  display: "flex",
+  right: "0",
+  height: "$gr5",
+  width: "$gr5",
+  marginRight: "$gr2",
+  justifyContent: "center",
+  textAlign: "center",
+  alignItems: "center",
+  cursor: "pointer",
+  border: "none",
+  background: "linear-gradient(90deg, #f0f0f000 0, transparent  38.2%)",
+  zIndex: "1",
+  fill: "$black50",
+
+  "&:focus, &:hover": {
+    fill: "$brightRed",
+  },
+
+  svg: {
+    fill: "inherit",
+    padding: "5px",
+    marginLeft: "$gr2",
+    transition: "$dcAll",
+  },
+});
+
+const StyledTextArea = styled("div", {
+  position: "relative",
+  display: "flex",
+  flexGrow: "1",
+
+  variants: {
+    isFocused: {
+      true: {
+        color: "$black",
+      },
+      false: {
+        textarea: {
+          height: "$gr5 !important",
+          color: "$black50",
+          whiteSpace: "nowrap",
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+        },
+      },
+    },
+  },
+
+  textarea: {
+    background: "transparent",
+    padding: "15px $gr5 10px",
+    border: "none",
+    fontSize: "$gr3",
+    lineHeight: "147%",
+    height: "$gr5",
+    zIndex: "1",
+    fontFamily: "$northwesternSansRegular",
+    resize: "none",
+    overflow: "hidden",
+    width: "100%",
+    outline: "none",
+    transition: "$dcAll",
+    boxSizing: "border-box",
+
+    "&::placeholder": {
+      overflow: "hidden",
+      color: "$black80",
+      textOverflow: "ellipsis",
+    },
+  },
+});
+
+export { Clear, StyledTextArea };

--- a/components/Search/TextArea.tsx
+++ b/components/Search/TextArea.tsx
@@ -1,0 +1,93 @@
+import { Clear, StyledTextArea } from "@/components/Search/TextArea.styled";
+import React, {
+  ChangeEvent,
+  FocusEvent,
+  KeyboardEvent,
+  forwardRef,
+  useEffect,
+  useRef,
+} from "react";
+
+import { IconClear } from "@/components/Shared/SVG/Icons";
+
+interface SearchTextAreaProps {
+  isAi: boolean;
+  isFocused: boolean;
+  searchValue: string;
+  handleSearchChange: (e: ChangeEvent<HTMLTextAreaElement>) => void;
+  handleSearchFocus: (e: FocusEvent<HTMLTextAreaElement>) => void;
+  handleSubmit: (e: KeyboardEvent<HTMLTextAreaElement>) => void;
+  clearSearchResults: () => void;
+}
+
+const SearchTextArea = forwardRef<HTMLTextAreaElement, SearchTextAreaProps>(
+  (
+    {
+      isAi,
+      isFocused,
+      searchValue,
+      handleSearchChange,
+      handleSearchFocus,
+      handleSubmit,
+      clearSearchResults,
+    },
+    textareaRef
+  ) => {
+    /**
+     * Resize the textarea to fit its content
+     */
+    useEffect(() => {
+      // @ts-ignore
+      const textarea = textareaRef?.current;
+      if (textarea) {
+        textarea.style.height = `${textarea.scrollHeight}px`;
+      }
+    }, [searchValue, isFocused]);
+
+    const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
+      handleSearchChange(e);
+
+      // @ts-ignore
+      const textarea = textareaRef?.current;
+      if (textarea) {
+        textarea.style.height = `${textarea.scrollHeight}px`;
+      }
+    };
+
+    const placeholderText = isAi
+      ? "What can I show you from our collections?"
+      : "Search by keyword or phrase, ex: Berkeley Music Festival";
+
+    return (
+      <StyledTextArea isFocused={isFocused}>
+        <textarea
+          autoComplete="on"
+          id="dc-search"
+          name="search"
+          onBlur={handleSearchFocus}
+          onChange={handleChange}
+          onKeyDown={(e: KeyboardEvent<HTMLTextAreaElement>) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              handleSubmit(e);
+            }
+          }}
+          onFocus={handleSearchFocus}
+          placeholder={placeholderText}
+          ref={textareaRef}
+          role="search"
+          value={searchValue}
+        />
+        {searchValue && (
+          <Clear onClick={clearSearchResults} type="reset">
+            <IconClear />
+          </Clear>
+        )}
+      </StyledTextArea>
+    );
+  }
+);
+
+SearchTextArea.displayName = "SearchTextArea";
+
+export default SearchTextArea;

--- a/components/Shared/Checkbox.styled.tsx
+++ b/components/Shared/Checkbox.styled.tsx
@@ -16,10 +16,10 @@ export const CheckboxRoot = styled(Checkbox.Root, {
   padding: "0",
   cursor: "pointer",
   borderRadius: "3px",
-  color: "$purple30",
+  color: "$white",
 
   svg: {
-    padding: "1px",
+    padding: "2px",
   },
 
   "&:hover, &:focus": {

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -10,3 +10,22 @@ jest.mock("next/dynamic", () => () => {
 });
 
 jest.mock("next/router", () => require("next-router-mock"));
+
+// Mock implementation of ResizeObserver
+class ResizeObserver {
+  constructor(callback) {
+    this.callback = callback;
+  }
+  observe() {
+    // Optionally, you can implement mock behavior for observe if needed
+  }
+  unobserve() {
+    // Optionally, you can implement mock behavior for unobserve if needed
+  }
+  disconnect() {
+    // Optionally, you can implement mock behavior for disconnect if needed
+  }
+}
+
+// Assign the mock ResizeObserver to the global window object
+global.ResizeObserver = ResizeObserver;

--- a/pages/collections/[id].tsx
+++ b/pages/collections/[id].tsx
@@ -137,7 +137,11 @@ const Collection: NextPage = () => {
         </Head>
       )}
 
-      <Layout title={collection?.title || ""} description={description || ""}>
+      <Layout
+        description={description || ""}
+        header="hero"
+        title={collection?.title || ""}
+      >
         {collection && (
           <>
             <HeroWrapper>

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -197,7 +197,7 @@ const SearchPage: NextPage = () => {
         data-testid="search-page-wrapper"
         title={HEAD_META["SEARCH"].title}
       >
-        <StyledResponseWrapper isAiResponse={showStreamedResponse}>
+        <StyledResponseWrapper>
           <Heading as="h1" isHidden>
             Northwestern
           </Heading>

--- a/styles/global.ts
+++ b/styles/global.ts
@@ -7,6 +7,7 @@ import {
   camptonExtraBold,
   camptonExtraLight,
 } from "./fonts";
+
 import { globalCss } from "@stitches/react";
 
 /* eslint sort-keys: 0 */
@@ -36,6 +37,9 @@ const defaults = {
     color: "$black80",
     fontFamily: "$northwesternSansRegular",
     fontSize: `${rem}px`,
+    optimizeLegibility: "auto",
+    textRendering: "optimizeLegibility",
+    fontSizeAdjust: 0.5,
   },
 
   p: {


### PR DESCRIPTION
This work refines the Search component and textarea UX. Now when a user begins to type, the `<textarea>` element will grow in by calculating the `scrollHeight` of the element and applying this height as a style. If the user unfocuses, the height should transition back to the default height (appx 50px) with a `text-overflow` rendering an ellipsis for overflowing textual content. 

To make this blend well with our current layout, I opted to simplify the background colors, making the previous background of purple now transparent and showing white. This should elevate the actionable elements in the header to the foreground.

Along with this, I also made some other stylistic updates regarding overall legibility of text in the `html` document, sharpening and modernizing things. Along with this, I also updated the styling of the AI Response / View `n` Results tab.

![image](https://github.com/nulib/dc-nextjs/assets/7376450/ef4eac75-c32f-4f6e-bc2d-ade7d63bdf70)

### Other Notes

- I needed to refine some `Search` components tests after making modifications. Mainily, I removed the need for us to know `isSearchActive` on the Generative AI toggle which was only used for margins. These updates should simplify things there.

- I needed to mock the ResizeObserver as Radix was screaming about this for some reason (see jest.setup)