### PR TITLE
Update query aggregations to show correct results for facet counts on AI aided responses.

### DIFF
--- a/components/Chat/Chat.tsx
+++ b/components/Chat/Chat.tsx
@@ -101,7 +101,7 @@ const Chat = () => {
 };
 
 const StyledChat = styled("section", {
-  padding: "$gr6 0",
+  padding: "$gr5 0",
   position: "relative",
 });
 

--- a/components/Facets/Facet/GenericFacet.test.tsx
+++ b/components/Facets/Facet/GenericFacet.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@/test-utils";
+
 import GenericFacet from "./GenericFacet";
 import mockRouter from "next-router-mock";
 
@@ -42,29 +43,31 @@ jest.mock("@/lib/dc-api", () => {
     },
     aggregations: {
       genre: {
-        buckets: [
-          {
-            doc_count: 36,
-            key: "black-and-white negatives",
-          },
-          { doc_count: 18, key: "black-and-white photographs" },
-          { doc_count: 17, key: "clippings (information artifacts)" },
-          {
-            doc_count: 11,
-            key: "letters (correspondence)",
-          },
-          {
-            doc_count: 9,
-            key: "sculpture (visual works)",
-          },
-          { doc_count: 8, key: "color photographs" },
-          {
-            doc_count: 7,
-            key: "notes (documents)",
-          },
-          { doc_count: 6, key: "photographs" },
-        ],
-        id: "genre",
+        genre: {
+          buckets: [
+            {
+              doc_count: 36,
+              key: "black-and-white negatives",
+            },
+            { doc_count: 18, key: "black-and-white photographs" },
+            { doc_count: 17, key: "clippings (information artifacts)" },
+            {
+              doc_count: 11,
+              key: "letters (correspondence)",
+            },
+            {
+              doc_count: 9,
+              key: "sculpture (visual works)",
+            },
+            { doc_count: 8, key: "color photographs" },
+            {
+              doc_count: 7,
+              key: "notes (documents)",
+            },
+            { doc_count: 6, key: "photographs" },
+          ],
+          id: "genre",
+        },
       },
     },
   };

