### PR TITLE
Add link to system prompt

### DIFF
--- a/components/Chat/Conversation.tsx
+++ b/components/Chat/Conversation.tsx
@@ -4,10 +4,11 @@ import {
   StyledResetButton,
 } from "./Conversation.styled";
 import { useEffect, useRef } from "react";
-
+import { styled } from "@/stitches.config";
 import { useRouter } from "next/router";
 import { useSearchState } from "@/context/search-context";
 import Stack from "./Stack/Stack";
+import { AI_SYS_PROMPT_MSG } from "@/lib/constants/common";
 
 interface ChatConversationProps {
   conversationCallback: (message: string) => void;
@@ -95,40 +96,45 @@ const ChatConversation: React.FC<ChatConversationProps> = ({
 
   return (
     <StyledChatConversation data-testid="chat-conversation">
-      <form
-        onSubmit={handleSubmit}
-        ref={formRef}
-        data-is-focused="false"
-        data-is-streaming={isStreaming}
-      >
-        <textarea
-          ref={textareaRef}
-          onKeyDown={handleKeyDown}
-          placeholder={textareaPlaceholder}
-          onFocus={handleFocus}
-          onBlur={handleFocus}
-        ></textarea>
-        {conversation.context?.works &&
-          conversation.context.works.length > 0 && (
-            <Stack
-              context={conversation.context}
-              isDismissable
-              dismissCallback={handleStackDismiss}
-            />
-          )}
-        <button type="submit" disabled={isStreaming}>
-          {isStreaming ? (
-            <>
-              Responding
-              <IconSparkles />
-            </>
-          ) : (
-            <>
-              Reply <IconReply />
-            </>
-          )}
-        </button>
-      </form>
+      <div>
+        <form
+          onSubmit={handleSubmit}
+          ref={formRef}
+          data-is-focused="false"
+          data-is-streaming={isStreaming}
+        >
+          <textarea
+            ref={textareaRef}
+            onKeyDown={handleKeyDown}
+            placeholder={textareaPlaceholder}
+            onFocus={handleFocus}
+            onBlur={handleFocus}
+          ></textarea>
+          {conversation.context?.works &&
+            conversation.context.works.length > 0 && (
+              <Stack
+                context={conversation.context}
+                isDismissable
+                dismissCallback={handleStackDismiss}
+              />
+            )}
+          <button type="submit" disabled={isStreaming}>
+            {isStreaming ? (
+              <>
+                Responding
+                <IconSparkles />
+              </>
+            ) : (
+              <>
+                Reply <IconReply />
+              </>
+            )}
+          </button>
+        </form>
+        <StyledSystemPrompt>
+          <AI_SYS_PROMPT_MSG />
+        </StyledSystemPrompt>
+      </div>
       <StyledResetButton onClick={handleClearConversation}>
         Start new conversation
         <IconRefresh />
@@ -136,5 +142,15 @@ const ChatConversation: React.FC<ChatConversationProps> = ({
     </StyledChatConversation>
   );
 };
+
+export const StyledSystemPrompt = styled("p", {
+  margin: 0,
+  fontSize: "$gr1",
+  color: "$black50",
+  marginBlockStart: "$gr1",
+  a: {
+    cursor: "pointer",
+  },
+});
 
 export default ChatConversation;

--- a/components/Chat/Feedback/Feedback.tsx
+++ b/components/Chat/Feedback/Feedback.tsx
@@ -259,11 +259,11 @@ const StyledChatFeedbackForm = styled("form", {
   variants: {
     isExpanded: {
       true: {
-        opacity: "1",
+        visibility: "visible",
         height: "auto",
       },
       false: {
-        opacity: "0",
+        visibility: "hidden",
         height: "0",
       },
     },

--- a/components/Search/GenerativeAIToggle.tsx
+++ b/components/Search/GenerativeAIToggle.tsx
@@ -4,6 +4,7 @@ import {
   AI_DISCLAIMER,
   AI_LOGIN_ALERT,
   AI_TOGGLE_LABEL,
+  AI_SYS_PROMPT_MSG,
 } from "@/lib/constants/common";
 import {
   CheckboxIndicator,
@@ -32,7 +33,12 @@ function GenerativeAITooltip() {
         <Tooltip.Portal>
           <TooltipContent side="bottom" sideOffset={3} collisionPadding={19}>
             <TooltipArrow />
-            <TooltipBody>{AI_DISCLAIMER}</TooltipBody>
+            <TooltipBody>
+              {AI_DISCLAIMER}
+              <p>
+                <AI_SYS_PROMPT_MSG />
+              </p>
+            </TooltipBody>
           </TooltipContent>
         </Tooltip.Portal>
       </Tooltip.Root>

--- a/lib/constants/common.tsx
+++ b/lib/constants/common.tsx
@@ -2,5 +2,19 @@ export const AI_DISCLAIMER = `This is a preview of Digital Collection's semantic
 export const AI_LOGIN_ALERT = `You must be logged in with a Northwestern NetID to use the Generative AI search feature.`;
 export const AI_SEARCH_UNSUBMITTED = `What can I help you find? Try searching for "john cage scrapbooks" or "who played at the Berkeley Folk Music Festival in 1965?"`;
 export const AI_TOGGLE_LABEL = "Use Generative AI";
+export const AI_SYS_PROMPT_MSG = () => (
+  <span className="ai-sys-prompt-msg">
+    Curious how this works? Click{" "}
+    <a
+      href="https://github.com/nulib/dc-api-v2/blob/main/chat/src/agent/search_agent.py#:~:text=DEFAULT_SYSTEM_MESSAGE"
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label="Learn more about the AI system prompt"
+    >
+      here
+    </a>
+    .
+  </span>
+);
 export const AI_K_VALUE = 40;
 export const SEARCH_RESULTS_PER_PAGE = 40;


### PR DESCRIPTION
## Summary of changes

- Adds a link to the current system prompt (1) in the Gen AI tooltip (2) below the user input area

## Examples

Below the user input:
<img width="1240" alt="image" src="https://github.com/user-attachments/assets/7252a02b-0ea8-4845-ab32-d0b7f4f3640c" />

In the tooltip:

<img width="516" alt="image" src="https://github.com/user-attachments/assets/d8db0c5d-25f1-4803-a9d6-d779e34a8713" />


## Notes

- I added it a constant instead of a new component because it didn't feel important enough to be a component (original vibe coding) or have state or have children, but also if you prefer it be inside of `/components` I'm happy to change that easily.
- I let the parents control the styling so that it would match the tooltip styling better, but we can also keep it consistently styled wherever it is
- Also updated the feedback form to `visibility: "hidden"` instead of `opacity: 0` which improves keyboard navigation