### PR TITLE
Add docs to chat conversation

### DIFF
--- a/components/Chat/Chat.tsx
+++ b/components/Chat/Chat.tsx
@@ -8,7 +8,7 @@ import { StyledUnsubmitted } from "./Response/Response.styled";
 import { styled } from "@/stitches.config";
 import { useSearchState } from "@/context/search-context";
 import { v4 as uuidv4 } from "uuid";
-import { Turn } from "@/types/context/search-context";
+import InterstitialDocuments from "./Response/InterstitialDocuments";
 
 const Chat = () => {
   const { searchState, searchDispatch } = useSearchState();
@@ -39,7 +39,7 @@ const Chat = () => {
   const handleConversationCallback = (value: string) => {
     setIsStreaming(true);
 
-    if (ref && value)
+    if (ref && value) {
       searchDispatch({
         type: "updateConversation",
         conversation: {
@@ -48,13 +48,22 @@ const Chat = () => {
             ...conversation.turns,
             {
               question: value,
+              userDocs: conversation.latestDocs
+                ? conversation.latestDocs
+                : undefined,
               answer: "",
               aggregations: [],
               works: [],
             },
           ],
+          // if the user is using faceted docs in a question
+          // reset the latest docs
+          latestDocs: conversation.latestDocs
+            ? undefined
+            : conversation.latestDocs,
         },
       });
+    }
   };
 
   const handleResponseCallback = () => {
@@ -85,10 +94,17 @@ const Chat = () => {
                 key={index}
                 question={turn.question}
                 content={turn.renderedContent}
+                userDocs={turn.userDocs}
                 responseCallback={handleResponseCallback}
               />
             );
           })}
+        {conversation.latestDocs && conversation.latestDocs.length > 0 && (
+          <InterstitialDocuments
+            documents={conversation.latestDocs}
+            canRemove={true}
+          />
+        )}
         <ChatConversation
           conversationCallback={handleConversationCallback}
           isStreaming={isStreaming}

