### PR TITLE
Add privacy policy links; refine auth dialog layout.

### DIFF
--- a/components/Footer/Content.tsx
+++ b/components/Footer/Content.tsx
@@ -1,0 +1,200 @@
+import {
+  FooterContentColumn,
+  FooterContentWrapper,
+  FooterCopyright,
+  FooterIcon,
+  FooterList,
+  FooterStyled,
+  Social,
+} from "./Footer.styled";
+
+import React from "react";
+
+export const FooterContent: React.FC = () => {
+  const currentYear = () => {
+    const today = new Date();
+    return today.getFullYear();
+  };
+
+  return (
+    <FooterStyled>
+      <FooterContentWrapper>
+        {/* Column 1 */}
+        <FooterContentColumn>
+          <a href="https://www.northwestern.edu">
+            <div className="footer-logo">
+              <img
+                alt="Northwestern University logo"
+                src="https://common.northwestern.edu/v8/css/images/northwestern-university.svg"
+                style={{
+                  maxWidth: "200px",
+                  marginBottom: "1rem",
+                }}
+              />
+            </div>
+          </a>
+          <FooterList>
+            <li>&copy; {currentYear()} Northwestern University</li>
+            <li>
+              <a href="https://www.northwestern.edu/emergency/index.html">
+                Campus Emergency Information
+              </a>
+            </li>
+            <li>
+              <a href="https://www.northwestern.edu/hr/careers/">Careers</a>
+            </li>
+            <li>
+              <a href="https://www.northwestern.edu/contact.html">
+                Contact Northwestern University
+              </a>
+            </li>
+            <li>
+              <a href="https://www.northwestern.edu/privacy/">Privacy Policy</a>
+            </li>
+            <li>
+              <a href="https://www.northwestern.edu/disclaimer.html">
+                Disclaimer
+              </a>
+            </li>
+            <li>
+              <a href="https://www.northwestern.edu/accessibility/about/report-an-accessibility-issue.html">
+                Report an Accessibility Issue
+              </a>
+            </li>
+            <li>
+              <a href="https://policies.northwestern.edu/">
+                University Policies
+              </a>
+            </li>
+          </FooterList>
+        </FooterContentColumn>
+
+        {/* Column 2 */}
+        <FooterContentColumn className="contact">
+          <FooterList>
+            <FooterIcon
+              css={{
+                background:
+                  "url('https://common.northwestern.edu/v8/css/images/icons/pin-drop.svg') no-repeat",
+              }}
+            >
+              <span className="hide-label">Address</span>
+            </FooterIcon>
+            <li>1970 Campus Drive</li>
+            <li>Evanston, IL 60208</li>
+          </FooterList>
+          <FooterList>
+            <FooterIcon
+              css={{
+                background:
+                  "url('https://common.northwestern.edu/v8/css/images/icons/mobile-phone.svg') no-repeat",
+              }}
+            >
+              <span className="hide-label">Phone number</span>
+            </FooterIcon>
+            <li>(847) 491-7658</li>
+          </FooterList>
+          <FooterList>
+            <FooterIcon
+              css={{
+                background:
+                  "url('https://common.northwestern.edu/v8/css/images/icons/email.svg') no-repeat",
+                left: "-2.2rem",
+              }}
+            >
+              <span className="hide-label">Email Address</span>
+            </FooterIcon>
+
+            <li>
+              <a href="mailto:library@northwestern.edu">
+                library@northwestern.edu
+              </a>
+            </li>
+          </FooterList>
+        </FooterContentColumn>
+
+        {/* Column 3 */}
+        <FooterContentColumn>
+          <p style={{ lineHeight: "1", margin: "0 0 1rem" }}>
+            <strong>Social Media</strong>
+          </p>
+          <Social
+            className="facebook"
+            href="https://www.facebook.com/NorthwesternLibrary"
+          >
+            Facebook
+          </Social>
+
+          <Social className="twitter" href="https://twitter.com/nu_library">
+            Twitter
+          </Social>
+          <Social
+            className="instagram"
+            href="https://www.instagram.com/nu_library/"
+          >
+            Instagram
+          </Social>
+          <br />
+          <Social
+            className="youtube"
+            href="https://www.youtube.com/user/NorthwesternLib"
+          >
+            YouTube
+          </Social>
+          <Social
+            className="wordpress"
+            href="http://sites.northwestern.edu/northwesternlibrary/"
+          >
+            WordPress
+          </Social>
+        </FooterContentColumn>
+
+        {/* Column 4 */}
+        <FooterContentColumn>
+          <div>
+            <FooterList>
+              <li>
+                <a href="http://northwestern.libanswers.com/">FAQs</a>
+              </li>
+              <li>
+                <a href="https://www.library.northwestern.edu/about/support/index.html">
+                  Support Us
+                </a>
+              </li>
+              <li>
+                <a href="https://www.library.northwestern.edu/about/library-jobs/index.html">
+                  Library Jobs
+                </a>
+              </li>
+              <li>
+                <a href="https://www.library.northwestern.edu/about/administration/policies/index.html">
+                  Library Policies
+                </a>
+              </li>
+              <li>
+                <a href="https://www.library.northwestern.edu/about/contact/general-feedback.html">
+                  Provide Feedback
+                </a>
+              </li>
+            </FooterList>
+          </div>
+        </FooterContentColumn>
+      </FooterContentWrapper>
+
+      <FooterCopyright>
+        <p>
+          Northwestern University Libraries is dedicated to the fair and ethical
+          preservation, digitization, curation, and use of its collections. The
+          works on this Web site are made available to the public under Fair Use
+          (Section 107 of the Copyright Act) for learning and teaching purposes,
+          as well as to promote the mission and activities of Northwestern
+          University Libraries. Northwestern University Libraries does not claim
+          the copyright of any materials on this site. If you are the copyright
+          holder of any item(s) in this collection or have questions, comments
+          or concerns about this exhibit, please contact us via email at{" "}
+          <a href="library@northwestern.edu">library@northwestern.edu</a>.
+        </p>
+      </FooterCopyright>
+    </FooterStyled>
+  );
+};

