### PR TITLE
Use next hooks to avoid renrender with previous query.

### DIFF
--- a/hooks/useQueryParams.ts
+++ b/hooks/useQueryParams.ts
@@ -1,22 +1,12 @@
-import React from "react";
-import { UrlFacets } from "@/types/context/filter-context";
 import { parseUrlFacets } from "@/lib/utils/facet-helpers";
 import { useRouter } from "next/router";
 
 export default function useQueryParams() {
-  const { isReady, query } = useRouter();
-  const [urlFacets, setUrlFacets] = React.useState<UrlFacets>({});
-  const [searchTerm, setSearchTerm] = React.useState<string>();
+  const { query } = useRouter();
 
-  React.useEffect(() => {
-    if (!isReady) return;
-
-    const obj = parseUrlFacets(query);
-    const q = (query.q ? query.q : "") as string;
-
-    setUrlFacets(obj);
-    setSearchTerm(q);
-  }, [isReady, query]);
+  const { q = "" } = query;
+  const searchTerm = Array.isArray(q) ? q.join(" ") : q;
+  const urlFacets = parseUrlFacets(query);
 
   return {
     searchTerm,


### PR DESCRIPTION
## What does this do?

This fixes an issue where the query params of the rendering page are delayed in the re-rendering due to a hiccup in a `useEffect()`.  updates our `useQueryParams()` hook to no longer utilize the `React.useEffect()`. In doing so, we won't see as many re-renders when the hook is called on components where it is used. 

## How should we review?

This isn't the most obvious thing to review as it is literally milliseconds between renders. But the best way is to:

 - Spin up DC or visit https://preview-5154.dc.rdc-staging.library.northwestern.edu/
 - Set to `Use Generative AI` and login
 - Do any search, let it complete
 - Do another search, question rendered on screen should immediately be replaced\
 

As this updates a hook used throughout DC, we should review legacy search:

 - Complete a non-AI search
 - Play with facets
 - Things should be 💯 