### PR TITLE
Adjust div width using flex within textarea.

### DIFF
--- a/components/Search/Search.styled.ts
+++ b/components/Search/Search.styled.ts
@@ -29,8 +29,11 @@ const SearchStyled = styled("form", {
 
   "> div": {
     display: "flex",
-    flexGrow: "1",
     justifyContent: "flex-end",
+
+    "&:first-child": {
+      flexGrow: "1",
+    },
   },
 
   "@sm": {


### PR DESCRIPTION
## What does this do?

This fix cleans up a small CSS issue related to #5103 after work was completed for https://github.com/nulib/dc-nextjs/pull/357. 

Previous styling adjustments to the Search component textarea caused the clear ❌  icon not align properly and appear in the center of the component. This was due to the wrapping div element not extending its width automatically.

This fix places the CSS `flex-grow` on only the first `div` element, allowing it to take all remaining space in the search component. 

## How can we review?

- Go to https://preview-5103-clear-flex-fix.d2v1qbdeix3nr2.amplifyapp.com/
- Begin typing anything in the Search component `textarea`
- The Clear ❌ button should be aligned to the right of the textarea
- Make the screensize smaller viewport (tablet or phone) 
- The Search should wrap to multiple lines with the texarea on the first line with a clear icon flush right, and the generative AI toggle and submit button on the below.

