### PR TITLE
Add Identifier to metadata list.

### DIFF
--- a/lib/constants/works.ts
+++ b/lib/constants/works.ts
@@ -36,6 +36,9 @@ const WORK_METADATA_LABELS: WorkMetadata[] = [
     searchParam: "genre",
   },
   {
+    label: "Identifier",
+  },
+  {
     label: "Keyword",
   },
   {


### PR DESCRIPTION
## What does this do?

This adds `Identifier` to the `WORK_METADATA_LABELS` allowing for formatting of each entry as a styled item in the `components/Work/Metadata.tsx` component.

## How should we review?

This can be easily reviewed at https://preview-5437-identifier-entries.dc.rdc-staging.library.northwestern.edu/items/01871556-952d-489c-816f-644c9622daa7 where the UI now presents the values as individual entries 

![image](https://github.com/user-attachments/assets/07c5d6b8-143a-49cd-a47f-e1bd52a2309e)

As compared to https://dc.library.northwestern.edu/items/01871556-952d-489c-816f-644c9622daa7 where the the values are merged as one

![image](https://github.com/user-attachments/assets/ef512bc4-55e0-40f3-8a5c-74d009b80f56)