--- a/components/Facets/Filter/Submit.tsx
+++ b/components/Facets/Filter/Submit.tsx
@@ -46,8 +46,6 @@ const FacetsFilterSubmit: React.FC<FacetsFilterSubmitProps> = ({
     setIsModalOpen(false);
   };
 
-  console.log(`isAI`, isAI);
-
   return (
     <div data-testid="facets-submit" style={{ display: "flex" }}>
       <Button

--- a/components/Facets/UserFacets/UserFacets.styled.ts
+++ b/components/Facets/UserFacets/UserFacets.styled.ts
@@ -141,6 +141,8 @@ const StyledValue = styled("button", {
 const ValueWrapper = styled("div", {
   display: "flex",
   flexWrap: "wrap",
+  position: "relative",
+  zIndex: 2,
 
   variants: {
     isModal: {

--- a/components/Search/Options.styled.tsx
+++ b/components/Search/Options.styled.tsx
@@ -69,71 +69,6 @@ const StyledOptionsExtras = styled("div", {
   },
 });
 
-const StyledOptionsTabs = styled("div", {
-  [`div[role="tablist"]`]: {
-    display: "flex",
-    flexWrap: "nowrap",
-    height: "38px",
-    borderRadius: "50px",
-    overflow: "hidden",
-
-    button: {
-      cursor: "pointer",
-      backgroundColor: "transparent",
-      border: "0",
-      color: "$purple",
-      fontFamily: "$northwesternSansRegular",
-      fontSize: "$gr3",
-      padding: "0 $gr3",
-      height: "2rem",
-      transition: "$dcAll",
-      whiteSpace: "nowrap",
-      display: "flex",
-      alignItems: "center",
-
-      "@md": {
-        padding: "0 $gr2",
-      },
-
-      "&[data-state=active]": {
-        color: "$black",
-        fontFamily: "$northwesternSansBold",
-
-        [`& ${IconStyled}`]: {
-          color: "$purple",
-          fill: "$purple",
-        },
-      },
-
-      "&[data-state=inactive]": {
-        color: "$black50",
-
-        [`& ${IconStyled}`]: {
-          color: "$black20",
-          fill: "$black20",
-        },
-      },
-
-      "&:first-child": {
-        paddingLeft: "$gr1",
-      },
-
-      "&:hover": {
-        color: "$purple",
-
-        [`& ${IconStyled}`]: {
-          color: "$purple",
-          fill: "$purple",
-        },
-      },
-    },
-
-    "@sm": {
-      marginBottom: "$gr3",
-    },
-  },
-});
-
 const slideInFromLeft = keyframes({
   "0%": { transform: "translateX(-100vw)" },
   "100%": { transform: "translateX0)" },
@@ -173,10 +108,6 @@ const StyledOptions = styled("div", {
       webkitFontSmoothing: "subpixel-antialiased",
       animation: `${slideInFromLeft} 1s ${timingFunction};`,
 
-      [`& ${StyledOptionsTabs}`]: {
-        display: "none",
-      },
-
       "@sm": {
         top: "$gr5",
         marginTop: "$gr4",
@@ -190,6 +121,5 @@ export {
   StyledOptionsBar,
   StyledOptionsExtras,
   StyledOptionsFacets,
-  StyledOptionsTabs,
   StyledOptionsWidth,
 };

--- a/components/Search/Options.tsx
+++ b/components/Search/Options.tsx
@@ -4,7 +4,6 @@ import {
   StyledOptionsBar,
   StyledOptionsExtras,
   StyledOptionsFacets,
-  StyledOptionsTabs,
   StyledOptionsWidth,
 } from "@/components/Search/Options.styled";
 
@@ -39,7 +38,6 @@ const SearchOptions: React.FC<SearchOptionsProps> = ({
         maxWidth={searchFixed ? optionsRef.current?.clientWidth : undefined}
       >
         <StyledOptionsBar data-testid="facets-ui-wrapper" ref={optionsRef}>
-          {renderTabList && <StyledOptionsTabs>{tabs}</StyledOptionsTabs>}
           <StyledOptionsFacets isTabResults={activeTab === "results"}>
             <Facets />
             <StyledOptionsExtras>

--- a/components/Search/Panel.styled.tsx
+++ b/components/Search/Panel.styled.tsx
@@ -80,7 +80,6 @@ const StyledSearchPanel = styled("aside", {
 
 const StyledSearchPanelContent = styled("div", {
   height: "100%",
-  padding: "$gr4 0",
   background: "white",
 });
 

--- a/components/Search/Search.styled.ts
+++ b/components/Search/Search.styled.ts
@@ -1,5 +1,5 @@
-import { styled } from "@/stitches.config";
 import { TabsContent } from "@radix-ui/react-tabs";
+import { styled } from "@/stitches.config";
 
 /* eslint sort-keys: 0 */
 
@@ -147,12 +147,13 @@ const StyledResponseWrapper = styled("div", {
 const StyledTabsContent = styled(TabsContent, {
   display: "grid",
   gridTemplateColumns: "minmax(0, 1fr) min(1120px, 100%) minmax(0, 1fr)",
-  marginTop: "-30px",
+
   ">*:first-child": {
     gridColumn: "2 / 3",
     gridRow: "1",
     width: "100%",
   },
+
   ">*:nth-child(2)": {
     gridColumn: "1 / 4",
     gridRow: "1",

--- a/lib/collection-helpers.ts
+++ b/lib/collection-helpers.ts
@@ -1,5 +1,9 @@
 import { Aggs, ApiSearchRequestBody } from "@/types/api/request";
-import { ApiResponseBucket, ApiSearchResponse } from "@/types/api/response";
+import {
+  ApiResponseAggregation,
+  ApiResponseBucket,
+  ApiSearchResponse,
+} from "@/types/api/response";
 import { apiGetRequest, apiPostRequest } from "@/lib/dc-api";
 
 import type { Collection } from "@nulib/dcapi-types";
@@ -188,7 +192,10 @@ export async function getCollectionWorkCounts(
       url: `${process.env.NEXT_PUBLIC_DCAPI_ENDPOINT}/search`,
     });
 
-    const collectionBuckets = response?.aggregations?.collections?.buckets;
+    const collectionAggregations =
+      response?.aggregations as ApiResponseAggregation;
+
+    const collectionBuckets = collectionAggregations?.collections?.buckets;
     if (!collectionBuckets || collectionBuckets.length === 0) {
       /** The Collection has no Works, send default zero counts */
       if (collectionId) {
@@ -263,7 +270,9 @@ export async function getMetadataAggs(collectionId: string, field: string) {
     });
 
     if (response?.aggregations) {
-      return response.aggregations.collectionMetadata.buckets;
+      const aggregations = response.aggregations as ApiResponseAggregation;
+
+      return aggregations.collectionMetadata.buckets;
     }
     return null;
   } catch (err) {
@@ -312,7 +321,8 @@ export async function getTopMetadataAggs({
     });
 
     if (response?.aggregations) {
-      for (const [key, value] of Object.entries(response?.aggregations)) {
+      const aggregations = response.aggregations as ApiResponseAggregation;
+      for (const [key, value] of Object.entries(aggregations)) {
         topMetadata.push({
           field: key,
           value: shuffle(value.buckets.map((bucket) => bucket.key)).slice(0, 3),

--- a/lib/queries/aggs.test.ts
+++ b/lib/queries/aggs.test.ts
@@ -18,23 +18,45 @@ describe("buildAggs function", () => {
     const response = aggs.buildAggs(facets, facetFilterValue, userFacets);
 
     expect(response).toEqual({
-      genre: {
-        terms: {
-          field: "genre.label",
-          order: {
-            _count: "desc",
+      userFacets: {
+        filter: {
+          bool: {
+            must: [
+              { term: { "genre.label": "paintings (visual works)" } },
+              { term: { "subject.label": "Painting" } },
+              { term: { "subject.label": "19th century" } },
+            ],
           },
-          size: 20,
+        },
+        aggs: {
+          userFacets: {
+            terms: {
+              field: "genre.label",
+              include: ["paintings (visual works)"],
+              order: { _count: "desc" },
+              size: 20,
+            },
+          },
         },
       },
-      userFacets: {
-        terms: {
-          field: "genre.label",
-          include: ["paintings (visual works)"],
-          order: {
-            _count: "desc",
+      genre: {
+        filter: {
+          bool: {
+            must: [
+              { term: { "genre.label": "paintings (visual works)" } },
+              { term: { "subject.label": "Painting" } },
+              { term: { "subject.label": "19th century" } },
+            ],
           },
-          size: 20,
+        },
+        aggs: {
+          genre: {
+            terms: {
+              field: "genre.label",
+              order: { _count: "desc" },
+              size: 20,
+            },
+          },
         },
       },
     });
@@ -52,15 +74,19 @@ describe("buildAggs function", () => {
     const userFacets = {};
 
     const response = aggs.buildAggs(facets, facetFilterValue, userFacets);
+
     expect(response).toEqual({
       subject: {
-        terms: {
-          field: "subject.label",
-          include: ".*(A|a)(R|r)(C|c)(H|h)(I|i)(T|t)(E|e)(C|c).*",
-          order: {
-            _count: "desc",
+        filter: { bool: { must: [] } },
+        aggs: {
+          subject: {
+            terms: {
+              field: "subject.label",
+              include: ".*(A|a)(R|r)(C|c)(H|h)(I|i)(T|t)(E|e)(C|c).*",
+              order: { _count: "desc" },
+              size: 20,
+            },
           },
-          size: 20,
         },
       },
     });
@@ -78,15 +104,21 @@ describe("buildAggs function", () => {
     const userFacets = {};
 
     const response = aggs.buildAggs(facets, facetFilterValue, userFacets);
+
+    console.log(JSON.stringify(response));
+
     expect(response).toEqual({
       subject: {
-        terms: {
-          field: "subject.label",
-          include: '.*"Art".*',
-          order: {
-            _count: "desc",
+        filter: { bool: { must: [] } },
+        aggs: {
+          subject: {
+            terms: {
+              field: "subject.label",
+              include: '.*"Art".*',
+              order: { _count: "desc" },
+              size: 20,
+            },
           },
-          size: 20,
         },
       },
     });
@@ -95,13 +127,18 @@ describe("buildAggs function", () => {
     const singleQuoteResponse = aggs.buildAggs(facets, `"`, userFacets);
     expect(singleQuoteResponse).toEqual({
       subject: {
-        terms: {
-          field: "subject.label",
-          include: " ",
-          order: {
-            _count: "desc",
+        filter: { bool: { must: [] } },
+        aggs: {
+          subject: {
+            terms: {
+              field: "subject.label",
+              include: " ",
+              order: {
+                _count: "desc",
+              },
+              size: 20,
+            },
           },
-          size: 20,
         },
       },
     });

--- a/lib/queries/aggs.ts
+++ b/lib/queries/aggs.ts
@@ -2,6 +2,7 @@ import { Aggs } from "@/types/api/request";
 import { FacetsInstance } from "@/types/components/facets";
 import { SortOrder } from "@elastic/elasticsearch/api/types";
 import { UrlFacets } from "@/types/context/filter-context";
+import { buildFacetFilters } from "./facet";
 import { facetRegex } from "@/lib/utils/facet-helpers";
 
 /**
@@ -54,13 +55,22 @@ export const buildAggs = (
 
     if (userFacetsValues) {
       aggs.userFacets = {
-        terms: {
-          field: facet.field,
-          include: userFacetsValues,
-          order: {
-            _count: desc,
+        filter: {
+          bool: {
+            must: buildFacetFilters(userFacets),
           },
-          size: 20,
+        },
+        aggs: {
+          userFacets: {
+            terms: {
+              field: facet.field,
+              include: userFacetsValues,
+              order: {
+                _count: desc,
+              },
+              size: 20,
+            },
+          },
         },
       };
     }
@@ -69,7 +79,14 @@ export const buildAggs = (
      * Default agg values for the active Facet
      */
     aggs[facet.id] = {
-      terms,
+      filter: {
+        bool: {
+          must: buildFacetFilters(userFacets),
+        },
+      },
+      aggs: {
+        [facet.id]: { terms: terms },
+      },
     };
   });
 

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -2,6 +2,10 @@ import * as Tabs from "@radix-ui/react-tabs";
 
 import { GetServerSideProps, NextPage } from "next";
 import React, { useEffect, useState } from "react";
+import {
+  StyledResponseWrapper,
+  StyledTabsContent,
+} from "@/components/Search/Search.styled";
 
 import { ActiveTab } from "@/types/context/search-context";
 import { ApiSearchRequestBody } from "@/types/api/request";
@@ -20,10 +24,6 @@ import SearchPanel from "@/components/Search/Panel";
 import SearchResults from "@/components/Search/Results";
 import { SearchResultsState } from "@/types/components/search";
 import SearchSimilar from "@/components/Search/Similar";
-import {
-  StyledResponseWrapper,
-  StyledTabsContent,
-} from "@/components/Search/Search.styled";
 import { UserContext } from "@/context/user-context";
 import { apiPostRequest } from "@/lib/dc-api";
 import axios from "axios";
@@ -71,7 +71,6 @@ const SearchPage: NextPage = () => {
   });
 
   const showStreamedResponse = Boolean(user?.isLoggedIn && isAI);
-  const totalResults = searchResults.data?.pagination?.total_hits;
 
   /**
    * on a query change, we check to see if the user is using the AI and then
@@ -96,9 +95,6 @@ const SearchPage: NextPage = () => {
    */
   useEffect(() => {
     if (!router.isReady) return;
-
-    // Reset search results state
-    setSearchResults(defaultSearchResultsState);
 
     (async () => {
       try {
@@ -158,6 +154,10 @@ const SearchPage: NextPage = () => {
    */
   useEffect(() => {
     if (!pageQueryUrl) return;
+
+    // Reset search results state
+    setSearchResults(defaultSearchResultsState);
+
     (async () => {
       try {
         const response = await axios.get(pageQueryUrl);
@@ -231,9 +231,6 @@ const SearchPage: NextPage = () => {
           <Tabs.Root
             value={activeTab}
             className="tabs-wrapper"
-            style={{
-              overflow: "hidden",
-            }}
             onValueChange={(value) => setActiveTab(value as ActiveTab)}
           >
             {activeTab === "results" && (

--- a/types/api/response.ts
+++ b/types/api/response.ts
@@ -14,6 +14,14 @@ export interface ApiResponseAggregation {
   };
 }
 
+export interface ApiResponseFilteredAggregation {
+  [key: string]: {
+    [key: string]: {
+      buckets: ApiResponseBucket[];
+    };
+  };
+}
+
 export type ApiResponseBucket = {
   doc_count: number;
   key: string;
@@ -24,7 +32,7 @@ export type ApiResponseBucket = {
 export type ApiResponseData = Collection | SearchShape[] | Work;
 
 export interface ApiSearchResponse extends ApiResponse {
-  aggregations?: ApiResponseAggregation;
+  aggregations?: ApiResponseAggregation | ApiResponseFilteredAggregation;
   data: SearchShape[];
   pagination: Pagination;
 }

--- a/types/context/search-context.ts
+++ b/types/context/search-context.ts
@@ -1,4 +1,7 @@
-import { ApiResponseAggregation } from "@/types/api/response";
+import {
+  ApiResponseAggregation,
+  ApiResponseFilteredAggregation,
+} from "@/types/api/response";
 
 export type ActiveTab = "stream" | "results";
 
@@ -8,7 +11,7 @@ export interface Article {
 }
 
 export interface SearchContextStore {
-  aggregations?: ApiResponseAggregation;
+  aggregations?: ApiResponseAggregation | ApiResponseFilteredAggregation;
   conversation: {
     body: Article[];
     ref?: string;


### PR DESCRIPTION
## What does this do?

This updates our queries by adding a `post_filter` on **query** and `filter` within **aggs**. These changes affected the response shape of `aggregations` and required some adjustments within components handling this data and types defining its shape.

#### `post_filter` added to query body

https://github.com/nulib/dc-nextjs/blob/7fa0c5356a1a355bd3a556bfd8cb0b55fece041d/lib/queries/aggs.ts#L82-L86

#### `filter` added to aggs

https://github.com/nulib/dc-nextjs/blob/7fa0c5356a1a355bd3a556bfd8cb0b55fece041d/lib/queries/aggs.ts#L58-L62

https://github.com/nulib/dc-nextjs/blob/7fa0c5356a1a355bd3a556bfd8cb0b55fece041d/lib/queries/aggs.ts#L82-L86



## How should we review?

1. Go to https://preview-5432-ai-aggs.dc.rdc-staging.library.northwestern.edu/search
2. Set **Use Generative AI**
3. Do a search that would bring up some fun results, ex: _wisconsin football_
4. Get that conversation rolling, and click on **View Results →** for the first search results interstitial
5. Click **Filter** and facet for subject that might cut the total results down a bit but not something extremely specific. If you went with _wisconsin football_, this might be **College Students**

![image](https://github.com/user-attachments/assets/4832689a-bc8e-4432-896a-b1e7a8b49429)

6. After clicking, this facet being selected should filter out other facets that are exclusive of it.

![image](https://github.com/user-attachments/assets/889ae2fc-3bbc-45c9-acb4-18aec3e2d67b)

7. Selecting another option should further drill in and make available options less abundant.

![image](https://github.com/user-attachments/assets/e1bb8c2c-2cee-4e70-b03f-6fa5830c1f00)

8. Toggling to another Facet, ex: **Genre** should also show only available options.

![image](https://github.com/user-attachments/assets/2d7f6ab8-2e06-4ad5-9851-99c757d23f30)

9. Click View Results should show results accurately.

![image](https://github.com/user-attachments/assets/e6c30e3e-b956-408c-9813-253efcaf897a)
 