### PR TITLE
Add GTM dataLayer data to Shared and 404/403 pages

### DIFF
--- a/lib/dc-api.ts
+++ b/lib/dc-api.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosError } from "axios";
+import axios, { AxiosError, RawAxiosRequestHeaders } from "axios";
 
 import type { ApiSearchRequestBody } from "@/types/api/request";
 
@@ -55,12 +55,16 @@ async function apiPostRequest<R>(
   }
 }
 
-async function getIIIFResource<R>(uri: string | null): Promise<R | undefined> {
+async function getIIIFResource<R>(
+  uri: string | null,
+  headers?: RawAxiosRequestHeaders,
+): Promise<R | undefined> {
   if (!uri) return Promise.resolve(undefined);
   try {
     const response = await axios({
       url: uri,
-      withCredentials: true,
+      headers,
+      withCredentials: Boolean(headers) ? false : true,
     });
     return response.data;
   } catch (err) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@samvera/image-downloader": "^1.1.6",
         "@stitches/react": "^1.2.6",
         "axios": "^1.2.2",
+        "cookies-next": "^4.2.1",
         "framer-motion": "^11.2.3",
         "jsonwebtoken": "^9.0.0",
         "next": "^14.2.3",
@@ -4138,6 +4139,11 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -6213,6 +6219,23 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookies-next": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/cookies-next/-/cookies-next-4.2.1.tgz",
+      "integrity": "sha512-qsjtZ8TLlxCSX2JphMQNhkm3V3zIMQ05WrLkBKBwu50npBbBfiZWIdmSMzBGcdGKfMK19E0PIitTfRFAdMGHXg==",
+      "dependencies": {
+        "@types/cookie": "^0.6.0",
+        "cookie": "^0.6.0"
+      }
     },
     "node_modules/core-util-is": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@samvera/image-downloader": "^1.1.6",
     "@stitches/react": "^1.2.6",
     "axios": "^1.2.2",
+    "cookies-next": "^4.2.1",
     "framer-motion": "^11.2.3",
     "jsonwebtoken": "^9.0.0",
     "next": "^14.2.3",

--- a/pages/403.tsx
+++ b/pages/403.tsx
@@ -2,6 +2,7 @@ import Head from "next/head";
 import Hero from "@/components/Hero/Hero";
 import Layout from "@/components/layout";
 import type { NextPage } from "next";
+import { buildDataLayer } from "@/lib/ga/data-layer";
 import { collection403 } from "@/lib/constants/error";
 import { loadDefaultStructuredData } from "@/lib/json-ld";
 import { styled } from "@/stitches.config";
@@ -32,5 +33,15 @@ const AccessForbidden: NextPage = () => {
     </>
   );
 };
+
+export async function getStaticProps() {
+  const dataLayer = buildDataLayer({
+    pageTitle: "403 page",
+  });
+
+  return {
+    props: { dataLayer },
+  };
+}
 
 export default AccessForbidden;

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -2,6 +2,7 @@ import Head from "next/head";
 import Hero from "@/components/Hero/Hero";
 import Layout from "@/components/layout";
 import type { NextPage } from "next";
+import { buildDataLayer } from "@/lib/ga/data-layer";
 import { collection404 } from "@/lib/constants/error";
 import { loadDefaultStructuredData } from "@/lib/json-ld";
 import { styled } from "@/stitches.config";
@@ -32,5 +33,15 @@ const PageNotFound: NextPage = () => {
     </>
   );
 };
+
+export async function getStaticProps() {
+  const dataLayer = buildDataLayer({
+    pageTitle: "404 page",
+  });
+
+  return {
+    props: { dataLayer },
+  };
+}
 
 export default PageNotFound;

--- a/pages/shared/[id].tsx
+++ b/pages/shared/[id].tsx
@@ -1,51 +1,29 @@
+import { GetServerSideProps, NextPage } from "next";
 import { apiGetRequest, getIIIFResource } from "@/lib/dc-api";
-import { useEffect, useState } from "react";
+import { getCookies, setCookie } from "cookies-next";
 
 import { AxiosResponse } from "axios";
 import { DCAPI_ENDPOINT } from "@/lib/constants/endpoints";
 import Head from "next/head";
 import Layout from "@/components/layout";
 import { Manifest } from "@iiif/presentation-3";
-import { NextPage } from "next";
 import SharedLink from "@/components/SharedLink/SharedLink";
 import type { Work } from "@nulib/dcapi-types";
 import { WorkProvider } from "@/context/work-context";
