### PR TITLE
Handle conversations chat UI.

### DIFF
--- a/components/Chat/Chat.test.tsx
+++ b/components/Chat/Chat.test.tsx
@@ -80,11 +80,6 @@ describe("Chat component", () => {
     const dataProps = el.getAttribute("data-props");
     const dataPropsObj = JSON.parse(dataProps!);
     expect(dataPropsObj.question).toEqual("tell me about boats");
-    expect(dataPropsObj.isStreamingComplete).toEqual(false);
-    expect(dataPropsObj.message).toEqual({
-      answer: "fake-answer-1",
-      end: "stop",
-    });
     expect(typeof dataPropsObj.conversationRef).toBe("string");
     expect(uuidRegex.test(dataPropsObj.conversationRef)).toBe(true);
   });
@@ -105,14 +100,6 @@ describe("Chat component", () => {
       <SearchProvider>
         <Chat />
       </SearchProvider>,
-    );
-
-    expect(mockMessage).toHaveBeenCalledWith(
-      expect.objectContaining({
-        auth: "fake-token",
-        message: "chat",
-        question: "boats",
-      }),
     );
   });
 

--- a/components/Chat/Conversation.test.tsx
+++ b/components/Chat/Conversation.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from "@/test-utils";
+
+import ChatConversation from "./Conversation";
+
+describe("Conversaton component", () => {
+  const handleConversationCallback = jest.fn();
+
+  it("renders a chat conversation", () => {
+    render(
+      <ChatConversation conversationCallback={handleConversationCallback} />,
+    );
+
+    const wrapper = screen.getByTestId("chat-conversation");
+    expect(wrapper).toBeInTheDocument();
+  });
+});

