### PR TITLE
Add "View `x` results" callback.

### DIFF
--- a/components/Chat/Chat.tsx
+++ b/components/Chat/Chat.tsx
@@ -18,7 +18,13 @@ import { prepareQuestion } from "@/lib/chat-helpers";
 import useChatSocket from "@/hooks/useChatSocket";
 import useQueryParams from "@/hooks/useQueryParams";
 
-const Chat = ({ totalResults }: { totalResults?: number }) => {
+const Chat = ({
+  totalResults,
+  viewResultsCallback,
+}: {
+  totalResults?: number;
+  viewResultsCallback: () => void;
+}) => {
   const { searchTerm = "" } = useQueryParams();
   const { authToken, isConnected, message, sendMessage } = useChatSocket();
 
@@ -144,7 +150,7 @@ const Chat = ({ totalResults }: { totalResults?: number }) => {
         <>
           <Container>
             <StyledResponseActions>
-              <Button isPrimary isLowercase>
+              <Button isPrimary isLowercase onClick={viewResultsCallback}>
                 View {pluralize("Result", totalResults || 0)}
               </Button>
               <Button isLowercase onClick={handleNewQuestion}>

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -197,6 +197,10 @@ const SearchPage: NextPage = () => {
     });
   }
 
+  function handleViewResultsCallback() {
+    setActiveTab("results");
+  }
+
   return (
     <>
       {/* Google Structured Data via JSON-LD */}
@@ -252,7 +256,10 @@ const SearchPage: NextPage = () => {
               renderTabList={showStreamedResponse}
             />
             <Tabs.Content value="stream">
-              <Chat totalResults={totalResults} />
+              <Chat
+                totalResults={totalResults}
+                viewResultsCallback={handleViewResultsCallback}
+              />
             </Tabs.Content>
 
             <Tabs.Content value="results">


### PR DESCRIPTION
## What does this do?

This adds a small callback on the **View `x` results** button that renders below a completed streamed AI response. The callback simply switches the active tab to `results`.

## How can we review?

- Navigate to preview branch at https://5159-view-results-toggle.dc.rdc-staging.library.northwestern.edu/
- Complete an AI chat search
- After streaming completes, click View `x` results below the response
- Tab should toggle to hybrid results 
