### PR TITLE
Use capabilities/magic/login route instead of chat route

### DIFF
--- a/components/Shared/AuthDialog.tsx
+++ b/components/Shared/AuthDialog.tsx
@@ -69,7 +69,7 @@ export default function AuthDialog() {
 
   useEffect(() => {
     axios
-      .get(`${DCAPI_ENDPOINT}/capabilities/magic/chat`)
+      .get(`${DCAPI_ENDPOINT}/capabilities/magic/login`)
       .then((response) => {
         const resp: { enabled: boolean; provider: string; feature: string } =
           response.data;


### PR DESCRIPTION
### Summary

Base whether to display the Magic Link login option on whether `capabilities/magic/login` is enabled rather than `capabilities/magic/chat`

### Steps to Test

Should work the same