### PR TITLE
Initiate new query on isAi toggle.

### DIFF
--- a/components/Search/Results.tsx
+++ b/components/Search/Results.tsx
@@ -1,0 +1,54 @@
+import {
+  NoResultsMessage,
+  ResultsMessage,
+  ResultsWrapper,
+} from "@/components/Search/Search.styled";
+
+import Grid from "@/components/Grid/Grid";
+import PaginationAltCounts from "@/components/Search/PaginationAltCounts";
+import { SearchResultsState } from "@/types/components/search";
+import { pluralize } from "@/lib/utils/count-helpers";
+import useGenerativeAISearchToggle from "@/hooks/useGenerativeAISearchToggle";
+
+const SearchResults: React.FC<SearchResultsState> = ({
+  data,
+  error,
+  loading,
+}) => {
+  const { isChecked: isAI } = useGenerativeAISearchToggle();
+
+  const totalResults = data?.pagination?.total_hits;
+
+  return (
+    <ResultsWrapper>
+      {loading && <></>}
+      {error && <p>{error}</p>}
+      {data && (
+        <>
+          {!isAI &&
+            (totalResults ? (
+              <ResultsMessage data-testid="results-count">
+                {pluralize("Result", totalResults)}
+              </ResultsMessage>
+            ) : (
+              <NoResultsMessage>
+                <strong>Your search did not match any results.</strong> Please
+                try broadening your search terms or adjusting your filters.
+              </NoResultsMessage>
+            ))}
+          <Grid data={data.data} info={data.info} />
+          {totalResults ? (
+            <PaginationAltCounts
+              pagination={data.pagination}
+              showResultCounts={!isAI}
+            />
+          ) : (
+            <></>
+          )}
+        </>
+      )}
+    </ResultsWrapper>
+  );
+};
+
+export default SearchResults;

--- a/components/Search/Search.tsx
+++ b/components/Search/Search.tsx
@@ -25,7 +25,7 @@ const Search: React.FC<SearchProps> = ({ isSearchActive }) => {
   const router = useRouter();
   const { urlFacets } = useQueryParams();
 
-  const { isChecked } = useGenerativeAISearchToggle();
+  const { isChecked, handleCheckChange } = useGenerativeAISearchToggle();
 
   const searchRef = useRef<HTMLTextAreaElement>(null);
   const formRef = useRef<HTMLFormElement>(null);
@@ -35,11 +35,11 @@ const Search: React.FC<SearchProps> = ({ isSearchActive }) => {
   const [searchFocus, setSearchFocus] = useState<boolean>(false);
 
   const handleSubmit = (
-    e:
+    e?:
       | SyntheticEvent<HTMLFormElement>
       | React.KeyboardEvent<HTMLTextAreaElement>,
   ) => {
-    e.preventDefault();
+    if (e) e.preventDefault();
 
     const updatedFacets: UrlFacets = {};
     const allFacetsIds = getAllFacetIds();
@@ -81,9 +81,8 @@ const Search: React.FC<SearchProps> = ({ isSearchActive }) => {
     });
   };
 
-  useEffect(() => {
-    setIsLoaded(true);
-  }, []);
+  useEffect(() => setIsLoaded(true), []);
+  useEffect(() => handleSubmit(), [isChecked]);
 
   useEffect(() => {
     if (router) {

--- a/types/components/search.ts
+++ b/types/components/search.ts
@@ -1,0 +1,10 @@
+import { ApiSearchResponse } from "@/types/api/response";
+
+/**
+ * Search response rendered to the UI
+ */
+export type SearchResultsState = {
+  data: ApiSearchResponse | null;
+  error: string | null;
+  loading: boolean;
+};


### PR DESCRIPTION
## What does this do?

This minor fix makes it so that a new query is initiated on toggle of the _Use Generative AI_ option in the search component. Previously, this only fired if the query string itself changed and was submitted. 

To make sure work, we adjust the useEffect hook on the search page to watch for any changes in `isAi` state here by adding it as a dependency. 
https://github.com/nulib/dc-nextjs/blob/88887a4db113408ab628a5f209ad90427d611c2d/pages/search.tsx#L146

And then we also reset the query response data to wipe previous data results.
https://github.com/nulib/dc-nextjs/blob/88887a4db113408ab628a5f209ad90427d611c2d/pages/search.tsx#L92-L93

Additionally, I have abstracted out the `search.tsx` screen further, creating the `components/Search/Results.tsx` file. This should give us better control over rendering of results in the future.

## How should we review?

- Go to https://preview-5164.dc.rdc-staging.library.northwestern.edu/ or this branch in your dev DC
- Complete a search (legacy), "Africa" or "Denver"
- See the results... note the first few items
- Select the _Use Generative AI_ toggle
- Screen should update to show Chat response with "See More Results" as a spinning loading SVG.
- See more results... first few items should be different
- Untoggle _Use Generative AI_
- Results should clear, new results should render