### PR TITLE
Preview/5323 feedback

### DIFF
--- a/components/Chat/Chat.tsx
+++ b/components/Chat/Chat.tsx
@@ -8,16 +8,16 @@ import { StyledUnsubmitted } from "./Response/Response.styled";
 import { styled } from "@/stitches.config";
 import { useSearchState } from "@/context/search-context";
 import { v4 as uuidv4 } from "uuid";
+import { Turn } from "@/types/context/search-context";
 
 const Chat = () => {
   const { searchState, searchDispatch } = useSearchState();
 
-  const {
-    conversation: { body, ref },
-  } = searchState;
+  const { conversation } = searchState;
 
+  const ref = conversation.ref;
   /** get initial question  */
-  const initialQuestion = body.length > 0 && body[0].question;
+  const initialQuestion = conversation.initialQuestion;
 
   const [isStreaming, setIsStreaming] = useState(false);
 
@@ -30,12 +30,7 @@ const Chat = () => {
     searchDispatch({
       type: "updateConversation",
       conversation: {
-        body: [
-          {
-            question: initialQuestion,
-            answer: "",
-          },
-        ],
+        ...conversation,
         ref: conversationRef,
       },
     });
@@ -48,19 +43,21 @@ const Chat = () => {
       searchDispatch({
         type: "updateConversation",
         conversation: {
-          body: [
-            ...body,
+          ...conversation,
+          turns: [
+            ...conversation.turns,
             {
               question: value,
               answer: "",
+              aggregations: [],
+              works: [],
             },
           ],
-          ref,
         },
       });
   };
 
-  const handleResponseCallback = (content: any) => {
+  const handleResponseCallback = () => {
     setIsStreaming(false);
   };
 
@@ -75,18 +72,19 @@ const Chat = () => {
     <Container>
       <StyledChat
         data-conversation-initial={initialQuestion}
-        data-conversation-length={body.length}
+        data-conversation-length={conversation.turns.length}
         data-conversation-ref={ref}
       >
-        {body
-          .filter((entry) => entry.question)
-          .map((entry, index) => {
+        {conversation.turns
+          .filter((turn) => turn.question)
+          .map((turn, index) => {
             return (
               <ChatResponse
                 conversationIndex={index}
                 conversationRef={ref}
                 key={index}
-                question={entry.question}
+                question={turn.question}
+                content={turn.renderedContent}
                 responseCallback={handleResponseCallback}
               />
             );

--- a/components/Chat/Response/Options.test.tsx
+++ b/components/Chat/Response/Options.test.tsx
@@ -1,16 +1,20 @@
 import { SearchProvider, useSearchState } from "@/context/search-context";
 import { render, screen } from "@testing-library/react";
+import type { SearchContextStore } from "@/types/context/search-context";
 
 import ResponseOptions from "@/components/Chat/Response/Options";
 
-const mockConversation = {
-  body: [
+const mockConversation: SearchContextStore["conversation"] = {
+  ref: "1234",
+  initialQuestion: "Do you have photos of Joan Baez in your collection?",
+  turns: [
     {
       question: "Do you have photos of Joan Baez in your collection?",
       answer: "",
+      aggregations: [],
+      works: [],
     },
   ],
-  ref: "1234",
 };
 
 const mockSearchDispatch = jest.fn();
@@ -49,8 +53,7 @@ describe("ResponseOptions", () => {
       searchState: { conversation },
     } = useSearchState();
 
-    //
-    expect(conversation.body[conversationIndex].question).toBe(
+    expect(conversation.turns[conversationIndex].question).toBe(
       "Do you have photos of Joan Baez in your collection?",
     );
   });

--- a/components/Search/Search.styled.ts
+++ b/components/Search/Search.styled.ts
@@ -146,6 +146,7 @@ const StyledResponseWrapper = styled("div", {
 
 const StyledTabsContent = styled(TabsContent, {
   display: "grid",
+  overflowX: "hidden",
   gridTemplateColumns: "minmax(0, 1fr) min(1120px, 100%) minmax(0, 1fr)",
 
   ">*:first-child": {

--- a/components/Search/Search.tsx
+++ b/components/Search/Search.tsx
@@ -70,13 +70,16 @@ const Search: React.FC<SearchProps> = ({ isSearchActive }) => {
     searchDispatch({
       type: "updateConversation",
       conversation: {
-        body: [
+        ref: undefined,
+        initialQuestion: searchValue,
+        turns: [
           {
             question: searchValue,
             answer: "",
+            aggregations: [],
+            works: [],
           },
         ],
-        ref: "",
       },
     });
 

--- a/context/search-context.tsx
+++ b/context/search-context.tsx
@@ -1,20 +1,10 @@
-import { Article, SearchContextStore } from "@/types/context/search-context";
-
-import { ApiResponseAggregation } from "@/types/api/response";
+import { SearchContextStore } from "@/types/context/search-context";
 import React from "react";
-import { Work } from "@nulib/dcapi-types";
 
 type Action =
   | {
-      type: "updateAggregations";
-      aggregations: ApiResponseAggregation | undefined;
-    }
-  | {
       type: "updateConversation";
-      conversation: {
-        body: Article[];
-        ref: string;
-      };
+      conversation: SearchContextStore["conversation"];
     }
   | {
       type: "updatePanel";
@@ -35,10 +25,10 @@ type SearchProviderProps = {
 };
 
 const defaultState: SearchContextStore = {
-  aggregations: {},
   conversation: {
-    body: [],
     ref: undefined,
+    initialQuestion: "",
+    turns: [],
   },
   panel: {
     interstitial: undefined,
@@ -54,12 +44,6 @@ const SearchStateContext = React.createContext<
 
 function searchReducer(state: State, action: Action) {
   switch (action.type) {
-    case "updateAggregations": {
-      return {
-        ...state,
-        aggregations: action.aggregations,
-      };
-    }
     case "updateConversation": {
       return {
         ...state,

--- a/lib/queries/aggs.test.ts
+++ b/lib/queries/aggs.test.ts
@@ -105,8 +105,6 @@ describe("buildAggs function", () => {
 
     const response = aggs.buildAggs(facets, facetFilterValue, userFacets);
 
-    console.log(JSON.stringify(response));
-
     expect(response).toEqual({
       subject: {
         filter: { bool: { must: [] } },

--- a/lib/queries/builder.ts
+++ b/lib/queries/builder.ts
@@ -39,8 +39,6 @@ export function buildQuery(obj: BuildQueryProps, isAI: boolean) {
   const must: QueryDslQueryContainer[] = [];
   let queryValue;
 
-  console.log({ aggs });
-
   // Build the "must" part of the query
   if (term) must.push(buildSearchPart(term));
 

--- a/types/context/search-context.ts
+++ b/types/context/search-context.ts
@@ -1,7 +1,5 @@
-import {
-  ApiResponseAggregation,
-  ApiResponseFilteredAggregation,
-} from "@/types/api/response";
+import { Work } from "@nulib/dcapi-types";
+import type { AggregationResultMessage } from "types/components/chat";
 
 export type ActiveTab = "stream" | "results";
 
@@ -10,11 +8,18 @@ export interface Article {
   answer: string;
 }
 
+export interface Turn extends Article {
+  aggregations: Omit<AggregationResultMessage, "type">["message"][];
+  works: Work[][];
+  renderedContent?: React.JSX.Element;
+}
+
 export interface SearchContextStore {
-  aggregations?: ApiResponseAggregation | ApiResponseFilteredAggregation;
   conversation: {
-    body: Article[];
     ref?: string;
+    /** the question that kickstarts a conversation */
+    initialQuestion: string;
+    turns: Turn[];
   };
   panel: {
     interstitial?: string;


### PR DESCRIPTION
## Summary of changes

- Updates the shape of the conversation context store (types/context/search-context.ts) for chat based conversation
- Updates the data sent via the feedback submission to reflect the new app state

## Context

Most changes are downstream of the changes in `search-contex.ts`, where the `conversation` state has been updated to this:

```ts
export interface Article {
  question: string;
  answer: string;
}

export interface Turn extends Article {
  aggregations: Omit<AggregationResultMessage, "type">["message"][];
  works: Work[][];
  renderedContent?: React.JSX.Element;
}

export interface SearchContextStore {
  conversation: {
    ref?: string;
    /** the question that kickstarts a conversation */
    initialQuestion: string;
    turns: Turn[];
  };
  panel: {
    interstitial?: string;
    open: boolean;
    query?: string;
  };
  searchFixed: boolean;
}
```

## Example

You can try it [here](https://preview-5323-feedback.dc.rdc-staging.library.northwestern.edu/), but it won't work for now as the new shape of the feedback won't be [validated in the api endpoint](https://github.com/nulib/dc-api-v2/blob/59992efb7b6de375c9d07a09552483e366d7dbab/node/src/handlers/post-chat-feedback.js#L7-L38).

**First question**:

First asked a question like this with aggs.

<img width="990" alt="agg-question" src="https://github.com/user-attachments/assets/2c83ee40-c741-4a42-922d-ea4f3223262b" />

After clicking the 👍 feedback, this is the payload:

```js
{
    "sentiment": "positive",
    "feedback": {
        "options": [],
        "text": "",
        "email": ""
    },
    "timestamp": "2025-03-10T14:59:42.963Z",
    "context": {
        "ref": "8e047a6f-9772-4d03-b67a-06511175bcfd",
        "initialQuestion": "What different kind of works are in the Berkeley Folk Music Festival collection?",
        "turns": [
            {
                "question": "What different kind of works are in the Berkeley Folk Music Festival collection?",
                "answer": "Let me explore the Berkeley Folk Music Festival collection contents.\n\nThe Berkeley Folk Music Festival collection consists primarily of visual materials, with 33,355 images forming the bulk of the archive. Let me search for some specific examples to provide more detail.\n\nThe Berkeley Folk Music Festival collection contains approximately 33,500 items spanning multiple formats:\n\n1. **Photographs** (33,355 images): The vast majority of the collection consists of photographs of folk artists and groups.\n\n2. **Audio Materials** (29 items): Sound recordings related to the festival.\n\n3. **Video Content** (1 item): A single video recording from the festival.\n\n4. **Documentary Materials**: The collection includes various printed and textual materials such as:\n   - Press clippings (like [reviews from the Berkeley Barb](https://dc.rdc-staging.library.northwestern.edu/items/761ccd38-f99a-4be2-9948-7afcd259078f) and other newspapers)\n   - Festival programs and brochures\n   - Correspondence\n   - Publicity materials\n   - Administrative documents (like [staff information sheets](https://dc.rdc-staging.library.northwestern.edu/items/57853b51-39ca-4372-adcd-347b53441ce7))\n   - Press releases (such as those for [Jubilee Concerts](https://dc.rdc-staging.library.northwestern.edu/items/c68cc988-5e3b-43ea-b505-46c65564f077))\n   - Posters and flyers\n\nThe collection documents the Berkeley Folk Music Festival from its early years through 1971, providing a comprehensive look at one of the significant folk music festivals of the American West Coast folk revival era. All materials are housed in the Charles Deering McCormick Library of Special Collections.",
                "aggregations": [
                    {
                        "doc_count_error_upper_bound": 0,
                        "sum_other_doc_count": 0,
                        "buckets": [
                            {
                                "key": "Image",
                                "doc_count": 33355
                            },
                            {
                                "key": "Audio",
                                "doc_count": 29
                            },
                            {
                                "key": "Video",
                                "doc_count": 1
                            }
                        ]
                    }
                ],
                "works": []
            }
        ]
    }
}
```

**Second question**:

Feedback on the follow up question sends back the entire conversation as well.

![search-question](https://github.com/user-attachments/assets/91910d27-b49e-4389-995c-5bb842fb28aa)


After clicking the 👍 feedback, this is the payload:

```js
{
    "sentiment": "positive",
    "feedback": {
        "options": [],
        "text": "",
        "email": ""
    },
    "timestamp": "2025-03-10T15:02:35.611Z",
    "context": {
        "ref": "8e047a6f-9772-4d03-b67a-06511175bcfd",
        "initialQuestion": "What different kind of works are in the Berkeley Folk Music Festival collection?",
        "turns": [
            {
                "question": "What different kind of works are in the Berkeley Folk Music Festival collection?",
                "answer": "Let me explore the Berkeley Folk Music Festival collection contents.\n\nThe Berkeley Folk Music Festival collection consists primarily of visual materials, with 33,355 images forming the bulk of the archive. Let me search for some specific examples to provide more detail.\n\nThe Berkeley Folk Music Festival collection contains approximately 33,500 items spanning multiple formats:\n\n1. **Photographs** (33,355 images): The vast majority of the collection consists of photographs of folk artists and groups.\n\n2. **Audio Materials** (29 items): Sound recordings related to the festival.\n\n3. **Video Content** (1 item): A single video recording from the festival.\n\n4. **Documentary Materials**: The collection includes various printed and textual materials such as:\n   - Press clippings (like [reviews from the Berkeley Barb](https://dc.rdc-staging.library.northwestern.edu/items/761ccd38-f99a-4be2-9948-7afcd259078f) and other newspapers)\n   - Festival programs and brochures\n   - Correspondence\n   - Publicity materials\n   - Administrative documents (like [staff information sheets](https://dc.rdc-staging.library.northwestern.edu/items/57853b51-39ca-4372-adcd-347b53441ce7))\n   - Press releases (such as those for [Jubilee Concerts](https://dc.rdc-staging.library.northwestern.edu/items/c68cc988-5e3b-43ea-b505-46c65564f077))\n   - Posters and flyers\n\nThe collection documents the Berkeley Folk Music Festival from its early years through 1971, providing a comprehensive look at one of the significant folk music festivals of the American West Coast folk revival era. All materials are housed in the Charles Deering McCormick Library of Special Collections.",
                "aggregations": [
                    {
                        "doc_count_error_upper_bound": 0,
                        "sum_other_doc_count": 0,
                        "buckets": [
                            {
                                "key": "Image",
                                "doc_count": 33355
                            },
                            {
                                "key": "Audio",
                                "doc_count": 29
                            },
                            {
                                "key": "Video",
                                "doc_count": 1
                            }
                        ]
                    }
                ],
                "works": []
            },
            {
                "question": "Tell me about the audio materials",
                "answer": "Let me query specifically about the audio materials in the collection.\n\nThe audio materials in the Berkeley Folk Music Festival collection include:\n\n1. **Festival Recordings**: Among the notable audio items is a series of recordings from the 1968 Festival broadcast on KPFA-FM radio. For example, [one recording](https://dc.rdc-staging.library.northwestern.edu/items/0e53eb22-46e9-4531-849a-1aa1a3f31197) from the 11th Berkeley Folk Music Festival features performances by several artists including:\n- Sam Hinton\n- Dave Fredrickson \n- Allan MacLeod\n- Dr. Humbead's New Tranquility String Band\n- Alice Stuart\n\nThis particular recording consists of 2 audio reels running 1 hour and 46 minutes in stereo format.\n\nThe collection contains 29 audio recordings in total, documenting festival performances, workshops, and broadcasts from various years of the event. These audio materials complement the extensive photographic and documentary record of the festival, helping to preserve not just the visual history but also the actual music and sounds of this significant folk music event.\n\nThe audio recordings appear to be primarily on reel-to-reel tape format, recorded at professional broadcast quality standards typical of the era (like the 7 1/2 ips speed noted in some recordings). Some of these recordings were made in collaboration with local radio stations like KPFA-FM and KQED, who helped document the festival through broadcasts and recordings.",
                "aggregations": [],
                "works": [
                    [
                        {
                            "id": "63bad26d-9985-460a-93db-b8c96fc53885",
                            "title": "Berkeley Folk Music Festival",
                            "visibility": "Public",
                            "work_type": "Image",
                            "thumbnail": "https://dcapi.rdc-staging.library.northwestern.edu/api/v2/works/63bad26d-9985-460a-93db-b8c96fc53885/thumbnail"
                        },
                        {
                            "id": "cf319978-7dfa-4320-b4ee-3a8fe0cd958f",
                            "title": "Berkeley Folk Music Festival campfire sing",
                            "visibility": "Public",
                            "work_type": "Image",
                            "thumbnail": "https://dcapi.rdc-staging.library.northwestern.edu/api/v2/works/cf319978-7dfa-4320-b4ee-3a8fe0cd958f/thumbnail"
                        },
                       // removed 18 works for brevity
                    ],
                   [
                        {
                            "id": "0e53eb22-46e9-4531-849a-1aa1a3f31197",
                            "title": "1968 Berkeley Folk Music Festival, Part 3.",
                            "visibility": "Public",
                            "work_type": "Audio",
                            "thumbnail": "https://dcapi.rdc-staging.library.northwestern.edu/api/v2/works/0e53eb22-46e9-4531-849a-1aa1a3f31197/thumbnail"
                        },
                        {
                            "id": "d0e087be-f044-4bce-957c-0ab51fc5c886",
                            "title": "Berkeley Folk Music Festival campfire sing",
                            "visibility": "Public",
                            "work_type": "Image",
                            "thumbnail": "https://dcapi.rdc-staging.library.northwestern.edu/api/v2/works/d0e087be-f044-4bce-957c-0ab51fc5c886/thumbnail"
                        },
                       // removed 18 works for brevity
                     ]
                ]
            }
        ]
    }
}
```

Note how on this second turn, two searches were performed, so in a `turn` the `works` is an `Work[][]`

## Considerations

- The api endpoint validation needs to be updated before this can work
- I'm not sure who the consumers are the feedback are so I figured sending back the too much is better than too little. We can remove any noise from the payload