### PR TITLE
Hide magic link option if user is already signed in with a magic link

### DIFF
--- a/components/Shared/AuthDialog.test.tsx
+++ b/components/Shared/AuthDialog.test.tsx
@@ -184,5 +184,30 @@ describe("AuthDialog", () => {
         expect(magicLinkButton).toHaveClass(/isDanger/);
       });
     });
+
+    it("should not display the magic link option if the user is logged in with the magic link", async () => {
+      const userContextWithMagicLink: UserContextType = {
+        ...defaultUserContext,
+        user: {
+          isInstitution: false,
+          isLoggedIn: true,
+          isReadingRoom: false,
+          scopes: [],
+          provider: "magic",
+        },
+      };
+      render(withUserProvider(<AuthDialog />, userContextWithMagicLink));
+
+      // useEfect will be called immediately, so we can check if the API was called
+      await waitFor(() => {
+        expect(mockedAxios.get).toHaveBeenCalled();
+      });
+
+      // let the final useEffect run
+      await waitFor(() => {
+        const magicLinkSection = screen.queryByTestId("magic-link");
+        expect(magicLinkSection).not.toBeInTheDocument();
+      });
+    });
   });
 });

--- a/components/Shared/AuthDialog.tsx
+++ b/components/Shared/AuthDialog.tsx
@@ -21,7 +21,7 @@ import { apiGetRequest } from "@/lib/dc-api";
 import axios from "axios";
 
 export default function AuthDialog() {
-  const { closeSignInModal, isSignInModalOpen } = useContext(UserContext);
+  const { closeSignInModal, isSignInModalOpen, user } = useContext(UserContext);
   const router = useRouter();
   const [ssoUrl, setSsoUrl] = useState("");
   const [magicLinkResponse, setMagicLinkResponse] = useState<
@@ -80,6 +80,15 @@ export default function AuthDialog() {
         setShouldRenderMagicLink(false);
       });
   }, []);
+
+  useEffect(() => {
+    // If a user is logged in via magic link, we don't want to show the magic link option
+    // Note: getUser() in UserContext and the axios call above are both async
+    // so this useEffect tracks both values in orders to run after they have completed.
+    if (user && user.isLoggedIn && user.provider === "magic") {
+      setShouldRenderMagicLink(false);
+    }
+  }, [shouldRenderMagicLink, user]);
 
   useEffect(() => {
     if (!window) return;


### PR DESCRIPTION
## Description

Hides the magic link option for sign in if the user is already signed in via a magic link

Though the main signin link in the header is hidden, on protected works, a sign in link is shown prompting signin with Net ID. If a user used a magic link, we want to ensure they do not see that option again, reinforcing that they need to use a Net ID.

## Test

Preview: http://preview-already-signed-in.dc.rdc-staging.library.northwestern.edu/

- sign in with a magic link
- Go to a restricted work
- Click on the "sign in" link in the restricted content banner