### PR TITLE
Show leading zeros on minutes in shared link expiration display

### DIFF
--- a/lib/utils/date-helpers.test.ts
+++ b/lib/utils/date-helpers.test.ts
@@ -1,0 +1,73 @@
+import { formatDate, formatDateLong } from "./date-helpers";
+
+describe("formatDate", () => {
+  test("should format date correctly", () => {
+    const result = formatDate("2023-11-14T13:14:00Z");
+    expect(result).toBe("2023-10-2"); // Note: getMonth() is zero-based, getDay() returns day of the week
+  });
+
+  test("should handle invalid date", () => {
+    const result = formatDate("invalid-date");
+    expect(result).toBe("NaN-NaN-NaN");
+  });
+});
+
+describe("formatDateLong", () => {
+  it("should return a properly formatted date string for a valid date input", () => {
+    const inputDate = "2023-11-14T13:14:00Z"; // UTC time
+    const dateObj = new Date(inputDate);
+
+    // Dynamically generate the expected output based on the local time zone
+    const expectedOutput = `${dateObj.toLocaleString("en-US", { month: "long" })} ${dateObj.getDate()}, ${dateObj.getFullYear()}, ${
+      dateObj.getHours() > 12 ? dateObj.getHours() - 12 : dateObj.getHours()
+    }:${dateObj.getMinutes().toString().padStart(2, "0")}${
+      dateObj.getHours() >= 12 ? "pm" : "am"
+    }`;
+
+    expect(formatDateLong(inputDate)).toBe(expectedOutput);
+  });
+
+  it("should return an empty string for an undefined input", () => {
+    expect(formatDateLong(undefined)).toBe("");
+  });
+
+  it("should handle midnight correctly in the local time zone", () => {
+    const inputDate = "2023-11-14T00:00:00Z"; // Midnight in UTC
+    const dateObj = new Date(inputDate);
+
+    const hour = dateObj.getHours() % 12 || 12;
+    const minutes = dateObj.getMinutes().toString().padStart(2, "0");
+    const ampm = dateObj.getHours() >= 12 ? "pm" : "am";
+
+    const expectedOutput = `${dateObj.toLocaleString("en-US", { month: "long" })} ${dateObj.getDate()}, ${dateObj.getFullYear()}, ${hour}:${minutes}${ampm}`;
+
+    expect(formatDateLong(inputDate)).toBe(expectedOutput);
+  });
+
+  it("should handle noon correctly in the local time zone", () => {
+    const inputDate = "2023-11-14T12:00:00Z"; // Noon in UTC
+    const dateObj = new Date(inputDate);
+
+    // Dynamically calculate expected output in the local time zone
+    const hour = dateObj.getHours() % 12 || 12;
+    const minutes = dateObj.getMinutes().toString().padStart(2, "0");
+    const ampm = dateObj.getHours() >= 12 ? "pm" : "am";
+
+    const expectedOutput = `${dateObj.toLocaleString("en-US", { month: "long" })} ${dateObj.getDate()}, ${dateObj.getFullYear()}, ${hour}:${minutes}${ampm}`;
+
+    expect(formatDateLong(inputDate)).toBe(expectedOutput);
+  });
+
+  it("should pad minutes correctly", () => {
+    const inputDate = "2023-11-14T13:04:00Z"; // UTC time
+    const dateObj = new Date(inputDate);
+
+    const expectedOutput = `${dateObj.toLocaleString("en-US", { month: "long" })} ${dateObj.getDate()}, ${dateObj.getFullYear()}, ${
+      dateObj.getHours() > 12 ? dateObj.getHours() - 12 : dateObj.getHours()
+    }:${dateObj.getMinutes().toString().padStart(2, "0")}${
+      dateObj.getHours() >= 12 ? "pm" : "am"
+    }`;
+
+    expect(formatDateLong(inputDate)).toBe(expectedOutput);
+  });
+});

--- a/lib/utils/date-helpers.ts
+++ b/lib/utils/date-helpers.ts
@@ -7,12 +7,9 @@ export function formatDateLong(date: string | undefined): string {
   if (!date) return "";
 
   const dateObj = new Date(date);
-  const hour =
-    dateObj.getHours() > 12 ? dateObj.getHours() - 12 : dateObj.getHours();
-  // Write a JS Date object to a string in the format like "November 14, 2023, 1:14pm"
-  return `${dateObj.toLocaleString("en-US", {
-    month: "long",
-  })} ${dateObj.getDate()}, ${dateObj.getFullYear()}, ${hour}:${dateObj.getMinutes()}${
-    dateObj.getHours() > 12 ? "pm" : "am"
-  }`;
+  const hour = dateObj.getHours() % 12 || 12; // Handle midnight and noon
+  const minutes = dateObj.getMinutes().toString().padStart(2, "0");
+  const ampm = dateObj.getHours() >= 12 ? "pm" : "am";
+
+  return `${dateObj.toLocaleString("en-US", { month: "long" })} ${dateObj.getDate()}, ${dateObj.getFullYear()}, ${hour}:${minutes}${ampm}`;
 }


### PR DESCRIPTION
- Shared links are currently displaying minutes in the expiration without leading zeroes.
- This update will now display, for example: `1:06pm` instead of `1:6pm`

### Steps to Test

- create a shared link in Meadow when the minute is a single digit
- view the shared link in DC and verify correct display of expiration time