### PR TITLE
Add "No title" string; replace "ok".

### DIFF
--- a/components/Grid/Item.tsx
+++ b/components/Grid/Item.tsx
@@ -21,6 +21,8 @@ const GridItem: React.FC<GridItemProps> = ({ item, isFeatured }) => {
     );
   };
 
+  const noTitleString = "No title";
+
   useEffect(() => {
     switch (item.api_model) {
       case "Work":
@@ -47,7 +49,7 @@ const GridItem: React.FC<GridItemProps> = ({ item, isFeatured }) => {
                 ? `${item.representative_file_set.url}/square/512,/0/default.jpg`
                 : item.thumbnail || "",
             supplementalInfo: item.work_type,
-            title: item.title || "ok",
+            title: item.title || noTitleString,
           }}
         />
       </Link>


### PR DESCRIPTION
## What does this do?

Address issue where our DC API allows `null` titles and DC must insert a string. In This case we will use "No title" as the value and replace the per-existing and accidentally used "ok".

## How should we review

Results on this page should be labeled as "No title"

https://preview-5571-no-title.dc.rdc-staging.library.northwestern.edu/search?q=%2280b4b209-88d3-4e07-9890-9a4fdaef5c46%22