### PR TITLE
Handle chat response 'end' message

### DIFF
--- a/types/components/chat.ts
+++ b/types/components/chat.ts
@@ -22,6 +22,10 @@ export type Answer = {
 
 export type StreamingMessage = {
   answer?: string;
+  end?: {
+    reason: "stop" | "length" | "timeout" | "eos_token";
+    ref: string;
+  };
   question?: string;
   ref: string;
   source_documents?: Array<Work>;


### PR DESCRIPTION
## What does this do?
Handles the `end` object from chat response for error messaging in the UI.   If an error occurs (communicated in the stream response), the `Chat` component will display a default `Announcement` component specifying the error and why the streamed response appears incomplete.

Example visual:

![image](https://github.com/user-attachments/assets/16f270be-fc84-427b-b686-d2fb04586ffa)

