### PR TITLE
Include facets on query_string queries for hybrid.

### DIFF
--- a/lib/constants/common.ts
+++ b/lib/constants/common.ts
@@ -2,3 +2,5 @@ export const AI_DISCLAIMER = `This is a preview of Digital Collection's semantic
 export const AI_LOGIN_ALERT = `You must be logged in with a Northwestern NetID to use the Generative AI search feature.`;
 export const AI_SEARCH_UNSUBMITTED = `What can I help you find? Try searching for "john cage scrapbooks" or "who played at the Berkeley Folk Music Festival in 1965?"`;
 export const AI_TOGGLE_LABEL = "Use Generative AI";
+export const AI_K_VALUE = 40;
+export const SEARCH_RESULTS_PER_PAGE = 20;

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -24,6 +24,7 @@ import { IconSparkles } from "@/components/Shared/SVG/Icons";
 import Layout from "@/components/layout";
 import { PRODUCTION_URL } from "@/lib/constants/endpoints";
 import PaginationAltCounts from "@/components/Search/PaginationAltCounts";
+import { SEARCH_RESULTS_PER_PAGE } from "@/lib/constants/common";
 import SearchOptions from "@/components/Search/Options";
 import SearchSimilar from "@/components/Search/Similar";
 import { SpinLoader } from "@/components/Shared/Loader.styled";
@@ -46,8 +47,6 @@ type RequestState = {
 };
 
 const SearchPage: NextPage = () => {
-  const size = 40;
-
   const router = useRouter();
   const { page, q } = router.query;
 
@@ -120,7 +119,7 @@ const SearchPage: NextPage = () => {
 
         const body: ApiSearchRequestBody = buildQuery(
           {
-            size,
+            size: SEARCH_RESULTS_PER_PAGE,
             term: q as string,
             urlFacets,
           },


### PR DESCRIPTION
## What does this do?

This updates the query_string portion of hybrid queries to also include the facets for filtering, giving us more accurate results. Additionally, we have added some new constants for `AI_K_VALUE` and the `SEARCH_RESULTS_PER_PAGE`.

## How should we review?

- Go to https://preview-5176.dc.rdc-staging.library.northwestern.edu
- complete and ai search with "documents of west africa"
- click "view n results"
- facet to `Video` work type

We should only see video.

- Do the same for other work types and we are 💯 