--- a/components/Chat/Conversation.tsx
+++ b/components/Chat/Conversation.tsx
@@ -1,0 +1,225 @@
+import { IconArrowForward, IconRefresh, IconReply } from "../Shared/SVG/Icons";
+
+import { styled } from "@/stitches.config";
+import { transform } from "next/dist/build/swc";
+import { useRef } from "react";
+import { useRouter } from "next/router";
+
+const textareaPlaceholder = "Ask a followup question...";
+
+interface ChatConversationProps {
+  conversationCallback: (message: string) => void;
+  isStreaming?: boolean;
+}
+
+const ChatConversation: React.FC<ChatConversationProps> = ({
+  conversationCallback,
+  isStreaming,
+}) => {
+  const router = useRouter();
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const formRef = useRef<HTMLFormElement>(null);
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    submitConversationCallback();
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      submitConversationCallback();
+    }
+  };
+
+  const submitConversationCallback = () => {
+    if (isStreaming) return;
+
+    const value = textareaRef.current?.value;
+    if (value) conversationCallback(value);
+
+    /* Clear the textarea and unfocus it */
+    textareaRef.current!.value = "";
+    textareaRef.current!.blur();
+  };
+
+  const handleFocus = () => {
+    const isFocused = String(textareaRef.current === document.activeElement);
+    formRef.current!.dataset.isFocused = isFocused;
+  };
+
+  const handleClearConversation = () => {
+    const textarea = document.getElementById(
+      "dc-search",
+    ) as HTMLTextAreaElement;
+    if (textarea) {
+      textarea.value = "";
+      textarea.innerText = "";
+      textarea.focus();
+    }
+
+    router.push({
+      pathname: "/search",
+    });
+  };
+
+  return (
+    <StyledChatConversation data-testid="chat-conversation">
+      <form onSubmit={handleSubmit} ref={formRef} data-is-focused="false">
+        <textarea
+          ref={textareaRef}
+          onKeyDown={handleKeyDown}
+          placeholder={textareaPlaceholder}
+          onFocus={handleFocus}
+          onBlur={handleFocus}
+        ></textarea>
+        <button type="submit" disabled={isStreaming}>
+          Reply <IconReply />
+        </button>
+      </form>
+      <StyledResetButton onClick={handleClearConversation}>
+        Start new conversation
+        <IconRefresh />
+      </StyledResetButton>
+    </StyledChatConversation>
+  );
+};
+
+const StyledResetButton = styled("button", {
+  border: "none",
+  backgroundColor: "$white",
+  display: "inline-flex",
+  justifyContent: "center",
+  alignItems: "center",
+  gap: "$gr1",
+  fontFamily: "$northwesternSansRegular",
+  fontSize: "$gr3",
+  color: "$purple",
+  padding: "$gr3",
+  borderRadius: "3px",
+  cursor: "pointer",
+  transition: "$dcAll",
+  textDecoration: "underline",
+  textDecorationThickness: "min(2px,max(1px,.05em))",
+  textUnderlineOffset: "calc(.05em + 2px)",
+  textDecorationColor: "$purple10",
+  margin: "0 auto",
+
+  svg: {
+    fill: "transparent",
+    stroke: "$purple",
+    strokeWidth: "48px",
+    height: "1.25em",
+    width: "1.25em",
+    transform: "rotate(45deg) scaleX(-1)",
+  },
+});
+
+const StyledChatConversation = styled("div", {
+  display: "flex",
+  flexDirection: "column",
+  margin: "$gr5 0 $gr4",
+  gap: "$gr3",
+
+  form: {
+    position: "relative",
+    transition: "$dcAll",
+    borderRadius: "3px",
+    flexWrap: "wrap",
+    overflow: "hidden",
+    flexGrow: 1,
+    zIndex: 0,
+    height: "62px",
+
+    ["&[data-is-focused=true]"]: {
+      backgroundColor: "$white !important",
+      boxShadow: "3px 3px 11px #0001",
+      outline: "2px solid $purple60",
+
+      button: {
+        backgroundColor: "$purple",
+        color: "$white",
+      },
+    },
+
+    ["&[data-is-focused=false]"]: {
+      backgroundColor: "#f0f0f0",
+      boxShadow: "none",
+      outline: "2px solid transparent",
+
+      textarea: {
+        color: "$black50",
+        whiteSpace: "nowrap",
+        overflow: "hidden",
+        textOverflow: "ellipsis",
+      },
+    },
+
+    textarea: {
+      width: "100%",
+      height: "100%",
+      padding: "15px $gr3",
+      border: "none",
+      resize: "none",
+      backgroundColor: "$gray6",
+      fontSize: "$gr3",
+      lineHeight: "147%",
+      zIndex: "1",
+      fontFamily: "$northwesternSansRegular",
+      overflow: "hidden",
+      outline: "none",
+      transition: "$dcAll",
+      boxSizing: "border-box",
+
+      "&::placeholder": {
+        overflow: "hidden",
+        color: "$black50",
+        textOverflow: "ellipsis",
+      },
+    },
+
+    button: {
+      position: "absolute",
+      bottom: "$gr2",
+      right: "$gr2",
+      height: "38px",
+      borderRadius: "3px",
+      background: "$purple",
+      border: "none",
+      color: "$white",
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "center",
+      transition: "$dcAll",
+      cursor: "pointer",
+      fontSize: "$gr2",
+      padding: "0 $gr2",
+      gap: "$gr2",
+      fontFamily: "$northwesternSansRegular",
+
+      "&:hover, &:focus": {
+        backgroundColor: "$purple120",
+        color: "$white",
+      },
+
+      svg: {
+        width: "1rem",
+        height: "1rem",
+        fill: "transparent",
+        stroke: "$white",
+        // transform: "rotate(-90deg)",
+
+        path: {
+          strokeWidth: "32px",
+        },
+      },
+
+      "&:disabled": {
+        backgroundColor: "$black20",
+        color: "$white",
+      },
+    },
+  },
+});
+
+export default ChatConversation;

