### PR TITLE
Wrap query value with `(` and `)` characters.

### DIFF
--- a/lib/dc-api.test.ts
+++ b/lib/dc-api.test.ts
@@ -13,7 +13,7 @@ describe("iiifSearchUri", () => {
     expect(DC_API_SEARCH_URL).toContain(uri.pathname);
 
     // check that the query string has the expected params
-    expect(params.get("query")).toEqual("Joan Baez");
+    expect(params.get("query")).toEqual("(Joan Baez)");
     expect(params.get("as")).toEqual("iiif");
   });
 
@@ -23,7 +23,7 @@ describe("iiifSearchUri", () => {
     const params = new URLSearchParams(uri.search);
 
     // check that the size param is set to 100
-    expect(params.get("query")).toEqual("John Fahey");
+    expect(params.get("query")).toEqual("(John Fahey)");
     expect(params.get("as")).toEqual("iiif");
     expect(params.get("size")).toEqual("100");
   });
@@ -39,7 +39,7 @@ describe("iiifSearchUri", () => {
 
     // check that the facets are appended as params
     expect(params.get("query")).toEqual(
-      'Muddy Waters AND work_type:"Image" AND genre.label:"photographs"',
+      '(Muddy Waters) AND work_type:"Image" AND genre.label:"photographs"',
     );
     expect(params.get("as")).toEqual("iiif");
   });

--- a/lib/dc-api.ts
+++ b/lib/dc-api.ts
@@ -1,12 +1,13 @@
 import { DCAPI_ENDPOINT, DC_API_SEARCH_URL } from "./constants/endpoints";
 import axios, {
   AxiosError,
-  RawAxiosRequestHeaders,
   AxiosResponse,
+  RawAxiosRequestHeaders,
 } from "axios";
-import { getFacetById } from "@/lib/utils/facet-helpers";
+
 import type { ApiSearchRequestBody } from "@/types/api/request";
 import { NextRouter } from "next/router";
+import { getFacetById } from "@/lib/utils/facet-helpers";
 
 interface ApiGetRequestParams {
   url: string;
@@ -95,7 +96,7 @@ function iiifSearchUri(query: NextRouter["query"], size?: number): string {
 
   const queries = Object.keys(query).map((key) => {
     if (key === "q") {
-      return query[key];
+      return `(${query[key]})`;
     }
 
     const facet = getFacetById(key);


### PR DESCRIPTION
## What does this do?

There was an issue where queries compounding with facets were not returning accurate results for IIIF Collections. This wraps the query value in a `(` and `)` characters to syntactically seperate the string from the `AND` query string part that follows.
 
Essentially, this makes a query that would have been...
 
```
query=big mama thornon and genre.label:"brochures"
```

...output as:

```
query=(big mama thornon) AND genre.label:"brochures"
```

Which helps translates a collection that would have been empty as;
https://api.dc.library.northwestern.edu/api/v2/search?query=big+mama+thornon+AND+genre.label%3A%22brochures%22&size=40&as=iiif

to:

https://dcapi.rdc-staging.library.northwestern.edu/api/v2/search?query=%28big+mama+thornon%29+AND+genre.label%3A%22brochures%22&size=40&as=iiif

## How should we review?

1. Go to preview branch on https://preview-hotfix-iiif-search-query-string.dc.rdc-staging.library.northwestern.edu/search?q=big+mama+thornon&genre=brochures
2. Note that I have search for "big mama thornon" (note the typo) and faceted on the **Genre** _brochures_
3. Click the **View as IIIF** dropdown. View in Theseus and other viewers.

Note that these same steps in production DC https://dc.library.northwestern.edu/search?q=big+mama+thornon&genre=brochures do not return the IIIF Collection as expected.
