### PR TITLE
Address conversation front end refinements.

### DIFF
--- a/components/Chat/Conversation.styled.tsx
+++ b/components/Chat/Conversation.styled.tsx
@@ -1,4 +1,5 @@
 import { keyframes, styled } from "@/stitches.config";
+
 import { StyledStack } from "./Stack/Stack.styled";
 
 const gradientAnimation = keyframes({
@@ -73,6 +74,12 @@ const StyledChatConversation = styled("div", {
       animation: "none !important",
       background: "$purple10",
 
+      textarea: {
+        "&::placeholder": {
+          color: "$purple60",
+        },
+      },
+
       ["button[type='submit']"]: {
         backgroundColor: "$purple",
         color: "$white",
@@ -121,15 +128,15 @@ const StyledChatConversation = styled("div", {
 
     [`& > ${StyledStack}`]: {
       position: "absolute",
-      top: "calc($gr3 / 2)",
-      left: "calc($gr3 / 2)",
+      top: "calc($gr2)",
+      left: "calc($gr2)",
       zIndex: 1,
     },
 
     // 40px is a too magic numbery
     [`&:has(${StyledStack}[data-isdismissed=false])`]: {
       textarea: {
-        textIndent: "40px",
+        textIndent: "50px",
         "&::placeholder": {},
       },
     },

--- a/components/Chat/Conversation.tsx
+++ b/components/Chat/Conversation.tsx
@@ -3,12 +3,13 @@ import {
   StyledChatConversation,
   StyledResetButton,
 } from "./Conversation.styled";
+import { defaultState, useSearchState } from "@/context/search-context";
 import { useEffect, useRef } from "react";
+
+import { AI_SYS_PROMPT_MSG } from "@/lib/constants/common";
+import Stack from "./Stack/Stack";
 import { styled } from "@/stitches.config";
 import { useRouter } from "next/router";
-import { useSearchState } from "@/context/search-context";
-import Stack from "./Stack/Stack";
-import { AI_SYS_PROMPT_MSG } from "@/lib/constants/common";
 
 interface ChatConversationProps {
   conversationCallback: (message: string) => void;
@@ -21,7 +22,7 @@ const ChatConversation: React.FC<ChatConversationProps> = ({
 }) => {
   const router = useRouter();
   const {
-    searchState: { conversation },
+    searchState: { conversation, panel },
     searchDispatch,
   } = useSearchState();
 
@@ -38,6 +39,27 @@ const ChatConversation: React.FC<ChatConversationProps> = ({
     window.addEventListener("scroll", handleScroll);
     return () => window.removeEventListener("scroll", handleScroll);
   }, []);
+
+  useEffect(() => {
+    if (conversation?.context?.works?.length && !panel.open) {
+      const searchWrapper = document.getElementById("search-wrapper");
+
+      if (searchWrapper) {
+        const searchWrapperBottom =
+          searchWrapper.offsetTop + searchWrapper.offsetHeight;
+        const targetScrollTop = searchWrapperBottom - window.innerHeight;
+
+        window.scrollTo({
+          top: targetScrollTop,
+          behavior: "smooth",
+        });
+      }
+
+      if (textareaRef.current) {
+        textareaRef.current.focus();
+      }
+    }
+  }, [conversation?.context?.works, panel.open]);
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -88,6 +110,11 @@ const ChatConversation: React.FC<ChatConversationProps> = ({
       textarea.innerText = "";
       textarea.focus();
     }
+
+    searchDispatch({
+      type: "updateConversation",
+      conversation: defaultState.conversation,
+    });
 
     router.push({
       pathname: "/search",
@@ -144,10 +171,10 @@ const ChatConversation: React.FC<ChatConversationProps> = ({
 };
 
 export const StyledSystemPrompt = styled("p", {
-  margin: 0,
-  fontSize: "$gr1",
+  margin: "$gr2",
+  fontSize: "$gr2",
   color: "$black50",
-  marginBlockStart: "$gr1",
+  textAlign: "right",
   a: {
     cursor: "pointer",
   },

--- a/components/Chat/Stack/Stack.styled.tsx
+++ b/components/Chat/Stack/Stack.styled.tsx
@@ -30,8 +30,9 @@ const StyledStackItem = styled("div", {
 });
 
 const StyledStackFillerItem = styled(StyledStackItem, {
-  borderBottom: "1px solid $black20",
-  borderRight: "1px solid $black20",
+  backgroundColor: "$white",
+  borderBottom: "1px solid #0004",
+  borderRight: "1px solid #0004",
   borderRadius: `0 0 ${gr(2)}px 0`,
 });
 
@@ -46,21 +47,23 @@ const StyledStackContent = styled(StyledStack, {
   ["& > :first-child"]: {
     // this is the first child of the stack
     // ensures the Tooltip is hoverable
-    zIndex: 1,
+    zIndex: 2,
   },
 
   [`& ${StyledStackItem}`]: {
     width: "2rem",
     height: "2rem",
-    boxShadow: "2px 2px 5px #0002",
+    boxShadow: "2px 2px 5px #0001",
   },
 
   [`${StyledStackItem}:nth-child(1 of ${StyledStackFillerItem})`]: {
     transform: "translateX(2px) translateY(2px)",
+    zIndex: 1,
   },
 
   [`${StyledStackItem}:nth-child(2 of ${StyledStackFillerItem})`]: {
     transform: "translateX(4px) translateY(4px)",
+    zIndex: 0,
   },
 });
 

--- a/components/Chat/Stack/Stack.styled.tsx
+++ b/components/Chat/Stack/Stack.styled.tsx
@@ -1,6 +1,6 @@
-import { styled } from "@/stitches.config";
-import { gr } from "@/styles/sizes";
 import { IconClear } from "@/components/Shared/SVG/Icons";
+import { gr } from "@/styles/sizes";
+import { styled } from "@/stitches.config";
 
 const StyledStack = styled("div", {
   width: "fit-content",
@@ -30,8 +30,8 @@ const StyledStackItem = styled("div", {
 });
 
 const StyledStackFillerItem = styled(StyledStackItem, {
-  borderBottom: "1px solid $black50",
-  borderRight: "1px solid $black50",
+  borderBottom: "1px solid $black20",
+  borderRight: "1px solid $black20",
   borderRadius: `0 0 ${gr(2)}px 0`,
 });
 
@@ -52,30 +52,28 @@ const StyledStackContent = styled(StyledStack, {
   [`& ${StyledStackItem}`]: {
     width: "2rem",
     height: "2rem",
-    boxShadow: "2px 2px 5px -1px #0002",
+    boxShadow: "2px 2px 5px #0002",
   },
 
   [`${StyledStackItem}:nth-child(1 of ${StyledStackFillerItem})`]: {
-    transform: "translateX(3px) translateY(3px)",
+    transform: "translateX(2px) translateY(2px)",
   },
 
   [`${StyledStackItem}:nth-child(2 of ${StyledStackFillerItem})`]: {
-    transform: "translateX(6px) translateY(6px)",
+    transform: "translateX(4px) translateY(4px)",
   },
 });
 
 const StyledStackDismiss = styled("button", {
   borderRadius: "100%",
-  borderWidth: "1px",
-  borderStyle: "solid",
-  borderColor: "$black50",
+  border: "none",
   padding: "calc($gr1 / 4)",
   display: "flex",
-  backgroundColor: "$gray6",
+  backgroundColor: "$white",
   cursor: "pointer",
   width: "$gr3",
   height: "$gr3",
-  transform: "translateX(calc(100% + 10px)) translateY(calc(100% + 10px))",
+  transform: "translateX(calc(100% + 7px)) translateY(calc(100% + 7px))",
   transition: "all 200ms ease-in-out",
   fill: "$black50",
   // ensure dismiss is above the first child of the stack

--- a/context/search-context.tsx
+++ b/context/search-context.tsx
@@ -1,5 +1,5 @@
-import { SearchContextStore } from "@/types/context/search-context";
 import React from "react";
+import { SearchContextStore } from "@/types/context/search-context";
 
 type Action =
   | {

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -217,7 +217,7 @@ const SearchPage: NextPage = () => {
         data-testid="search-page-wrapper"
         title={HEAD_META["SEARCH"].title}
       >
-        <StyledResponseWrapper>
+        <StyledResponseWrapper id="search-wrapper">
           <Heading as="h1" isHidden>
             Northwestern
           </Heading>
@@ -241,10 +241,9 @@ const SearchPage: NextPage = () => {
               />
             )}
 
-            <StyledTabsContent value="stream" id="foo">
+            <StyledTabsContent value="stream">
               <div
                 style={{
-                  transition: "all 382ms ease-in-out",
                   opacity: panel.open ? 0 : 1,
                   filter: panel.open ? "grayscale(1)" : "none",
                   height: panel.open ? 0 : "auto",


### PR DESCRIPTION
## What does this do?

This addresses issues noted in https://github.com/nulib/repodev_planning_and_docs/issues/5519

## How should we review:

Go to https://preview-5519-conversations-punchlist.dc.rdc-staging.library.northwestern.edu/

**Scroll to behavior**

- Chat by searching/toggling on gen ai
- Watch it stream in
- Click on _View results_ for any search to toggle grid results
- Facet/filter however
- Add docs (chat about results) to Back to conversation action
- Window should scroll so form is visible

**Clearing**

- Chat by searching/toggling on gen ai or continue conversation above
- Conversation should clear when clicking _Start new conversation_

