### PR TITLE
Adjust DC Next for new token scopes configuration

### DIFF
--- a/components/Clover/ViewerWrapper.test.tsx
+++ b/components/Clover/ViewerWrapper.test.tsx
@@ -10,10 +10,14 @@ const userContextValue = {
     isReadingRoom: false,
     name: "Joan Doe",
     sub: "jdoe2399",
+    isInstitution: true,
+    scopes: ["read:Public", "read:Institution", "read:Published", "chat"],
+    primaryAffiliation: "staff",
+    provider: "nusso",
   },
 };
 const readingRoomMessage =
-  /You have access to Work because you are in the reading room/i;
+  /You have access to this Work because you are in the reading room/i;
 
 describe("WorkViewerWrapper", () => {
   it("renders a wrapping element for Clover", async () => {
@@ -31,7 +35,7 @@ describe("WorkViewerWrapper", () => {
     render(
       <UserContext.Provider value={readingUserContext}>
         <WorkViewerWrapper
-          isWorkRestricted={true}
+          isWorkReadingRoomOnly={true}
           manifestId="http://testing.com"
         />
       </UserContext.Provider>,
@@ -47,7 +51,7 @@ describe("WorkViewerWrapper", () => {
     render(
       <UserContext.Provider value={readingUserContext}>
         <WorkViewerWrapper
-          isWorkRestricted={false}
+          isWorkReadingRoomOnly={false}
           manifestId="http://testing.com"
         />
       </UserContext.Provider>,

--- a/components/Clover/ViewerWrapper.tsx
+++ b/components/Clover/ViewerWrapper.tsx
@@ -24,13 +24,13 @@ export const CloverViewer = dynamic(
 
 interface WrapperProps {
   manifestId: Work["iiif_manifest"];
-  isWorkRestricted?: boolean;
+  isWorkReadingRoomOnly?: boolean;
   viewerOptions?: ViewerConfigOptions;
 }
 
 const WorkViewerWrapper: React.FC<WrapperProps> = ({
   manifestId,
-  isWorkRestricted,
+  isWorkReadingRoomOnly,
   viewerOptions = {},
 }) => {
   const userAuth = React.useContext(UserContext);
@@ -88,11 +88,13 @@ const WorkViewerWrapper: React.FC<WrapperProps> = ({
             options={options}
           />
         )}
-        {isWorkRestricted && userAuth?.user?.isReadingRoom && (
+        {isWorkReadingRoomOnly && (
           <Announcement>
             <AnnouncementContent>
               <IconInfo />
-              <p>You have access to Work because you are in the reading room</p>
+              <p>
+                You have access to this Work because you are in the reading room
+              </p>
             </AnnouncementContent>
           </Announcement>
         )}

--- a/components/Grid/Item.tsx
+++ b/components/Grid/Item.tsx
@@ -16,9 +16,9 @@ const GridItem: React.FC<GridItemProps> = ({ item, isFeatured }) => {
   const userContext = useContext(UserContext);
 
   const isRestricted = (item: SearchShape): boolean => {
-    const { visibility } = item;
-    if (!userContext?.user?.isLoggedIn && visibility !== "Public") return true;
-    return false;
+    return !(
+      userContext?.user?.scopes?.includes(`read:${item?.visibility}`) ?? false
+    );
   };
 
   useEffect(() => {

--- a/components/Work/ActionsDialog/DownloadAndShare/DownloadAndShare.tsx
+++ b/components/Work/ActionsDialog/DownloadAndShare/DownloadAndShare.tsx
@@ -33,12 +33,9 @@ const DownloadAndShare: React.FC = () => {
   const router = useRouter();
   const isSharedLinkPage = router.pathname.includes("/shared");
 
-  const { isUserLoggedIn, isWorkInstitution, isWorkRestricted } =
-    useWorkAuth(work);
+  const { isWorkPrivate, isWorkInstitution } = useWorkAuth(work);
 
-  const showEmbedWarning = Boolean(
-    isWorkRestricted || (isUserLoggedIn && isWorkInstitution),
-  );
+  const showEmbedWarning = Boolean(isWorkPrivate || isWorkInstitution);
 
   useEffect(() => {
     if (manifest?.items && Array.isArray(manifest?.items)) {

--- a/components/Work/ActionsDialog/DownloadAndShare/EmbedResources.test.tsx
+++ b/components/Work/ActionsDialog/DownloadAndShare/EmbedResources.test.tsx
@@ -5,17 +5,30 @@ import React from "react";
 import { manifest } from "@/mocks/work-page/download-and-share";
 import { work1 } from "@/mocks/work-page/work1";
 
+import { UserContext } from "@/context/user-context";
+
+const userContextValue = {
+  user: {
+    isLoggedIn: false,
+    scopes: ["read:Public", "read:Published"],
+    isReadingRoom: false,
+    isInstitution: false,
+  },
+};
+
 const alternateFormatItems = manifest.rendering ? [...manifest.rendering] : [];
 
 describe("EmbedResources", () => {
   it("should render the Download and Embed section with standard images ", () => {
     render(
-      <EmbedResources
-        manifest={manifest}
-        alternateFormatItems={[]}
-        showEmbedWarning={false}
-        work={work1}
-      />,
+      <UserContext.Provider value={userContextValue}>
+        <EmbedResources
+          manifest={manifest}
+          alternateFormatItems={[]}
+          showEmbedWarning={false}
+          work={work1}
+        />
+      </UserContext.Provider>,
     );
     expect(
       screen.getByRole("heading", { name: "Download and Embed" }),
@@ -39,12 +52,14 @@ describe("EmbedResources", () => {
 
   it("should render the Download and Embed section with alternate formats. It should also include 'pdf' in the link if it's a PDF mime/type", () => {
     render(
-      <EmbedResources
-        manifest={manifest}
-        alternateFormatItems={alternateFormatItems}
-        showEmbedWarning={false}
-        work={work1}
-      />,
+      <UserContext.Provider value={userContextValue}>
+        <EmbedResources
+          manifest={manifest}
+          alternateFormatItems={alternateFormatItems}
+          showEmbedWarning={false}
+          work={work1}
+        />
+      </UserContext.Provider>,
     );
 
     expect(

--- a/components/Work/ActionsDialog/DownloadAndShare/EmbedResources.tsx
+++ b/components/Work/ActionsDialog/DownloadAndShare/EmbedResources.tsx
@@ -46,7 +46,7 @@ const EmbedResources: React.FC<EmbedResourcesProps> = ({
 }) => {
   const router = useRouter();
   const [imageCanvases, setImageCanvases] = React.useState<Canvas[]>([]);
-  const { isWorkRestricted } = useWorkAuth(work);
+  const { userCanRead } = useWorkAuth(work);
   const isSharedLinkPage = router.pathname.includes("/shared");
 
   React.useEffect(() => {
@@ -62,13 +62,13 @@ const EmbedResources: React.FC<EmbedResourcesProps> = ({
     <EmbedResourcesWrapper>
       <Heading as="h3">Download and Embed</Heading>
 
-      {isWorkRestricted && !isSharedLinkPage && (
+      {!userCanRead && !isSharedLinkPage && (
         <Announcement>
           Download requires Northwestern University NetID authentication{" "}
         </Announcement>
       )}
 
-      {(!isWorkRestricted || isSharedLinkPage) && (
+      {(userCanRead || isSharedLinkPage) && (
         <>
           {alternateFormatItems && alternateFormatItems.length > 0 && (
             <>

--- a/context/user-context.tsx
+++ b/context/user-context.tsx
@@ -16,18 +16,24 @@ const UserProvider = ({ children }: { children: ReactNode }) => {
       if (!result) return;
       const {
         email,
+        isInstitution = false,
         isLoggedIn = false,
         isReadingRoom = false,
         name,
         primaryAffiliation,
+        provider,
+        scopes,
         sub,
       } = result;
       setUser({
         email,
+        isInstitution,
         isLoggedIn,
         isReadingRoom,
         name,
         primaryAffiliation,
+        provider,
+        scopes,
         sub,
       });
     });

--- a/hooks/useWorkAuth.ts
+++ b/hooks/useWorkAuth.ts
@@ -9,15 +9,23 @@ const useWorkAuth = (work: Work | null | undefined) => {
   const isWorkPrivate = work?.visibility === "Private";
   const isWorkPublic = work?.visibility === "Public";
 
-  const isWorkRestricted =
-    isWorkPrivate || (!isUserLoggedIn && isWorkInstitution);
+  const publishedStatus = work?.published ? "Published" : "Unpublished";
+  const userCanRead =
+    userAuthContext?.user?.scopes.includes(`read:${work?.visibility}`) &&
+    userAuthContext?.user?.scopes.includes(`read:${publishedStatus}`);
+
+  const isWorkReadingRoomOnly =
+    userAuthContext?.user?.isReadingRoom &&
+    (isWorkPrivate ||
+      (isWorkInstitution && !userAuthContext?.user?.isInstitution));
 
   return {
     isUserLoggedIn,
     isWorkInstitution,
     isWorkPrivate,
     isWorkPublic,
-    isWorkRestricted,
+    isWorkReadingRoomOnly,
+    userCanRead,
   };
 };
 

--- a/lib/work-helpers.ts
+++ b/lib/work-helpers.ts
@@ -21,18 +21,6 @@ export async function getWork(id: string) {
   }
 }
 
-export async function getWorkManifest(id: string) {
-  try {
-    const response = await apiGetRequest({
-      url: `${DC_API_SEARCH_URL}/works/${id}?as=iiif`,
-    });
-    return response;
-  } catch (err) {
-    console.error("Error getting the work", id);
-    return null;
-  }
-}
-
 export interface WorkSliders {
   iiifCollectionId: string;
   customViewAll: string;

--- a/pages/embedded-viewer/[manifestId].tsx
+++ b/pages/embedded-viewer/[manifestId].tsx
@@ -18,7 +18,7 @@ interface EmbeddedViewerPageProps {
 
 const EmbeddedViewerPage: NextPage<EmbeddedViewerPageProps> = ({ work }) => {
   const router = useRouter();
-  const { isWorkRestricted } = useWorkAuth(work);
+  const { userCanRead } = useWorkAuth(work);
   const thumbnail = work?.thumbnail || "";
 
   const searchParams = getUrlSearchParams(decodeURIComponent(router.asPath));
@@ -49,7 +49,7 @@ const EmbeddedViewerPage: NextPage<EmbeddedViewerPageProps> = ({ work }) => {
 
   return (
     <>
-      {!isWorkRestricted ? (
+      {userCanRead ? (
         <WorkViewerWrapper
           manifestId={work.iiif_manifest}
           viewerOptions={viewerOptions}

--- a/pages/items/[id].tsx
+++ b/pages/items/[id].tsx
@@ -43,11 +43,10 @@ const WorkPage: NextPage<WorkPageProps> = ({
   const userAuthContext = useContext(UserContext);
   const [work, setWork] = useState<Work>();
   const [manifest, setManifest] = useState<Manifest>();
-  const { isWorkRestricted } = useWorkAuth(work);
+  const { userCanRead, isWorkReadingRoomOnly } = useWorkAuth(work);
   const router = useRouter();
   const { isChecked: isAI } = useGenerativeAISearchToggle();
 
-  const isReadingRoom = userAuthContext?.user?.isReadingRoom;
   const related = work ? getWorkSliders(work, isAI) : [];
   const collectionWorkTypeCounts =
     collectionWorkCounts &&
@@ -100,13 +99,13 @@ const WorkPage: NextPage<WorkPageProps> = ({
         {!isLoading && work && manifest && (
           <WorkProvider initialState={{ manifest: manifest, work: work }}>
             <ErrorBoundary FallbackComponent={ErrorFallback}>
-              {work.iiif_manifest && (isReadingRoom || !isWorkRestricted) && (
+              {work.iiif_manifest && userCanRead && (
                 <WorkViewerWrapper
                   manifestId={work.iiif_manifest}
-                  isWorkRestricted={isWorkRestricted}
+                  isWorkReadingRoomOnly={isWorkReadingRoomOnly}
                 />
               )}
-              {work && !isReadingRoom && isWorkRestricted && (
+              {work && !userCanRead && (
                 <WorkRestrictedDisplay
                   thumbnail={work.thumbnail}
                   workId={work.id}

--- a/types/context/user.ts
+++ b/types/context/user.ts
@@ -1,13 +1,16 @@
 export type User = {
-  sub: string;
-  name: string;
-  primaryAffiliation: string;
-  email: string;
+  sub?: string;
+  name?: string;
+  primaryAffiliation?: string;
+  email?: string;
   isLoggedIn: boolean;
   isReadingRoom: boolean;
   iat?: number;
   exp?: number;
   iss?: string;
+  scopes: string[];
+  provider?: string;
+  isInstitution: boolean;
 };
 
 export type UserContext = {


### PR DESCRIPTION
### Summary

Along with this [DCAPI change](https://github.com/nulib/dc-api-v2/pull/314), the JWT now has `scopes` which define what the user can access. 

```
  read:Public
  read:Published
  read:Institution
  read:Private
  read:Unpublished
  chat
```

Additionally there has been an `isInstitution` claim added to distinguish between NUSSO and MagicLink logins

This work uses these scopes as much as possible and removes logic from front end.

### Specific Changes in this PR

- MagicLink users should behave as anonymous users except for chat access
  - see locks by thumbnails in search results for Institution works
  - See blurred bg image instead of Clover viewer for Institution works
  - Same Download and Share Tab restrictions as anonymous users
  - Respect existing Reading Room restrictions

### How to test

- Run dev app against staging (or local) API
- Check anonymous, Northwestern and MagicLink (& reading room. if possible) users for appropriate access to works across the site
