### PR TITLE
Address timing issue related to initial question.

### DIFF
--- a/components/Chat/Chat.tsx
+++ b/components/Chat/Chat.tsx
@@ -7,38 +7,18 @@ import Container from "@/components/Shared/Container";
 import { StyledUnsubmitted } from "./Response/Response.styled";
 import { styled } from "@/stitches.config";
 import { useSearchState } from "@/context/search-context";
-import { v4 as uuidv4 } from "uuid";
 
 const Chat = () => {
-  const { searchState, searchDispatch } = useSearchState();
-
-  const { conversation } = searchState;
-
-  const ref = conversation.ref;
-  /** get initial question  */
-  const initialQuestion = conversation.initialQuestion;
-
   const [isStreaming, setIsStreaming] = useState(false);
-
-  useEffect(() => {
-    if (!initialQuestion) return;
-
-    const conversationRef = uuidv4();
-    setIsStreaming(true);
-
-    searchDispatch({
-      type: "updateConversation",
-      conversation: {
-        ...conversation,
-        ref: conversationRef,
-      },
-    });
-  }, [initialQuestion]);
+  const {
+    searchState: { conversation },
+    searchDispatch,
+  } = useSearchState();
 
   const handleConversationCallback = (value: string) => {
     setIsStreaming(true);
 
-    if (ref && value) {
+    if (conversation.ref && value) {
       searchDispatch({
         type: "updateConversation",
         conversation: {
@@ -63,7 +43,7 @@ const Chat = () => {
     setIsStreaming(false);
   };
 
-  if (!initialQuestion)
+  if (!conversation?.initialQuestion)
     return (
       <Container>
         <StyledUnsubmitted>{AI_SEARCH_UNSUBMITTED}</StyledUnsubmitted>
@@ -73,9 +53,9 @@ const Chat = () => {
   return (
     <Container>
       <StyledChat
-        data-conversation-initial={initialQuestion}
+        data-conversation-initial={conversation.initialQuestion}
         data-conversation-length={conversation.turns.length}
-        data-conversation-ref={ref}
+        data-conversation-ref={conversation.ref}
       >
         {conversation.turns
           .filter((turn) => turn.question)
@@ -83,8 +63,8 @@ const Chat = () => {
             return (
               <ChatResponse
                 conversationIndex={index}
-                conversationRef={ref}
-                key={index}
+                conversationRef={conversation.ref}
+                key={`${conversation.ref}--${index}`}
                 question={turn.question}
                 content={turn.renderedContent}
                 context={turn.context}

--- a/components/Chat/Response/Response.tsx
+++ b/components/Chat/Response/Response.tsx
@@ -10,12 +10,12 @@ import ResponseImages from "@/components/Chat/Response/Images";
 import ResponseInterstitial from "@/components/Chat/Response/Interstitial";
 import ResponseMarkdown from "@/components/Chat/Response/Markdown";
 import ResponseOptions from "./Options";
+import Stack from "../Stack/Stack";
+import type { Turn } from "@/types/context/search-context";
 import { prepareQuestion } from "@/lib/chat-helpers";
 import useChatSocket from "@/hooks/useChatSocket";
 import { useSearchState } from "@/context/search-context";
 import { v4 as uuidv4 } from "uuid";
-import type { Turn } from "@/types/context/search-context";
-import Stack from "../Stack/Stack";
 
 interface ChatResponseProps {
   conversationIndex: number;

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -49,7 +49,7 @@ const SearchPage: NextPage = () => {
   const { user } = React.useContext(UserContext);
   const { isChecked: isAI } = useGenerativeAISearchToggle();
   const { searchState } = useSearchState();
-  const { panel } = searchState;
+  const { conversation, panel } = searchState;
 
   const [activeTab, setActiveTab] = useState<ActiveTab>("results");
 
@@ -250,7 +250,7 @@ const SearchPage: NextPage = () => {
                   height: panel.open ? 0 : "auto",
                 }}
               >
-                <Chat />
+                <Chat key={conversation.ref} />
               </div>
               <SearchPanel />
             </StyledTabsContent>


### PR DESCRIPTION
## What does this do?

This addresses a timing issue related to an initial question, where the question was only set in the search context if the user was already on the search page and refreshed. All logic for setting of the initial question and the conversation ref (a uuid) has now been moved to the Search component. Now the initial question is only set in the case of a form submission in the Search.tsx component.

Additionally, if the Generative AI checkbox is toggled true in this component, the conversation ref is reset, creating a new conversation. This flushing of the ref was necessary in cases of a user toggling back and forth between semantic conversations and legacy search.

## How should we review?

Go to https://preview-initial-conversation-question.dc.rdc-staging.library.northwestern.edu/

A) Homepage start

 - Search something, ex: `jim roberts`
 - Set AI Gen checkbox `true`
 - Submit
 - Question should render in purple bubble
 - Answer should be streaming in
 
B) Search page start

 - Go to search page first, see legacy results
 - Set AI Gen checkbox `true`
 - Should toggle to chat view
 - Ask a question
 - Question should render in purple bubble
 - Answer should be streaming in

C) Followup questions should function as expected
D) Search new question from Top search bar should reset conversation as expected