### PR TITLE
Update clover deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@radix-ui/react-switch": "^1.0.1",
         "@radix-ui/react-tabs": "^1.0.1",
         "@radix-ui/react-tooltip": "^1.0.7",
-        "@samvera/clover-iiif": "^2.16.8",
+        "@samvera/clover-iiif": "^2.16.10",
         "@samvera/image-downloader": "^1.1.6",
         "@stitches/react": "^1.2.6",
         "axios": "^1.2.2",
@@ -5031,9 +5031,9 @@
       "license": "MIT"
     },
     "node_modules/@samvera/clover-iiif": {
-      "version": "2.16.8",
-      "resolved": "https://registry.npmjs.org/@samvera/clover-iiif/-/clover-iiif-2.16.8.tgz",
-      "integrity": "sha512-eZUkvd2yyCNfmtjDkor/nxIMQmsuMHp8IKP/3LrIy4HcJO8qJWWTGXAkqRtRGIkJqL6x5HcjaL5KvNPdoMsTHA==",
+      "version": "2.16.10",
+      "resolved": "https://registry.npmjs.org/@samvera/clover-iiif/-/clover-iiif-2.16.10.tgz",
+      "integrity": "sha512-/tu4oX9EsE12gDgena05sLLlaJtUjsYkt8UK8P03XRbE0RXbfEFNSNZ1pMNiRDB+f5eMwpgOW9Dob0XXEublsQ==",
       "dependencies": {
         "@iiif/helpers": "^1.2.19",
         "@iiif/parser": "^2.1.4",
@@ -5061,7 +5061,8 @@
         "react-lazy-load-image-component": "^1.6.2",
         "sanitize-html": "^2.13.1",
         "swiper": "^9.0.0",
-        "uuid": "^9.0.1"
+        "uuid": "^9.0.1",
+        "vtt.js": "^0.13.0"
       },
       "peerDependencies": {
         "swiper": "^9.0.0"
@@ -17898,6 +17899,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/vtt.js": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/vtt.js/-/vtt.js-0.13.0.tgz",
+      "integrity": "sha512-t0OJvTmsryCOIHdLWmUPx6V3e0MRGaZMp0Cr5DETWrWNfg9RCHcQlF7X7zNF4mQxhtkyiVKOefdSErSB/KWgOA=="
     },
     "node_modules/w3c-xmlserializer": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@radix-ui/react-switch": "^1.0.1",
     "@radix-ui/react-tabs": "^1.0.1",
     "@radix-ui/react-tooltip": "^1.0.7",
-    "@samvera/clover-iiif": "^2.16.8",
+    "@samvera/clover-iiif": "^2.16.10",
     "@samvera/image-downloader": "^1.1.6",
     "@stitches/react": "^1.2.6",
     "axios": "^1.2.2",


### PR DESCRIPTION
## What does this do?

This updates Clover to latest to accommodate better handling of Content State Annotations related to `t` fragments on Video and Audio works.