### PR TITLE
Adjust flex to make textarea responsive on smaller viewports. 

### DIFF
--- a/components/Search/Search.styled.ts
+++ b/components/Search/Search.styled.ts
@@ -10,6 +10,7 @@ const SearchStyled = styled("form", {
   marginRight: "$gr4",
   transition: "$dcAll",
   borderRadius: "3px",
+  flexWrap: "wrap",
 
   variants: {
     isFocused: {
@@ -26,9 +27,16 @@ const SearchStyled = styled("form", {
     },
   },
 
+  "> div": {
+    display: "flex",
+    flexGrow: "1",
+    justifyContent: "flex-end",
+  },
+
   "@sm": {
     width: "100%",
     marginRight: "0",
+    flexDirection: "column",
   },
 
   "@lg": {

--- a/components/Search/Search.tsx
+++ b/components/Search/Search.tsx
@@ -114,10 +114,12 @@ const Search: React.FC<SearchProps> = ({ isSearchActive }) => {
         clearSearchResults={clearSearchResults}
         ref={searchRef}
       />
-      <GenerativeAIToggle />
-      <Button type="submit" data-testid="submit-button">
-        Search <IconArrowForward />
-      </Button>
+      <div>
+        <GenerativeAIToggle />
+        <Button type="submit" data-testid="submit-button">
+          Search <IconArrowForward />
+        </Button>
+      </div>
       {isLoaded && <IconSearch />}
     </SearchStyled>
   );


### PR DESCRIPTION
## What does this do?

This applies a simple CSS flexbox fix to make our textera/form responsive at smaller viewports, wrapping the AI toggle and search submit to their own line.

![image](https://github.com/user-attachments/assets/779e5a5a-907f-46a8-af40-d8af50702c63)