--- a/components/Chat/Conversation.tsx
+++ b/components/Chat/Conversation.tsx
@@ -6,6 +6,7 @@ import {
 import { useEffect, useRef } from "react";
 
 import { useRouter } from "next/router";
+import { useSearchState } from "@/context/search-context";
 
 interface ChatConversationProps {
   conversationCallback: (message: string) => void;
@@ -17,11 +18,16 @@ const ChatConversation: React.FC<ChatConversationProps> = ({
   isStreaming,
 }) => {
   const router = useRouter();
+  const {
+    searchState: { conversation },
+  } = useSearchState();
 
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const formRef = useRef<HTMLFormElement>(null);
 
-  const textareaPlaceholder = "Ask a followup question";
+  const textareaPlaceholder = conversation.latestDocs
+    ? "Ask about these documents"
+    : "Ask a followup question";
 
   const handleScroll = () => {
     // handle scrolling

--- a/components/Chat/Response/Images.tsx
+++ b/components/Chat/Response/Images.tsx
@@ -6,7 +6,7 @@ export const INITIAL_MAX_ITEMS = 5;
 
 const ResponseImages = ({ works }: { works: Work[] }) => {
   return (
-    <StyledImages>
+    <StyledImages className="response-images">
       {works.slice(0, INITIAL_MAX_ITEMS).map((document: Work) => (
         <GridItem key={document.id} item={document} />
       ))}

--- a/components/Chat/Response/Interstitial.tsx
+++ b/components/Chat/Response/Interstitial.tsx
@@ -83,6 +83,10 @@ const ResponseInterstitial: React.FC<ResponseInterstitialProps> = ({
     case "discover_fields":
       text = `Discovering`;
       break;
+    case "retrieve_documents":
+      const docCount = input.doc_ids.length;
+      text = `Retrieving ${docCount} document${docCount > 1 ? "s" : ""}`;
+      break;
     case "search":
       text = `Searching for <strong>${input.query}</strong>`;
       action = input.query;

--- a/components/Chat/Response/InterstitialDocuments.tsx
+++ b/components/Chat/Response/InterstitialDocuments.tsx
@@ -1,0 +1,85 @@
+import { useEffect } from "react";
+import type { SearchContextStore } from "@/types/context/search-context";
+import {
+  StyledInterstitial,
+  StyledInterstitialWrapper,
+  StyledInterstitialIcon,
+  StyledInterstitialAction,
+} from "../Response/Interstitial.styled";
+import ResponseImages from "../Response/Images";
+import { IconClear, IconSparkles } from "@/components/Shared/SVG/Icons";
+import { useSearchState } from "@/context/search-context";
+
+interface InterstitialDocumentsProps {
+  documents: NonNullable<SearchContextStore["conversation"]["latestDocs"]>;
+  canRemove: boolean;
+}
+
+const InterstitialDocuments = ({
+  documents,
+  canRemove,
+}: InterstitialDocumentsProps) => {
+  const { searchState, searchDispatch } = useSearchState();
+
+  const {
+    panel: { open, interstitial },
+    conversation,
+  } = searchState;
+
+  useEffect(() => {
+    // if the panel is being opened or there is no interstitial, exit
+    if (open || !interstitial) return;
+
+    if ("latestdocs" !== interstitial) return;
+
+    const interstitialElement = document.getElementById(
+      `interstitial-latestdocs`,
+    );
+
+    if (!interstitialElement) return;
+
+    // because the search bar is absolutely positioned,
+    // grab its height to offset the scroll position
+    const searchBar = document.getElementById("dc-search");
+    const offset = searchBar?.offsetHeight || 0;
+    const topPos =
+      interstitialElement.getBoundingClientRect().top + window.scrollY - offset;
+
+    window.scrollTo({
+      top: topPos - 25, // 25 is to offset the box-shadow
+      behavior: "smooth",
+    });
+  }, [open]);
+
+  const removeDocs = () => {
+    searchDispatch({
+      type: "updateConversation",
+      conversation: {
+        ...conversation,
+        latestDocs: undefined,
+      },
+    });
+  };
+  return (
+    <>
+      <StyledInterstitialWrapper
+        id="interstitial-latestdocs"
+        data-testid="interstitial-latestdocs"
+      >
+        <StyledInterstitial>
+          <StyledInterstitialIcon>
+            <IconSparkles />
+          </StyledInterstitialIcon>
+          Selected documents ({documents.length}):
+        </StyledInterstitial>
+        {canRemove && (
+          <StyledInterstitialAction onClick={() => removeDocs()}>
+            Remove documents <IconClear />
+          </StyledInterstitialAction>
+        )}
+      </StyledInterstitialWrapper>
+      <ResponseImages works={documents} />
+    </>
+  );
+};
+export default InterstitialDocuments;

--- a/components/Chat/Response/Response.styled.tsx
+++ b/components/Chat/Response/Response.styled.tsx
@@ -18,7 +18,7 @@ const StyledResponse = styled("article", {
   zIndex: "0",
   marginBottom: "$gr4",
 
-  "> div": {
+  "> div:not(.response-images)": {
     display: "flex",
     flexDirection: "column",
     gap: "$gr3",

--- a/components/Chat/Response/Response.tsx
+++ b/components/Chat/Response/Response.tsx
@@ -104,7 +104,7 @@ const ChatResponse: React.FC<ChatResponseProps> = ({
           <ResponseAggregations message={message.message} />
         </>
       ));
-      var foo = message.message;
+
       setTurnAggregations([...turnAggregations, message.message]);
     }
 

--- a/components/Chat/Response/Response.tsx
+++ b/components/Chat/Response/Response.tsx
@@ -15,11 +15,13 @@ import useChatSocket from "@/hooks/useChatSocket";
 import { useSearchState } from "@/context/search-context";
 import { v4 as uuidv4 } from "uuid";
 import type { Turn } from "@/types/context/search-context";
+import InterstitialDocuments from "./InterstitialDocuments";
 
 interface ChatResponseProps {
   conversationIndex: number;
   conversationRef?: string;
   question: string;
+  userDocs: Turn["userDocs"];
   content?: React.JSX.Element;
   responseCallback?: (response?: any) => void;
 }
@@ -28,6 +30,7 @@ const ChatResponse: React.FC<ChatResponseProps> = ({
   conversationIndex,
   conversationRef,
   question,
+  userDocs,
   content,
   responseCallback,
 }) => {
@@ -45,6 +48,7 @@ const ChatResponse: React.FC<ChatResponseProps> = ({
         question,
         authToken,
         conversationRef,
+        userDocs,
       );
       sendMessage(preparedQuestion);
     }
@@ -158,6 +162,9 @@ const ChatResponse: React.FC<ChatResponseProps> = ({
       data-question={question}
     >
       <StyledQuestion>{question}</StyledQuestion>
+      {userDocs && userDocs.length > 0 && (
+        <InterstitialDocuments documents={userDocs} canRemove={false} />
+      )}
       <div data-testid="response-content">
         {content ? (
           content

--- a/components/Search/Options.styled.tsx
+++ b/components/Search/Options.styled.tsx
@@ -87,6 +87,7 @@ const StyledOptions = styled("div", {
     flexGrow: "0",
     flexShrink: "1",
     height: "unset",
+    margin: "0",
 
     "@sm": {
       backgroundColor: "transparent",

--- a/components/Search/Panel.styled.tsx
+++ b/components/Search/Panel.styled.tsx
@@ -8,7 +8,7 @@ const SearchResultsLabel = styled(StyledInterstitial, {
   justifyContent: "space-between",
   width: "100%",
 
-  div: {
+  "> div": {
     display: "flex",
     alignItems: "center",
     gap: "$gr2",

--- a/components/Search/Search.styled.ts
+++ b/components/Search/Search.styled.ts
@@ -147,6 +147,7 @@ const StyledResponseWrapper = styled("div", {
 const StyledTabsContent = styled(TabsContent, {
   display: "grid",
   overflowX: "hidden",
+  overflowY: "clip",
   gridTemplateColumns: "minmax(0, 1fr) min(1120px, 100%) minmax(0, 1fr)",
 
   ">*:first-child": {
@@ -156,6 +157,7 @@ const StyledTabsContent = styled(TabsContent, {
   },
 
   ">*:nth-child(2)": {
+    minHeight: 0,
     gridColumn: "1 / 4",
     gridRow: "1",
     width: "100%",

--- a/lib/chat-helpers.ts
+++ b/lib/chat-helpers.ts
@@ -1,17 +1,36 @@
 import axios, { AxiosError } from "axios";
 
 import { DCAPI_CHAT_FEEDBACK } from "./constants/endpoints";
+import { Work } from "@nulib/dcapi-types";
+
+function mapWorksToApiDocs(works: Work[]) {
+  if (!works) {
+    return [];
+  }
+
+  return works.map((d) => {
+    return {
+      id: d.id || "",
+      title: d.title || "",
+      visibility: d.visibility || "",
+      work_type: d.work_type || "",
+      thumbnail: d.thumbnail || "",
+    };
+  });
+}
 
 const prepareQuestion = (
   questionString: string,
   authToken: string,
   conversationRef: string,
+  userDocs?: Work[],
 ) => {
   return {
     auth: authToken,
     message: "chat",
     question: questionString,
     ref: conversationRef,
+    docs: userDocs ? mapWorksToApiDocs(userDocs) : userDocs,
   };
 };
 

--- a/types/components/chat.ts
+++ b/types/components/chat.ts
@@ -69,6 +69,10 @@ export type ToolStartMessage = {
     | {
         tool: "aggregate";
         input: { agg_field: string; term_field: string; term: string };
+      }
+    | {
+        tool: "retrieve_documents";
+        input: { doc_ids: string[] };
       };
 };
 

--- a/types/context/search-context.ts
+++ b/types/context/search-context.ts
@@ -11,6 +11,8 @@ export interface Article {
 export interface Turn extends Article {
   aggregations: Omit<AggregationResultMessage, "type">["message"][];
   works: Work[][];
+  /** Docs users can send along in addition to a question */
+  userDocs?: Work[];
   renderedContent?: React.JSX.Element;
 }
 
@@ -19,6 +21,8 @@ export interface SearchContextStore {
     ref?: string;
     /** the question that kickstarts a conversation */
     initialQuestion: string;
+    /** Docs user adds to context, but not asked a question about */
+    latestDocs?: Work[];
     turns: Turn[];
   };
   panel: {


### PR DESCRIPTION
## Description

Adds the ability to add search results back into the conversation history as implemented in the [backend PR](https://github.com/nulib/dc-api-v2/pull/293)

## Summary of changes

- Adds `userDocs` to each `Turn`
- Adds `latestDocs` to the conversation history
- Users can optionally add filtered results to the chat history
- Users can remove results from history
- Users can ask about those docs specifically

## Example

Live: https://preview-5394-docs-to-convo.dc.rdc-staging.library.northwestern.edu/

Ask about a subject and go to "View results"

<img width="1319" alt="Screenshot 2025-03-24 at 4 15 48 PM" src="https://github.com/user-attachments/assets/abd8d858-9a52-4e89-a4f0-8724d59f96af" />

Filter results — will add a checkbox for "Add results to conversation". If checkbox is deselected, the user just returns to the conversation as normal

<img width="1638" alt="Screenshot 2025-03-24 at 4 16 18 PM" src="https://github.com/user-attachments/assets/367f414b-7a7a-4c66-bd22-74633fc9abda" />

Click "Back to the conversation" and return to the chat with a new interstitial. At this point nothing has been submitted to the API. The user can remove the docs if they desire. Note that the new chat prompt is "Ask about these documents".

<img width="1468" alt="Screenshot 2025-03-24 at 4 16 39 PM" src="https://github.com/user-attachments/assets/be9a72ac-f725-4dfd-bf63-bc549628ea1b" />

Ask a question about the selected documents:

<img width="1297" alt="Screenshot 2025-03-24 at 4 17 34 PM" src="https://github.com/user-attachments/assets/0855efa4-4b70-47b1-9af8-488597546b1b" />


## Notes

- There is a discrepancy where the `retrieve_documents` tool message doesn't seem to search for all the documents (or it isn't indicating that it is)

## Loose ends

Just jotting down things to come back to, no action needed now:
- docs in Feedback?
- naming conventions — docs vs results vs ???
- filter styling is still cut off