### PR TITLE
Update how View as IIIF construct urls

### DIFF
--- a/lib/dc-api.test.ts
+++ b/lib/dc-api.test.ts
@@ -38,9 +38,9 @@ describe("iiifSearchUri", () => {
     const params = new URLSearchParams(uri.search);
 
     // check that the facets are appended as params
-    expect(params.get("query")).toEqual("Muddy Waters");
+    expect(params.get("query")).toEqual(
+      'Muddy Waters AND work_type:"Image" AND genre.label:"photographs"',
+    );
     expect(params.get("as")).toEqual("iiif");
-    expect(params.get("workType")).toEqual("Image");
-    expect(params.get("genre")).toEqual("photographs");
   });
 });


### PR DESCRIPTION
## Summary

Updates how the "View as IIIF" links are constructed to match the `/search` query syntax.

## Testing

Go to: https://preview-5561-search-iiif.dc.rdc-staging.library.northwestern.edu/search

Create a complex search, e.g.

https://preview-5561-search-iiif.dc.rdc-staging.library.northwestern.edu/search?q=arab&genre=black-and-white+photographs&subject=Egypt--Deir+el-Bahri+Site&subject=Mentuhotep+II%2C+King+of+Egypt

This example has:
- a plain query: `q=arab`
- different faceted fields: `genre=black-and-white+photographs&subject=Egypt--Deir+el-Bahri+Site`
- two terms that are the same field with different values `subject=Egypt--Deir+el-Bahri+Site&subject=Mentuhotep+II%2C+King+of+Egypt`

The resulting API url will look like this:

https://dcapi.rdc-staging.library.northwestern.edu/api/v2/search?query=arab+AND+genre.label%3A%22black-and-white+photographs%22+AND+subject.label%3A%22Egypt--Deir+el-Bahri+Site%22+AND+subject.label%3A%22Mentuhotep+II%2C+King+of+Egypt%22&size=40&as=iiif