--- a/components/Chat/Feedback/Feedback.tsx
+++ b/components/Chat/Feedback/Feedback.tsx
@@ -216,13 +216,15 @@ const StyledChatFeedbackActivate = styled("div", {
   margin: "0 0 $gr2 ",
   display: "flex",
   alignItems: "center",
-  fontSize: "$gr3",
-  gap: "$gr2",
+  borderTop: "1px solid $gray6",
+  padding: "$gr3 0",
+
+  "> span": {
+    marginRight: "$gr2",
+  },
 });
 
-const StyledChatFeedbackConfirmation = styled("div", {
-  fontSize: "$gr3",
-});
+const StyledChatFeedbackConfirmation = styled("div", {});
 
 const StyledChatFeedbackForm = styled("form", {
   margin: "$gr3 0",
@@ -244,6 +246,9 @@ const StyledChatFeedbackForm = styled("form", {
 });
 
 const StyledChatFeedback = styled("div", {
+  fontSize: "$gr2",
+  color: "$black50",
+
   variants: {
     isSubmitted: {
       true: {
@@ -257,7 +262,7 @@ const StyledChatFeedback = styled("div", {
 });
 
 const StyledSentimentButton = styled("button", {
-  backgroundColor: "$purple10",
+  backgroundColor: "transparent",
   border: "none",
   padding: 0,
   height: "40px",
@@ -270,8 +275,8 @@ const StyledSentimentButton = styled("button", {
   borderRadius: "50%",
 
   "> span": {
-    height: "36px",
-    width: "36px",
+    height: "32px",
+    width: "32px",
   },
 
   "&:not([disabled])": {
@@ -290,7 +295,7 @@ const StyledSentimentButton = styled("button", {
 
   "&[data-is-selected=false]": {
     "> span": {
-      fill: "$purple30",
+      fill: "$black20",
     },
   },
 });

--- a/components/Chat/Response/Images.tsx
+++ b/components/Chat/Response/Images.tsx
@@ -1,38 +1,13 @@
-import { useEffect, useState } from "react";
-
 import GridItem from "@/components/Grid/Item";
 import { StyledImages } from "@/components/Chat/Response/Response.styled";
 import { Work } from "@nulib/dcapi-types";
 
 const INITIAL_MAX_ITEMS = 5;
 
-const ResponseImages = ({
-  isStreamingComplete,
-  works,
-}: {
-  isStreamingComplete: boolean;
-  works: Work[];
-}) => {
-  const [nextIndex, setNextIndex] = useState(0);
-
-  useEffect(() => {
-    if (isStreamingComplete) {
-      setNextIndex(works.length);
-      return;
-    }
-
-    if (nextIndex < works.length && nextIndex < INITIAL_MAX_ITEMS) {
-      const timer = setTimeout(() => {
-        setNextIndex(nextIndex + 1);
-      }, 100);
-
-      return () => clearTimeout(timer);
-    }
-  }, [isStreamingComplete, nextIndex, works.length]);
-
+const ResponseImages = ({ works }: { works: Work[] }) => {
   return (
     <StyledImages>
-      {works.slice(0, nextIndex).map((document: Work) => (
+      {works.slice(0, INITIAL_MAX_ITEMS).map((document: Work) => (
         <GridItem key={document.id} item={document} />
       ))}
     </StyledImages>

--- a/components/Chat/Response/Interstitial.styled.tsx
+++ b/components/Chat/Response/Interstitial.styled.tsx
@@ -9,16 +9,11 @@ const gradientAnimation = keyframes({
 
 const StyledInterstitialIcon = styled("div", {
   display: "flex",
-  width: "1.5rem",
-  height: "1.5rem",
+  width: "1rem",
+  height: "1rem",
   alignItems: "center",
   justifyContent: "center",
   borderRadius: "50%",
-  background:
-    "linear-gradient(73deg, $purple120 0%, $purple 38.2%, $brightBlueB 61.8%)",
-  backgroundSize: "250%",
-  backgroundPosition: "61.8%",
-  animation: `${gradientAnimation} 5s infinite alternate`,
   transition: "$dcAll",
   content: "",
 
@@ -34,21 +29,31 @@ const StyledInterstitialIcon = styled("div", {
   },
 
   svg: {
-    fill: "$white",
-    width: "0.85rem",
-    height: "0.85rem",
+    fill: "$purple",
+    width: "1rem",
+    height: "1rem",
   },
 });
 
 const StyledInterstitial = styled("div", {
-  color: "$black",
-  fontFamily: "$northwesternSansBold",
-  fontSize: "$gr4",
-  display: "flex",
+  fontFamily: "$northwesternSansRegular",
+  fontWeight: "400",
+  fontSize: "$gr3",
+  display: "inline-flex",
   alignItems: "center",
   gap: "$gr2",
+  marginBottom: "$gr1",
+  width: "fit-content",
+  color: "$purple60",
+  borderRadius: "1em",
+  paddingRight: "$gr2",
+  backgroundSize: "250%",
+  backgroundPosition: "61.8%",
+  animation: `${gradientAnimation} 5s infinite alternate`,
 
-  em: {
+  strong: {
+    fontFamily: "$northwesternSansBold",
+    fontWeight: "400",
     color: "$purple",
   },
 });

--- a/components/Chat/Response/Interstitial.tsx
+++ b/components/Chat/Response/Interstitial.tsx
@@ -1,9 +1,9 @@
+import { IconSearch, IconSparkles } from "@/components/Shared/SVG/Icons";
 import {
   StyledInterstitial,
   StyledInterstitialIcon,
 } from "@/components/Chat/Response/Interstitial.styled";
 
-import { IconSearch } from "@/components/Shared/SVG/Icons";
 import React from "react";
 import { ToolStartMessage } from "@/types/components/chat";
 
@@ -20,19 +20,22 @@ const ResponseInterstitial: React.FC<ResponseInterstitialProps> = ({
   switch (tool) {
     case "aggregate":
       text = (
-        <>
-          Aggregating {input.agg_field} by {input.term_field} {input.term}
-        </>
+        <label>
+          Aggregating <strong>{input.agg_field}</strong> by{" "}
+          <strong>
+            {input.term_field} {input.term}
+          </strong>
+        </label>
       );
       break;
     case "discover_fields":
-      text = <>Discovering fields</>;
+      text = <label>Discovering fields</label>;
       break;
     case "search":
       text = (
-        <>
-          Searching for <em>{input.query}</em>
-        </>
+        <label>
+          Searching for <strong>{input.query}</strong>
+        </label>
       );
       break;
     default:
@@ -42,7 +45,7 @@ const ResponseInterstitial: React.FC<ResponseInterstitialProps> = ({
   return (
     <StyledInterstitial data-testid="response-interstitial" data-tool={tool}>
       <StyledInterstitialIcon>
-        <IconSearch />
+        <IconSparkles />
       </StyledInterstitialIcon>
       <label>{text}</label>
     </StyledInterstitial>

--- a/components/Chat/Response/Markdown.tsx
+++ b/components/Chat/Response/Markdown.tsx
@@ -2,10 +2,34 @@ import React from "react";
 import { StyledResponseMarkdown } from "@/components/Chat/Response/Response.styled";
 import useMarkdown from "@nulib/use-markdown";
 
-const ResponseMarkdown = ({ content }: { content: string }) => {
-  const { jsx } = useMarkdown(content);
+/**
+ * Add a wrapper around HTML table elements to allow
+ * for horizontal scrolling in responsive viewports
+ */
+function addTableWrapper(html: string) {
+  let parsedHtml = html;
 
-  return <StyledResponseMarkdown>{jsx}</StyledResponseMarkdown>;
+  const tableRegex = /<table>([\s\S]*?)<\/table>/g;
+  const tableMatch = html.match(tableRegex);
+
+  if (tableMatch) {
+    tableMatch.forEach((table) => {
+      const tableWrapped = `<div class="table-wrapper">${table}</div>`;
+      parsedHtml = html.replace(table, tableWrapped);
+    });
+  }
+
+  return parsedHtml;
+}
+
+const ResponseMarkdown = ({ content }: { content: string }) => {
+  const { html } = useMarkdown(content);
+
+  const parsedHtml = addTableWrapper(html);
+
+  return (
+    <StyledResponseMarkdown dangerouslySetInnerHTML={{ __html: parsedHtml }} />
+  );
 };
 
 export default ResponseMarkdown;

--- a/components/Chat/Response/Options.tsx
+++ b/components/Chat/Response/Options.tsx
@@ -1,0 +1,11 @@
+import ChatFeedback from "../Feedback/Feedback";
+
+const ResponseOptions = () => {
+  return (
+    <>
+      <ChatFeedback />
+    </>
+  );
+};
+
+export default ResponseOptions;

--- a/components/Chat/Response/Response.styled.tsx
+++ b/components/Chat/Response/Response.styled.tsx
@@ -8,13 +8,19 @@ const CursorKeyframes = keyframes({
   },
 });
 
-const StyledResponse = styled("section", {
+const StyledResponse = styled("article", {
   display: "flex",
   position: "relative",
   flexDirection: "column",
   gap: "$gr3",
   zIndex: "0",
-  minHeight: "50vh",
+  marginBottom: "$gr5",
+
+  "> div": {
+    display: "flex",
+    flexDirection: "column",
+    gap: "$gr3",
+  },
 
   "h1, h2, h3, h4, h5, h6, strong": {
     fontFamily: "$northwesternSansBold",
@@ -30,10 +36,6 @@ const StyledResponse = styled("section", {
 const StyledResponseAside = styled("aside", {});
 
 const StyledResponseContent = styled("div", {});
-
-const StyledResponseWrapper = styled("div", {
-  padding: "0",
-});
 
 const StyledImages = styled("div", {
   display: "grid",
@@ -56,10 +58,6 @@ const StyledImages = styled("div", {
     figure: {
       padding: "0",
 
-      "> div": {
-        boxShadow: "5px 5px 13px rgba(0, 0, 0, 0.25)",
-      },
-
       figcaption: {
         "span:first-of-type": {
           textOverflow: "ellipsis",
@@ -73,24 +71,36 @@ const StyledImages = styled("div", {
   },
 });
 
-const StyledQuestion = styled("h3", {
+const StyledQuestion = styled("header", {
   fontFamily: "$northwesternSansBold",
   fontWeight: "400",
-  fontSize: "$gr6",
-  letterSpacing: "-0.012em",
+  fontSize: "$gr3",
   lineHeight: "1.35em",
-  margin: "0 0 $gr4",
-  padding: "0",
-  color: "$black",
+  padding: "$gr2 $gr3",
+  margin: "0",
+  color: "$purple120",
+  alignSelf: "flex-end",
+  borderRadius: "1rem",
+  backgroundColor: "$purple10",
 });
 
-const StyledResponseMarkdown = styled("article", {
+const StyledResponseMarkdown = styled("div", {
   fontSize: "$gr3",
   lineHeight: "1.47em",
-  overflow: "hidden",
 
-  p: {
+  ".table-wrapper": {
+    overflowX: "auto",
+    width: "100%",
+    "-webkit-overflow-scrolling": "touch",
+    margin: "$gr4 0",
+  },
+
+  "p, li": {
     lineHeight: "inherit",
+  },
+
+  li: {
+    marginBottom: "$gr1",
   },
 
   "h1, h2, h3, h4, h5, h6, strong": {
@@ -104,6 +114,36 @@ const StyledResponseMarkdown = styled("article", {
     textDecorationThickness: "min(2px,max(1px,.05em))",
     textUnderlineOffset: "calc(.05em + 2px)",
     textDecorationColor: "$purple10",
+  },
+
+  table: {
+    width: "100%",
+    borderCollapse: "collapse",
+    borderSpacing: "0",
+    marginBottom: "$gr4",
+    borderLeft: "1px solid $gray6",
+    borderRight: "1px solid $gray6",
+    borderTop: "1px solid $gray6",
+    margin: "0",
+
+    th: {
+      padding: "$gr2",
+      textAlign: "left",
+      fontWeight: "400",
+      fontFamily: "$northwesternSansBold",
+      borderBottom: "1px solid $gray6",
+    },
+
+    td: {
+      padding: "$gr2",
+      borderBottom: "1px solid $gray6",
+    },
+  },
+
+  img: {
+    maxWidth: "$gr7",
+    maxHeight: "$gr7",
+    borderRadius: "3px",
   },
 
   "span.markdown-cursor": {
@@ -131,12 +171,13 @@ const StyledResponseActions = styled("div", {
 const StyledUnsubmitted = styled("p", {
   color: "$black50",
   fontSize: "$gr3",
-  fontFamily: "$northwesternSansLight",
+  fontFamily: "$northwesternSansRegular",
   textAlign: "center",
   width: "61.8%",
   maxWidth: "61.8%",
   margin: "0 auto",
-  padding: "$gr4 0",
+  padding: "$gr5 0",
+  minHeight: "38.2vh",
 });
 
 const StyledResponseDisclaimer = styled("p", {
@@ -152,7 +193,6 @@ export {
   StyledResponseAside,
   StyledResponseContent,
   StyledResponseDisclaimer,
-  StyledResponseWrapper,
   StyledImages,
   StyledQuestion,
   StyledResponseMarkdown,

--- a/components/Search/Search.tsx
+++ b/components/Search/Search.tsx
@@ -27,13 +27,15 @@ const Search: React.FC<SearchProps> = ({ isSearchActive }) => {
   const router = useRouter();
   const { urlFacets } = useQueryParams();
 
+  const { q } = router.query;
+
   const { isChecked } = useGenerativeAISearchToggle();
 
   const searchRef = useRef<HTMLTextAreaElement>(null);
   const formRef = useRef<HTMLFormElement>(null);
 
   const [isLoaded, setIsLoaded] = useState<boolean>(false);
-  const [searchValue, setSearchValue] = useState<string>("");
+  const [searchValue, setSearchValue] = useState<string>(q as string);
   const [searchFocus, setSearchFocus] = useState<boolean>(false);
 
   const appendSearchJumpTo = isCollectionPage(router?.pathname);
@@ -88,12 +90,13 @@ const Search: React.FC<SearchProps> = ({ isSearchActive }) => {
   useEffect(() => setIsLoaded(true), []);
 
   useEffect(() => {
-    if (router) {
-      const { q } = router.query;
+    if (q) {
       if (q && searchRef.current) searchRef.current.value = q as string;
       setSearchValue(q as string);
+    } else {
+      setSearchValue("");
     }
-  }, [router]);
+  }, [q]);
 
   useEffect(() => {
     !searchFocus && !searchValue ? isSearchActive(false) : isSearchActive(true);

--- a/components/Shared/SVG/Icons.tsx
+++ b/components/Shared/SVG/Icons.tsx
@@ -136,6 +136,20 @@ const IconMenu: React.FC = () => (
   </svg>
 );
 
+const IconRefresh: React.FC = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+    <path d="M320 146s24.36-12-64-12a160 160 0 10160 160" />
+    <path d="M256 58l80 80-80 80" />
+  </svg>
+);
+
+const IconReply: React.FC = () => (
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 260 224">
+    <path d="m80,16L16,80l64,64" />
+    <path d="m32,80h106c58.76,0,106,49.33,106,108v20" />
+  </svg>
+);
+
 const IconReturnDownBack: React.FC = () => (
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
     <title>Return Down Back</title>
@@ -241,6 +255,8 @@ export {
   IconInfo,
   IconLock,
   IconMenu,
+  IconRefresh,
+  IconReply,
   IconReturnDownBack,
   IconSearch,
   IconSocialFacebook,

--- a/hooks/useChatSocket.ts
+++ b/hooks/useChatSocket.ts
@@ -62,6 +62,7 @@ const useChatSocket = () => {
 
   const sendMessage = useCallback((data: object) => {
     if (socketRef.current && socketRef.current.readyState === WebSocket.OPEN) {
+      console.log("Sending message", data);
       socketRef.current.send(JSON.stringify(data));
     }
   }, []);

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -12,8 +12,6 @@ import { DC_API_SEARCH_URL } from "@/lib/constants/endpoints";
 import { HEAD_META } from "@/lib/constants/head-meta";
 import Head from "next/head";
 import Heading from "@/components/Heading/Heading";
-import Icon from "@/components/Shared/Icon";
-import { IconSparkles } from "@/components/Shared/SVG/Icons";
 import Layout from "@/components/layout";
 import { PRODUCTION_URL } from "@/lib/constants/endpoints";
 import { SEARCH_RESULTS_PER_PAGE } from "@/lib/constants/common";
@@ -195,10 +193,6 @@ const SearchPage: NextPage = () => {
     });
   }
 
-  function handleViewResultsCallback() {
-    setActiveTab("results");
-  }
-
   return (
     <>
       {/* Google Structured Data via JSON-LD */}
@@ -233,28 +227,13 @@ const SearchPage: NextPage = () => {
             onValueChange={(value) => setActiveTab(value as ActiveTab)}
           >
             <SearchOptions
-              tabs={
-                <Tabs.List>
-                  <Tabs.Trigger value="stream" data-tab="stream">
-                    <Icon>
-                      <IconSparkles />
-                    </Icon>
-                    AI Response
-                  </Tabs.Trigger>
-                  <Tabs.Trigger value="results" data-tab="results">
-                    {Number.isInteger(totalResults) ? (
-                      "View More Results"
-                    ) : (
-                      <SpinLoader size="small" />
-                    )}
-                  </Tabs.Trigger>
-                </Tabs.List>
-              }
+              tabs={<></>} // placeholder for back tab
               activeTab={activeTab}
               renderTabList={showStreamedResponse}
             />
+
             <Tabs.Content value="stream">
-              <Chat viewResultsCallback={handleViewResultsCallback} />
+              <Chat />
             </Tabs.Content>
 
             <Tabs.Content value="results">


### PR DESCRIPTION
## What does this do?

This work makes major changes to the Chat response UI allowing for threaded conversations that are held in context through a `conversationRef`. A few updates have occurred to accommodate this change and iterate towards more complex multi question/answer responses.

1. useChatSocket is now handled at lower level component. This allows each question/answer to interact independently when receiving messages. Although indepdenent of each when receiving/sending messages, only one connection should be made at page level. This connection should sustain unless it times out.
 
https://github.com/nulib/dc-nextjs/blob/29f2c38eb544fb1576b492ec6fd74a454551186c/components/Chat/Response/Response.tsx#L27

2. The feedback form is now tied to each response. Note that the form UI is in place, however, the submission of this form and it's question/responses is not yet functional. Functionality for this will be handled in a new issue.

3. The more results table for hybrid search is hidden currently. This will be handled in a new issue and may require refinement before resolving.

4. We are not currently sending questions/answers to a higher level search context as we did previously. I have not yet determined if we need this search context any longer and what shape this should be. Solutions for (2) and (3) above should determine how we handle this. Tests related to mocking this context have temporally been removed.

## Review steps

This can be reviewed in amplify at https://preview-5354-conversations-ui.dc.rdc-staging.library.northwestern.edu/ or if run in a dev environment. If running in dev, be sure  to set `NEXT_PUBLIC_DCAPI_ENDPOINT`  to `https://dcapi-prototype.rdc-staging.library.northwestern.edu/api/v2`


![image](https://github.com/user-attachments/assets/f0e172c3-4702-4c52-a768-bf54c4b4a329)

