### PR TITLE
Remove number counts from Chat hybrid response results.

### DIFF
--- a/components/Chat/Chat.tsx
+++ b/components/Chat/Chat.tsx
@@ -151,10 +151,10 @@ const Chat = ({
           <Container>
             <StyledResponseActions>
               <Button isPrimary isLowercase onClick={viewResultsCallback}>
-                View {pluralize("Result", totalResults || 0)}
+                View More Results
               </Button>
               <Button isLowercase onClick={handleNewQuestion}>
-                Ask another Question
+                Ask Another Question
               </Button>
             </StyledResponseActions>
             <StyledResponseDisclaimer>{AI_DISCLAIMER}</StyledResponseDisclaimer>

--- a/components/Facets/Filter/Submit.tsx
+++ b/components/Facets/Filter/Submit.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@nulib/design-system";
 import { SetIsModalOpenType } from "@/components/Facets/Filter/Modal";
 import { useFilterState } from "@/context/filter-context";
+import useGenerativeAISearchToggle from "@/hooks/useGenerativeAISearchToggle";
 import useQueryParams from "@/hooks/useQueryParams";
 import { useRouter } from "next/router";
 
@@ -14,6 +15,7 @@ const FacetsFilterSubmit: React.FC<FacetsFilterSubmitProps> = ({
   total,
 }) => {
   const router = useRouter();
+  const { isChecked: isAI } = useGenerativeAISearchToggle();
   const {
     query: { q },
   } = router;
@@ -44,6 +46,8 @@ const FacetsFilterSubmit: React.FC<FacetsFilterSubmitProps> = ({
     setIsModalOpen(false);
   };
 
+  console.log(`isAI`, isAI);
+
   return (
     <div data-testid="facets-submit" style={{ display: "flex" }}>
       <Button
@@ -52,7 +56,7 @@ const FacetsFilterSubmit: React.FC<FacetsFilterSubmitProps> = ({
         onClick={handleSubmit}
         data-testid="submit-button"
       >
-        View Results {total ? `(${total})` : undefined}
+        View Results {total && !isAI ? `(${total})` : undefined}
       </Button>
     </div>
   );

--- a/components/Search/Pagination.styled.ts
+++ b/components/Search/Pagination.styled.ts
@@ -51,6 +51,9 @@ const LeftNav = styled("div", {
 
 const NavWrapper = styled("div", {
   display: "flex",
+  alignSelf: "flex-end",
+  flexGrow: "1",
+  justifyContent: "flex-end",
 
   "& button": {
     fontSize: "$gr3",

--- a/components/Search/PaginationAltCounts.test.tsx
+++ b/components/Search/PaginationAltCounts.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@/test-utils";
+
 import PaginationAltCounts from "@/components/Search/PaginationAltCounts";
 
 /* eslint sort-keys: 0 */
@@ -70,5 +71,16 @@ describe("PaginationAltCounts component", () => {
     expect(screen.getByText(/start/i)).toBeInTheDocument();
     expect(screen.getByText(/previous/i)).toBeInTheDocument();
     expect(screen.queryByText(/next/i)).toBeNull();
+  });
+
+  it("renders a pagination navigation without results for AI responses", () => {
+    render(
+      <PaginationAltCounts pagination={pagination} showResultCounts={false} />,
+    );
+
+    const results = screen.queryByTestId("results");
+    expect(screen.getByTestId("pagination-alt-counts")).not.toContainElement(
+      results,
+    );
   });
 });

--- a/components/Search/PaginationAltCounts.tsx
+++ b/components/Search/PaginationAltCounts.tsx
@@ -3,6 +3,7 @@ import {
   PaginationStyled,
   Results,
 } from "@/components/Search/Pagination.styled";
+
 import { Button } from "@nulib/design-system";
 import { Pagination as PaginationShape } from "@/types/api/response";
 import { pluralize } from "@/lib/utils/count-helpers";
@@ -10,9 +11,13 @@ import { useRouter } from "next/router";
 
 interface PaginationProps {
   pagination: PaginationShape;
+  showResultCounts?: boolean;
 }
 
-const PaginationAltCounts: React.FC<PaginationProps> = ({ pagination }) => {
+const PaginationAltCounts: React.FC<PaginationProps> = ({
+  pagination,
+  showResultCounts = true,
+}) => {
   const { current_page, limit, total_hits, total_pages } = pagination;
   const router = useRouter();
 
@@ -37,10 +42,12 @@ const PaginationAltCounts: React.FC<PaginationProps> = ({ pagination }) => {
       css={{ borderTopWidth: "1px", paddingTop: "$gr2" }}
       data-testid="pagination-alt-counts"
     >
-      <Results data-testid="results">
-        Showing <span>{startCount}</span> to <span>{endCount}</span> of{" "}
-        {pluralize("result", total_hits)}
-      </Results>
+      {showResultCounts && (
+        <Results data-testid="results">
+          Showing <span>{startCount}</span> to <span>{endCount}</span> of{" "}
+          {pluralize("result", total_hits)}
+        </Results>
+      )}
 
       <NavWrapper>
         {current_page > 2 && (

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -244,7 +244,7 @@ const SearchPage: NextPage = () => {
                   </Tabs.Trigger>
                   <Tabs.Trigger value="results" data-tab="results">
                     {Number.isInteger(totalResults) ? (
-                      <>View {pluralize("Result", totalResults || 0)}</>
+                      "View More Results"
                     ) : (
                       <SpinLoader size="small" />
                     )}
@@ -268,22 +268,26 @@ const SearchPage: NextPage = () => {
                   {error && <p>{error}</p>}
                   {apiData && (
                     <>
-                      {totalResults ? (
-                        <ResultsMessage data-testid="results-count">
-                          {pluralize("Result", totalResults)}
-                        </ResultsMessage>
-                      ) : (
-                        <NoResultsMessage>
-                          <strong>
-                            Your search did not match any results.
-                          </strong>{" "}
-                          Please try broadening your search terms or adjusting
-                          your filters.
-                        </NoResultsMessage>
-                      )}
+                      {!isAI &&
+                        (totalResults ? (
+                          <ResultsMessage data-testid="results-count">
+                            {pluralize("Result", totalResults)}
+                          </ResultsMessage>
+                        ) : (
+                          <NoResultsMessage>
+                            <strong>
+                              Your search did not match any results.
+                            </strong>{" "}
+                            Please try broadening your search terms or adjusting
+                            your filters.
+                          </NoResultsMessage>
+                        ))}
                       <Grid data={apiData.data} info={apiData.info} />
                       {totalResults ? (
-                        <PaginationAltCounts pagination={apiData.pagination} />
+                        <PaginationAltCounts
+                          pagination={apiData.pagination}
+                          showResultCounts={!isAI}
+                        />
                       ) : (
                         <></>
                       )}


### PR DESCRIPTION
## What does this do?

This brushstroke sweeps away the result counts from the UI where rendered on chat responses.

 - View More Results buttons (tabs and response footer actions)
 - View Results modal submit button
 - Pagination results counts in footer (for 40+ hits)

Note, this does not include individual agg accounts for bucket items on the filter facets modal.

## How should we review?

- Go to https://preview-5175.dc.rdc-staging.library.northwestern.edu or branch in DC
- Complete any AI search
- Counts should be excluded for:
  + View More Results buttons in tab and footer actions should say "View More Results"
  + View Results Modal submit button should say, "View Results"
  + Pagination result counts should not be displayd