### PR TITLE
Update chat endpoint route

### DIFF
--- a/lib/constants/endpoints.ts
+++ b/lib/constants/endpoints.ts
@@ -9,7 +9,7 @@ const DC_URL = process.env.NEXT_PUBLIC_DC_URL;
 const DCAPI_ENDPOINT = process.env.NEXT_PUBLIC_DCAPI_ENDPOINT;
 
 const DC_API_SEARCH_URL = `${DCAPI_ENDPOINT}/search`;
-const DCAPI_CHAT_ENDPOINT = `${DCAPI_ENDPOINT}/chat-endpoint`;
+const DCAPI_CHAT_ENDPOINT = `${DCAPI_ENDPOINT}/chat/endpoint`;
 
 export {
   DC_URL,


### PR DESCRIPTION
Updated in https://github.com/nulib/dc-api-v2/pull/226 from `chat-endpoint` to `chat/endpoint`