### PR TITLE
Update position and zIndex on viewer container.

### DIFF
--- a/components/Clover/ViewerWrapper.styled.ts
+++ b/components/Clover/ViewerWrapper.styled.ts
@@ -3,9 +3,6 @@ import { styled } from "@/stitches.config";
 /* eslint sort-keys: 0 */
 
 const ViewerWrapperStyled = styled("section", {
-  position: "relative",
-  zIndex: "1",
-
   ".clover-viewer-painting": {
     background: "#f0f0f0",
   },

--- a/components/Shared/Container.tsx
+++ b/components/Shared/Container.tsx
@@ -37,6 +37,7 @@ const Container: React.FC<ContainerProps> = ({
 
 export const ContainerStyled = styled("div", {
   margin: "0 auto",
+  padding: "0 $gr3",
   variants: {
     containerType: {
       default: {
@@ -55,11 +56,8 @@ export const ContainerStyled = styled("div", {
   },
   width: "100%",
 
-  "@sm": {
+  "@md": {
     padding: "0 $gr2",
-  },
-  "@lg": {
-    padding: "0 $gr3",
   },
 });
 


### PR DESCRIPTION
## What does this do?

This updates some styling choices in the `ViewerWrapper` component to ensure the dropdown element associated with `choice` does not visually slide under other elements.

This can be previewed at: https://preview-5552-choice-zindex.dc.rdc-staging.library.northwestern.edu/items/b8c3df72-0fd5-40ea-bb1c-088513e46c58/share?iiif-content=JTdCJTIyJTQwY29udGV4dCUyMiUzQSUyMmh0dHAlM0ElMkYlMkZpaWlmLmlvJTJGYXBpJTJGcHJlc2VudGF0aW9uJTJGMyUyRmNvbnRleHQuanNvbiUyMiUyQyUyMmlkJTIyJTNBJTIyaHR0cHMlM0ElMkYlMkZkY2FwaS5yZGMtc3RhZ2luZy5saWJyYXJ5Lm5vcnRod2VzdGVybi5lZHUlMkZhcGklMkZ2MiUyRndvcmtzJTJGYjhjM2RmNzItMGZkNS00MGVhLWJiMWMtMDg4NTEzZTQ2YzU4JTNGYXMlM0RpaWlmJTJGc3RhdGUlMkYxMTY0MTcwMzEzJTIyJTJDJTIydHlwZSUyMiUzQSUyMkFubm90YXRpb24lMjIlMkMlMjJtb3RpdmF0aW9uJTIyJTNBJTVCJTIyY29udGVudFN0YXRlJTIyJTVEJTJDJTIydGFyZ2V0JTIyJTNBJTdCJTIydHlwZSUyMiUzQSUyMlNwZWNpZmljUmVzb3VyY2UlMjIlMkMlMjJzb3VyY2UlMjIlM0ElN0IlMjJpZCUyMiUzQSUyMmh0dHBzJTNBJTJGJTJGZGNhcGkucmRjLXN0YWdpbmcubGlicmFyeS5ub3J0aHdlc3Rlcm4uZWR1JTJGYXBpJTJGdjIlMkZ3b3JrcyUyRmI4YzNkZjcyLTBmZDUtNDBlYS1iYjFjLTA4ODUxM2U0NmM1OCUzRmFzJTNEaWlpZiUyRmNhbnZhcyUyRjE0JTIyJTJDJTIydHlwZSUyMiUzQSUyMkNhbnZhcyUyMiUyQyUyMnBhcnRPZiUyMiUzQSU1QiU3QiUyMmlkJTIyJTNBJTIyaHR0cHMlM0ElMkYlMkZkY2FwaS5yZGMtc3RhZ2luZy5saWJyYXJ5Lm5vcnRod2VzdGVybi5lZHUlMkZhcGklMkZ2MiUyRndvcmtzJTJGYjhjM2RmNzItMGZkNS00MGVhLWJiMWMtMDg4NTEzZTQ2YzU4JTNGYXMlM0RpaWlmJTIyJTJDJTIydHlwZSUyMiUzQSUyMk1hbmlmZXN0JTIyJTdEJTVEJTdEJTdEJTJDJTIyYm9keSUyMiUzQSU1QiU3QiUyMnR5cGUlMjIlM0ElMjJUZXh0dWFsQm9keSUyMiUyQyUyMnZhbHVlJTIyJTNBJTIyVGhlJTIwJTVDJTIyY2hvaWNlJTVDJTIyJTIwZHJvcGRvd24lMjBzaG91bGQlMjBub3QlMjBvdmVybGFwJTIwdGh1bWJuYWlscy4lNUNuJTIwJTNDZW0lM0VOb3RlJTNBJTIwVGhpcyUyMGFubm90YXRpb24lMjB3YXMlMjBpbmNsdWRlZCUyMGFzJTIwcGFydCUyMG9mJTIwYSUyMHVzZXItYXV0aG9yZWQlMjBzaGFyZWQlMjBsaW5rLiUzQyUyRmVtJTNFJTIyJTJDJTIyZm9ybWF0JTIyJTNBJTIydGV4dCUyRnBsYWluJTIyJTdEJTVEJTdE

![image](https://github.com/user-attachments/assets/aea9a80f-90d1-4aec-8e42-603df26646d4)
