### PR TITLE
Revise playwright search and facet specs.

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,9 +1,9 @@
 name: Playwright Tests
 on:
-#   push:
-#     branches: []
-#   pull_request:
-#     branches: [main, deploy/staging]
+  push:
+    branches: []
+  pull_request:
+    branches: [main, deploy/staging]
   workflow_dispatch:
 jobs:
   test:

--- a/tests/404.spec.ts
+++ b/tests/404.spec.ts
@@ -1,0 +1,22 @@
+import { test as base, expect } from "@playwright/test";
+
+const WORK_404_ID = "00000000-0000-0000-0000-000000000000";
+
+const test = base.extend({});
+
+test.describe("404 page component", async () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(`/items/${WORK_404_ID}`);
+  });
+
+  test("renders the 404 page", async ({ page }) => {
+    await expect(page).toHaveURL(`/items/${WORK_404_ID}`);
+
+    const figure = await page.locator("main .swiper figure");
+
+    await expect(figure.locator(".slide-label")).toHaveText("Page Not Found");
+    await expect(figure.locator(".slide-summary")).toHaveText(
+      "Sorry the page you are looking for does not exist. It's possible the resource, work, or collection is no longer available. If you think you reached this page in error, please contact us.",
+    );
+  });
+});

--- a/tests/fixtures/work-page.ts
+++ b/tests/fixtures/work-page.ts
@@ -1,7 +1,13 @@
 import { type Page } from "@playwright/test";
 
+export const CANARY_WORK_ID = "cb8a19a7-3dec-47f3-80c0-12872ae61f8f";
+
 export class WorkPage {
-  readonly route: string = "/items";
+  readonly route: string = `/items/${CANARY_WORK_ID}`;
 
   constructor(public readonly page: Page) {}
+
+  async goto() {
+    await this.page.goto(this.route);
+  }
 }

--- a/tests/search.spec.ts
+++ b/tests/search.spec.ts
@@ -19,6 +19,7 @@ const test = base.extend<SearchPageFixtures>({
     await openGraphPage.goto();
     await use(openGraphPage);
   },
+
   // A fixture to help with the Search Page shared functionality
   searchPage: async ({ page }, use) => {
     const searchPage = new SearchPage(page);
@@ -91,6 +92,7 @@ test.describe("Search page component", () => {
     await searchInput.fill(searches[1].term);
     await searchBtn.click();
 
+    await page.waitForLoadState("domcontentloaded");
     await expect(page).toHaveURL(`/search?q=${searches[1].term}`);
     await searchPage.verifyTopResultsCount(searches[1].expectedResultCount);
     await expect(searchInput).toHaveValue(searches[1].term);
@@ -99,6 +101,7 @@ test.describe("Search page component", () => {
       searches[1].expectedResultCount,
     );
 
+    await page.waitForLoadState("domcontentloaded");
     await searchPage.verifyTopResultsCount(searches[1].expectedResultCount);
     await searchPage.verifyTotalsResultDisplay({
       count: search2,
@@ -110,6 +113,7 @@ test.describe("Search page component", () => {
     await expect(page).toHaveURL(/\/search/);
 
     // Verify original counts are back in place
+    await page.waitForLoadState("domcontentloaded");
     await searchPage.verifyTopResultsCount(TOTAL_RESULTS);
     await searchPage.verifyGridItemCount(TOTAL_RESULTS);
   });
@@ -124,10 +128,10 @@ test.describe("Search page component", () => {
     const audioBtn = facetInlineComponent.getByRole("radio", { name: "Audio" });
     const videoBtn = facetInlineComponent.getByRole("radio", { name: "Video" });
     const clearAllBtn = page.getByRole("button", {
-      name: "Clear All",
+      name: "Reset",
     });
     const publicWorksToggle = page.getByRole("switch", {
-      name: "Public works only",
+      name: "Public only",
     });
     const facetUserComponent = page
       .getByTestId("facet-user-component")
@@ -139,18 +143,21 @@ test.describe("Search page component", () => {
     const PUBLIC_WORKS_COUNT = 179;
 
     // Work Type facet button checks
+    await page.waitForLoadState("domcontentloaded");
     await expect(allBtn).toHaveAttribute("aria-checked", "true");
     await expect(imageBtn).toHaveAttribute("aria-checked", "false");
 
     // Select Image facet
-    // await imageBtn.click();
-    // await expect(imageBtn).toHaveAttribute("aria-checked", "true");
-    // await expect(allBtn).toHaveAttribute("aria-checked", "false");
-    // await searchPage.verifyTopResultsCount(IMAGE_COUNT);
-    // await searchPage.verifyGridItemCount(IMAGE_COUNT);
+    await imageBtn.click();
+    await page.waitForLoadState("domcontentloaded");
+    await expect(imageBtn).toHaveAttribute("aria-checked", "true");
+    await expect(allBtn).toHaveAttribute("aria-checked", "false");
+    await searchPage.verifyTopResultsCount(IMAGE_COUNT);
+    await searchPage.verifyGridItemCount(IMAGE_COUNT);
 
     // Select Audio facet
     await audioBtn.click();
+    await page.waitForLoadState("domcontentloaded");
     await expect(audioBtn).toHaveAttribute("aria-checked", "true");
     await expect(imageBtn).toHaveAttribute("aria-checked", "false");
     await searchPage.verifyTopResultsCount(AUDIO_COUNT);
@@ -158,19 +165,23 @@ test.describe("Search page component", () => {
 
     // Select Video facet
     await videoBtn.click();
+    await page.waitForLoadState("domcontentloaded");
     await expect(videoBtn).toHaveAttribute("aria-checked", "true");
     await expect(audioBtn).toHaveAttribute("aria-checked", "false");
     await searchPage.verifyTopResultsCount(VIDEO_COUNT);
     await searchPage.verifyGridItemCount(VIDEO_COUNT);
 
-    // Toggle Public Works
+    // Select All (work types) facet
     await allBtn.click();
     await page.waitForLoadState("domcontentloaded");
+    await searchPage.verifyTopResultsCount(TOTAL_RESULTS);
+
+    // Toggle Public Works
     await publicWorksToggle.click();
     await page.waitForLoadState("domcontentloaded");
-
     await searchPage.verifyTopResultsCount(PUBLIC_WORKS_COUNT);
     await searchPage.verifyGridItemCount(PUBLIC_WORKS_COUNT);
+    await expect(facetUserComponent).toContainText("1");
 
     // Test Filter Facet Toggle UI
     await clearAllBtn.click();
@@ -179,9 +190,12 @@ test.describe("Search page component", () => {
 
     await imageBtn.click();
     await page.waitForLoadState("domcontentloaded");
+    await publicWorksToggle.click();
+    await page.waitForLoadState("domcontentloaded");
     await expect(facetUserComponent).toContainText("1");
 
     await publicWorksToggle.click();
+    await page.waitForLoadState("domcontentloaded");
     await expect(facetUserComponent).toContainText("2");
   });
 });


### PR DESCRIPTION
## What does this do?

This work revises our playwright tests to work as-is with a few exceptions.

- Adds a 404 spec test
- Skips tests for `work.spec.test` due to timeout issue in GitHub CI ([#5238](https://github.com/nulib/repodev_planning_and_docs/issues/5238) to address this has been created).
- This does not include extending tests over chat features in search results. 

## How do we review?

- Do the tests pass (or skip) without fail or timing out?
- Is playwright a part of the git workflow?