### PR TITLE
Add current build command config to Terraform

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -57,7 +57,7 @@ resource "aws_amplify_app" "dc-next" {
             - npm ci --force
         build:
           commands:
-            - npm run test:ci && npm run prettier:check && npm run build
+            - npm run test:ci && npm run build
       artifacts:
         baseDirectory: .next
         files:


### PR DESCRIPTION
- We don't need prettier on the actual build.
- This was already present in the Amplify console, just moving to Terraform so it doesn't get overwritten