+import { buildWorkDataLayer } from "@/lib/ga/data-layer";
 import { loadDefaultStructuredData } from "@/lib/json-ld";
-import { useRouter } from "next/router";
 
-const SharedPage: NextPage = () => {
-  const [work, setWork] = useState<Work>();
-  const [manifest, setManifest] = useState<Manifest>();
-  const router = useRouter();
-  const [linkExpiration, setLinkExpiration] = useState<string>("");
+interface SharedPageProps {
+  linkExpiration: string;
+  manifest: Manifest;
+  work: Work;
+}
 
-  async function getWorkAndManifest(id: string) {
-    try {
-      const response = await apiGetRequest<AxiosResponse>(
-        {
-          url: `${DCAPI_ENDPOINT}/shared-links/${id}`,
-        },
-        true,
-      );
-      if (!response) return;
-      setWork(response.data.data);
-      const manifest = await getIIIFResource<Manifest>(
-        response.data.data.iiif_manifest,
-      );
-      setManifest(manifest);
-      setLinkExpiration(response.data.info.link_expiration || "");
-    } catch (err) {
-      console.error("err", err);
-    }
-    return true;
-  }
-
-  useEffect(() => {
-    !!router.query.id && getWorkAndManifest(router.query.id as string);
-  }, [router.query.id]);
-
-  if (!(work && manifest)) return <></>;
-
+const SharedPage: NextPage<SharedPageProps> = ({
+  linkExpiration,
+  manifest,
+  work,
+}) => {
   return (
     <WorkProvider initialState={{ manifest: manifest, work: work }}>
       {/* Google Structured Data via JSON-LD */}
@@ -59,7 +37,7 @@ const SharedPage: NextPage = () => {
           }}
         />
       </Head>
-      <Layout title={work.title || ""}>
+      <Layout title={work?.title || ""}>
         <SharedLink
           manifest={manifest}
           work={work}
@@ -68,6 +46,69 @@ const SharedPage: NextPage = () => {
       </Layout>
     </WorkProvider>
   );
+};
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const sharedId = decodeURIComponent(context?.params?.id as string);
+
+  try {
+    const url = `${DCAPI_ENDPOINT}/shared-links/${sharedId}`;
+    const response = await apiGetRequest<AxiosResponse>(
+      {
+        url,
+      },
+      true,
+    );
+
+    if (!response) throw new Error("No response from API");
+
+    const responseHeadersCookie = response.headers["set-cookie"];
+
+    if (!responseHeadersCookie)
+      throw new Error(`No shared link response for ${url}`);
+
+    const dcApiCookie = responseHeadersCookie[0].split(" ")[0].split("=");
+    const dcApiCookieKey = dcApiCookie[0];
+    const dcApiCookieValue = dcApiCookie[1].slice(0, -1);
+
+    const headers = {
+      Cookie: `${dcApiCookieKey}=${dcApiCookieValue}`,
+    };
+
+    const { req, res } = context;
+    setCookie(dcApiCookieKey, dcApiCookieValue, {
+      req,
+      res,
+      domain: ".library.northwestern.edu",
+      secure: true,
+    });
+
+    const work = response.data.data as Work;
+
+    const manifest =
+      (await getIIIFResource<Manifest>(work.iiif_manifest, headers)) || null;
+
+    const dataLayer = buildWorkDataLayer(work);
+
+    return {
+      props: {
+        dataLayer,
+        linkExpiration: (response.data.info.link_expiration as string) || "",
+        manifest,
+        work,
+      },
+    };
+  } catch (err) {
+    console.error("err", err);
+    return {
+      props: {
+        dataLayer: [],
+        linkExpiration: "",
+        manifest: null,
+        work: null,
+      },
+    };
+  }
 };
 
 export default SharedPage;


### PR DESCRIPTION
## What does this do?
Adds Google GTM `dataLayer` data to Shared Work pages (`/shared/ID`), and `404` and `403` pages.

## How to test
### Shared routes
1. Open up Meadow staging, and share a Work
2. Open DC in a dev environment which uses staging data, and copy/paste the `/shared/ID_HERE` string of the route do your local dev instance URL.
3. Open NUL GTM account in a browser, and click the "Preview" option.
4. Paste in your shared link URL
5. Validate DataLayer info is pulling through

### 403 / 404 routes
Same as above, put preview the "bad" routes, and notice that `dataLayer` data `pageTitle` will contain either "403 page" or "404 page"