--- a/components/Footer/Footer.styled.ts
+++ b/components/Footer/Footer.styled.ts
@@ -2,11 +2,166 @@ import { styled } from "@/stitches.config";
 
 /* eslint sort-keys: 0 */
 
-export const FooterStyled = styled("div", {
+export const FooterStyled = styled("footer", {
   background: "$purple",
-  padding: "$gr2 0",
+  color: "$white",
+  display: "flex",
+  flexDirection: "column",
+  flexWrap: "nowrap",
+  fontFamily: "$sansLight",
+  fontSize: "$3",
+  padding: "$6 0",
 
-  "a, a:visited": {
-    color: "$white !important",
+  "& a": {
+    color: "$white",
+    fontFamily: "$sansLight",
+
+    "&:hover, &:focus": {
+      textDecoration: "none",
+      color: "$white",
+    },
+  },
+
+  "& .hide-label": {
+    position: "absolute",
+    left: "-10000px",
+    top: "auto",
+    width: "1px",
+    height: "1px",
+    overflow: "hidden",
+  },
+
+  variants: {
+    isGrey: {
+      true: {
+        background: "$richBlack80",
+      },
+    },
+  },
+});
+
+export const FooterContentColumn = styled("div", {
+  marginRight: "5.15464%",
+  display: "inline-block",
+  position: "relative",
+  verticalAlign: "top",
+
+  "&.contact": {
+    "& ul": {
+      margin: "0 0 1rem 2rem",
+      position: "relative",
+    },
+  },
+
+  "@bp1": {
+    marginBottom: "$2",
+  },
+  "@bp2": {
+    marginBottom: "0",
+  },
+});
+
+export const FooterContentWrapper = styled("div", {
+  width: "100%",
+  display: "grid",
+  gap: "$4",
+  gridTemplateColumns: "1",
+
+  "@bp2": {
+    gridTemplateColumns: "repeat(2, 1fr)",
+  },
+
+  "@bp3": {
+    gridTemplateColumns: "repeat(4, 1fr)",
+  },
+});
+
+export const FooterCopyright = styled("div", {
+  color: "$nuPurple10",
+  margin: "$4 0 0",
+
+  "> p": {
+    lineHeight: "$6 !important",
+
+    a: {
+      border: "none",
+      color: "inherit",
+      textDecoration: "underline",
+    },
+  },
+});
+
+export const FooterIcon = styled("li", {
+  backgroundSize: "18px 24px",
+  position: "absolute",
+  top: "2px",
+  left: "-2rem",
+  height: "24px",
+  width: "18px",
+});
+
+export const FooterList = styled("ul", {
+  listStyleType: "none",
+  margin: "0",
+  padding: "0",
+
+  "& li": {
+    paddingBottom: "$3",
+  },
+
+  "& a": {
+    borderBottom: "0",
+    textDecoration: "underline",
+  },
+});
+
+export const Social = styled("a", {
+  display: "inline-block",
+  verticalAlign: "bottom",
+  overflow: "hidden",
+  margin: "4px",
+  width: "39px",
+  height: "39px",
+  fontSize: "0",
+  textIndent: "-9999px",
+  background:
+    "url(https://common.northwestern.edu/v8/css/images/icons/social-media-icons.svg);",
+  backgroundColor: "#fff",
+  transition: "background 0.3s",
+  border: "1px solid #fff",
+
+  "&:hover, &:focus": {
+    backgroundColor: "#b6acd1",
+  },
+
+  "&.facebook": {
+    backgroundPosition: "0 0",
+    "&:hover, &:focus": {
+      backgroundPosition: "0 -39px",
+    },
+  },
+  "&.twitter": {
+    backgroundPosition: "-39px 0",
+    "&:hover, &:focus": {
+      backgroundPosition: "-39px -39px",
+    },
+  },
+  "&.instagram": {
+    backgroundPosition: "-78px 0",
+    "&:hover, &:focus": {
+      backgroundPosition: "-78px -39px",
+    },
+  },
+  "&.youtube": {
+    backgroundPosition: "-156px 0",
+    "&:hover, &:focus": {
+      backgroundPosition: "-156px -39px",
+    },
+  },
+  "&.wordpress": {
+    backgroundPosition: "-234px 0",
+    "&:hover, &:focus": {
+      backgroundPosition: "-234px -39px",
+    },
   },
 });

--- a/components/Footer/Footer.tsx
+++ b/components/Footer/Footer.tsx
@@ -1,14 +1,14 @@
 import Container from "@/components/Shared/Container";
+import { FooterContent } from "@/components/Footer/Content";
 import { FooterStyled } from "@/components/Footer/Footer.styled";
-import { Footer as NUFooter } from "@nulib/design-system";
 import React from "react";
-import SiteContentMessage from "./SiteContentMessage/SiteContentMessage";
+import SiteContentMessage from "@/components/Footer/SiteContentMessage/SiteContentMessage";
 
 export default function Footer() {
   return (
     <FooterStyled>
       <Container data-testid="footer">
-        <NUFooter isCopyright />
+        <FooterContent />
       </Container>
       <SiteContentMessage />
     </FooterStyled>

--- a/components/Shared/AuthDialog.styled.ts
+++ b/components/Shared/AuthDialog.styled.ts
@@ -5,7 +5,7 @@ import { styled } from "@/stitches.config";
 /* eslint sort-keys: 0 */
 
 const AuthDialogOverlay = styled(Dialog.Overlay, {
-  background: "rgba(0 0 0 / 0.382)",
+  background: "rgba(0 0 0 / 0.618)",
   position: "fixed",
   top: 0,
   left: 0,
@@ -14,7 +14,7 @@ const AuthDialogOverlay = styled(Dialog.Overlay, {
   display: "grid",
   placeItems: "center",
   overflowY: "auto",
-  zIndex: "1",
+  zIndex: "10",
 });
 
 const AuthDialogContent = styled(Dialog.Content, {
@@ -30,7 +30,7 @@ const AuthDialogContent = styled(Dialog.Content, {
   maxWidth: "500px",
   maxHeight: "85vh",
   padding: "$gr4",
-  zIndex: "2",
+  zIndex: "20",
   fontSize: "$gr3",
   display: "flex",
   flexDirection: "column",
@@ -46,12 +46,27 @@ const AuthDialogContent = styled(Dialog.Content, {
 });
 
 const AuthDialogTitle = styled(Dialog.Title, {
-  fontSize: "$gr6",
+  fontSize: "$gr5",
   lineHeight: "1.5rem",
   padding: "0",
   margin: "0",
-  color: "$black50",
+  color: "$black80",
+  fontFamily: "$sansBold",
   fontWeight: "400",
+  letterSpacing: "-0.02em",
+});
+
+const AuthDialogDescription = styled(Dialog.Description, {
+  color: "$black50",
+});
+
+const AuthDialogOptions = styled("div", {
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  gap: "$gr4",
+  marginBottom: "$gr3",
+  width: "100%",
 });
 
 const AuthDialogColumn = styled("div", {
@@ -61,7 +76,7 @@ const AuthDialogColumn = styled("div", {
   justifyContent: "center",
   textAlign: "center",
   "text-wrap": "balance",
-  gap: "$gr1",
+  gap: "$gr2",
   width: "100%",
 
   "> *": {
@@ -80,15 +95,18 @@ const AuthDialogColumn = styled("div", {
 });
 
 const MagicLinkInput = styled("input", {
-  width: "100%",
   height: "2.5rem",
-  padding: "$gr1",
-  borderWidth: "1px",
-  borderColor: "$black10",
-  borderStyle: "solid",
+  padding: "$gr2",
+  border: "none !important",
+  backgroundColor: "$gray6",
   fontSize: "$gr3",
   lineHeight: "1.5rem",
-  color: "$black50",
+  color: "$black",
+  fontFamily: "$sansRegular",
+
+  "&::placeholder": {
+    color: "$black50",
+  },
 
   "&:user-invalid": {
     borderColor: "$brightRed",
@@ -99,14 +117,14 @@ const AuthDialogDivider = styled("div", {
   display: "flex",
   alignItems: "center",
   width: "100%",
-  color: "$black20",
-  fontSize: "$gr3",
+  color: "$black50",
+  fontSize: "$gr2",
 
   "&::before, &::after": {
     content: '""',
     flex: "1",
     height: "1px",
-    backgroundColor: "$black20",
+    backgroundColor: "$black10",
   },
 
   "&::before": {
@@ -144,7 +162,9 @@ const IconButton = styled("button", {
 export {
   AuthDialogContent,
   AuthDialogColumn,
+  AuthDialogDescription,
   AuthDialogDivider,
+  AuthDialogOptions,
   AuthDialogOverlay,
   AuthDialogTitle,
   IconButton,


### PR DESCRIPTION
## What does this do?

This is a small chunk of work that adds the Privacy Policy link to the footer and the sign in dialog. A few notes as this was a bit more complex than expected...

1. The Footer has been moved from the `@nulib/design-system` package to a component within digital collections. There are issues relating to old dependencies with the design system that need to be addressed before updates can easily by made to components there. As `dc-nextjs` is the only one of our repositories using the footer component, it may be best just to remove the component from the design system in a future issue.

2. The Privacy Policy has been added to the dialog for the sign in process. I refined a few stylistic choices along the way to make the form a bit less messy and provide the privacy policy breathing room at the footer of the dialog content.

## How should we review

1. Go to https://preview-5541-privacy-policy.dc.rdc-staging.library.northwestern.edu/
2. Scroll to bottom and see footer for Privacy Policy link
3. Click Sign In and see privacy policy link
4. Links will send user to https://www.northwestern.edu/privacy/