### PR TITLE
Add user primary affiliation to data layer.

### DIFF
--- a/context/user-context.tsx
+++ b/context/user-context.tsx
@@ -19,6 +19,7 @@ const UserProvider = ({ children }: { children: ReactNode }) => {
         isLoggedIn = false,
         isReadingRoom = false,
         name,
+        primaryAffiliation,
         sub,
       } = result;
       setUser({
@@ -26,6 +27,7 @@ const UserProvider = ({ children }: { children: ReactNode }) => {
         isLoggedIn,
         isReadingRoom,
         name,
+        primaryAffiliation,
         sub,
       });
     });

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -14,7 +14,6 @@ import Head from "next/head";
 import { ObjectLiteral } from "@/types";
 import React from "react";
 import { SearchProvider } from "@/context/search-context";
-import Transition from "@/components/Transition";
 import { User } from "@/types/context/user";
 import { UserProvider } from "@/context/user-context";
 import { defaultOpenGraphData } from "@/lib/open-graph";
@@ -56,6 +55,7 @@ function MyApp({ Component, pageProps }: MyAppProps) {
         ...pageProps.dataLayer,
         isLoggedIn: user?.isLoggedIn,
         isUsingAI: isUsingAI && user?.isLoggedIn,
+        userPrimaryAffiliation: user?.primaryAffiliation,
       };
 
       // "VirtualPageView" is a custom event that we use to track page views.

--- a/types/context/user.ts
+++ b/types/context/user.ts
@@ -1,6 +1,7 @@
 export type User = {
   sub: string;
   name: string;
+  primaryAffiliation: string;
   email: string;
   isLoggedIn: boolean;
   isReadingRoom: boolean;


### PR DESCRIPTION
## What does this do?

This grabs the `primaryAffiliation` off the _/whoami_ response and adds it to the GTM data layer payload. The key added to the dataLayer is `userPrimaryAffiliation`

![image](https://github.com/user-attachments/assets/0e998368-f636-45d9-941c-9206b64eee9e)


## How to review?

- Go to https://preview-5199.dc.rdc-staging.library.northwestern.edu or DC in dev
  + Login to hit the /whoami
- In a different tab, go to [Google Tag Manager](https://tagmanager.google.com) and login
  + Click Preview
  + Add `https://preview-5199.dc.rdc-staging.library.northwestern.edu` domain
  + Clear history
- Back in your DC tab, navigate your browser
- In your GTM tab, note the VirtualPageView event with the `userPrimaryAffiliation` key/value