### PR TITLE
Update dcapi types and fixtures.

### DIFF
--- a/mocks/sample-work1.ts
+++ b/mocks/sample-work1.ts
@@ -37,6 +37,7 @@ export const sampleWork1: Work = {
   embedding: [2345, 2345],
   embedding_model:
     "huggingface/sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2-stack-p-indexing-embedding",
+  embedding_text_length: "0",
   file_sets: [
     {
       accession_number: "inu-dil-50575a78-a47a-4a07-939f-6e1d6a9d7065",

--- a/mocks/sample-work2.ts
+++ b/mocks/sample-work2.ts
@@ -37,6 +37,7 @@ export const sampleWork2: Work = {
   embedding: [2345, 2345],
   embedding_model:
     "huggingface/sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2-stack-p-indexing-embedding",
+  embedding_text_length: "0",
   file_sets: [
     {
       accession_number: "inu-dil-50575a78-a47a-4a07-939f-6e1d6a9d7065",

--- a/mocks/shared-link/work.ts
+++ b/mocks/shared-link/work.ts
@@ -54,6 +54,7 @@ export const work: Work = {
   embedding: [2345, 2345],
   embedding_model:
     "huggingface/sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2-stack-p-indexing-embedding",
+  embedding_text_length: "0",
   file_sets: [
     {
       accession_number: "inu-dil-12b39039-68af-4a31-8b04-1b025d95a0b8",

--- a/mocks/work-page/work1.ts
+++ b/mocks/work-page/work1.ts
@@ -33,6 +33,7 @@ export const work1: Work = {
   embedding: [2345, 2345],
   embedding_model:
     "huggingface/sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2-stack-p-indexing-embedding",
+  embedding_text_length: "0",
   file_sets: [
     {
       accession_number: "BFMF_B06_F12_006_022n_am_donut_01",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@next/bundle-analyzer": "^14.0.3",
         "@next/font": "^14.0.3",
         "@next/third-parties": "^14.2.3",
-        "@nulib/dcapi-types": "^2.3.1",
+        "@nulib/dcapi-types": "^2.5.0",
         "@nulib/design-system": "^1.6.2",
         "@nulib/use-markdown": "^0.2.1",
         "@radix-ui/colors": "^3.0.0",
@@ -2198,10 +2198,9 @@
       }
     },
     "node_modules/@nulib/dcapi-types": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@nulib/dcapi-types/-/dcapi-types-2.3.1.tgz",
-      "integrity": "sha512-Puy2264x3K6q7QFLD9dAXw2KDrNOm2i61OxbLGQ/dVO9DxvsTghCwv7W3+//yRnVD/BFdHYwBNzxA3+X7K07Rg==",
-      "license": "Apache-2.0"
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@nulib/dcapi-types/-/dcapi-types-2.5.0.tgz",
+      "integrity": "sha512-Ai1AJioCC4y4lpGdvzziC7zDcrzUbIislM0InmRx9nuj4I/0Old9eJJyBrfiDv9uGdWwFGqBaleAUtZk6pQcTQ=="
     },
     "node_modules/@nulib/design-system": {
       "version": "1.6.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@next/bundle-analyzer": "^14.0.3",
     "@next/font": "^14.0.3",
     "@next/third-parties": "^14.2.3",
-    "@nulib/dcapi-types": "^2.3.1",
+    "@nulib/dcapi-types": "^2.5.0",
     "@nulib/design-system": "^1.6.2",
     "@nulib/use-markdown": "^0.2.1",
     "@radix-ui/colors": "^3.0.0",

--- a/tests/fixtures/works/canary-work.ts
+++ b/tests/fixtures/works/canary-work.ts
@@ -75,6 +75,7 @@ export const canaryWork: WorkExtended = {
   ],
   embedding: [123, 1234],
   embedding_model: "embed model here",
+  embedding_text_length: "0",
   file_sets: [
     {
       accession_number: "TEST_canary_002_001",


### PR DESCRIPTION
## What does this do? 

Updates `@nulib/dcapi-types` to v2.5.0 and updates fixtures as required.

## How should we review?

 - Does it build? Yes.
 - Check it out at https://preview-5195-dcapi-types.d2v1qbdeix3nr2.amplifyapp.com/ 