### PR TITLE
Remove errant `w` character.

### DIFF
--- a/components/Footer/Content.tsx
+++ b/components/Footer/Content.tsx
@@ -50,8 +50,7 @@ export const FooterContent: React.FC = () => {
             </li>
             <li>
               <a href="https://www.northwestern.edu/privacy/">Privacy Policy</a>
-            </li>{" "}
-            w
+            </li>
             <li>
               <a href="https://www.northwestern.edu/disclaimer.html">
                 Disclaimer


### PR DESCRIPTION
## What does this do?

Removes a typo accidentally added between list items in the footer.