### PR TITLE
Update tests for embed viewer; abstract as component.

### DIFF
--- a/components/Work/EmbeddedViewer.test.tsx
+++ b/components/Work/EmbeddedViewer.test.tsx
@@ -1,0 +1,44 @@
+// write tests
+import { render, screen } from "@testing-library/react";
+
+import EmbeddedViewer from "@/components/Work/EmbeddedViewer";
+import { WorkProvider } from "@/context/work-context";
+import WorkRestrictedDisplay from "@/components/Work/RestrictedDisplay";
+import WorkViewerWrapper from "@/components/Clover/ViewerWrapper";
+import { work1 } from "@/mocks/work-page/work1";
+
+jest.mock("@/context/work-context", () => ({
+  WorkProvider: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+jest.mock("@/components/Work/RestrictedDisplay", () => () => (
+  <div>WorkRestrictedDisplay</div>
+));
+
+jest.mock("@/components/Clover/ViewerWrapper", () => () => (
+  <div>WorkViewerWrapper</div>
+));
+
+describe("EmbeddedViewer", () => {
+  const mockWork = {
+    ...work1,
+  };
+
+  it("renders WorkViewerWrapper when userCanRead is true", () => {
+    render(
+      <EmbeddedViewer work={mockWork} userCanRead={true} searchParams={{}} />,
+    );
+
+    expect(screen.getByText("WorkViewerWrapper")).toBeInTheDocument();
+  });
+
+  it("renders WorkRestrictedDisplay when userCanRead is false", () => {
+    render(
+      <EmbeddedViewer work={mockWork} userCanRead={false} searchParams={{}} />,
+    );
+
+    expect(screen.getByText("WorkRestrictedDisplay")).toBeInTheDocument();
+  });
+});

--- a/components/Work/EmbeddedViewer.tsx
+++ b/components/Work/EmbeddedViewer.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { ViewerConfigOptions } from "@samvera/clover-iiif";
+import { Work } from "@nulib/dcapi-types";
+import { WorkProvider } from "@/context/work-context";
+import WorkRestrictedDisplay from "@/components/Work/RestrictedDisplay";
+import WorkViewerWrapper from "@/components/Clover/ViewerWrapper";
+
+const EmbeddedViewer = ({
+  work,
+  userCanRead,
+  searchParams,
+}: {
+  work: Work;
+  userCanRead?: boolean;
+  searchParams: { [key: string]: string };
+}) => {
+  const thumbnail = work?.thumbnail || "";
+
+  // Filter out any object properties which contain '/embedded-viewer' in the value
+  const filteredSearchParams = Object.keys(searchParams)
+    .filter((key) => !key.includes("/embedded-viewer") && !(key === "as"))
+    .reduce(
+      (obj, key) => {
+        obj[key] = searchParams[key];
+        return obj;
+      },
+      {} as { [key: string]: string },
+    );
+
+  const { informationPanelOpen = "false", showTitle = "true" } =
+    filteredSearchParams;
+
+  // Set up some default Clover Viewer UI configuration for the embed viewer use-case
+  const viewerOptions: ViewerConfigOptions = {
+    informationPanel: {
+      open: informationPanelOpen === "true" ? true : false,
+      renderToggle: true,
+    },
+    showIIIFBadge: false,
+    showTitle: showTitle === "true" ? true : false,
+  };
+
+  return (
+    <WorkProvider>
+      {userCanRead ? (
+        <WorkViewerWrapper
+          iiifContent={work.iiif_manifest}
+          viewerOptions={viewerOptions}
+        />
+      ) : (
+        <WorkRestrictedDisplay thumbnail={thumbnail} />
+      )}
+    </WorkProvider>
+  );
+};
+
+export default EmbeddedViewer;

--- a/pages/embedded-viewer/[manifestId].tsx
+++ b/pages/embedded-viewer/[manifestId].tsx
@@ -1,17 +1,13 @@
 import { GetServerSideProps, NextPage } from "next";
 
-import { DCAPI_ENDPOINT } from "@/lib/constants/endpoints";
+import EmbeddedViewer from "@/components/Work/EmbeddedViewer";
 import React from "react";
-import type { ViewerConfigOptions } from "@samvera/clover-iiif";
 import type { Work } from "@nulib/dcapi-types";
-import WorkRestrictedDisplay from "@/components/Work/RestrictedDisplay";
-import WorkViewerWrapper from "@/components/Clover/ViewerWrapper";
 import { buildWorkDataLayer } from "@/lib/ga/data-layer";
 import { getUrlSearchParams } from "@/lib/utils/get-url-search-params";
 import { getWork } from "@/lib/work-helpers";
 import { useRouter } from "next/router";
 import useWorkAuth from "@/hooks/useWorkAuth";
-import { WorkProvider } from "@/context/work-context";
 
 interface EmbeddedViewerPageProps {
   work: Work;
@@ -20,45 +16,15 @@ interface EmbeddedViewerPageProps {
 const EmbeddedViewerPage: NextPage<EmbeddedViewerPageProps> = ({ work }) => {
   const router = useRouter();
   const { userCanRead } = useWorkAuth(work);
-  const thumbnail = work?.thumbnail || "";
 
   const searchParams = getUrlSearchParams(decodeURIComponent(router.asPath));
 
-  // Filter out any object properties which contain '/embedded-viewer' in the value
-  const filteredSearchParams = Object.keys(searchParams)
-    .filter((key) => !key.includes("/embedded-viewer") && !(key === "as"))
-    .reduce(
-      (obj, key) => {
-        obj[key] = searchParams[key];
-        return obj;
-      },
-      {} as { [key: string]: string },
-    );
-
-  const { informationPanelOpen = "false", showTitle = "true" } =
-    filteredSearchParams;
-
-  // Set up some default Clover Viewer UI configuration for the embed viewer use-case
-  const viewerOptions: ViewerConfigOptions = {
-    informationPanel: {
-      open: informationPanelOpen === "true" ? true : false,
-      renderToggle: true,
-    },
-    showIIIFBadge: false,
-    showTitle: showTitle === "true" ? true : false,
-  };
-
   return (
-    <WorkProvider>
-      {userCanRead ? (
-        <WorkViewerWrapper
-          iiifContent={work.iiif_manifest}
-          viewerOptions={viewerOptions}
-        />
-      ) : (
-        <WorkRestrictedDisplay thumbnail={thumbnail} />
-      )}
-    </WorkProvider>
+    <EmbeddedViewer
+      work={work}
+      userCanRead={userCanRead}
+      searchParams={searchParams}
+    />
   );
 };
 

--- a/tests/work.spec.ts
+++ b/tests/work.spec.ts
@@ -35,6 +35,7 @@ test.describe("Work page component", async () => {
   /**
    * this test is skipped due to timeouts in github CI actions
    */
+  test.skip();
 
   test("renders Open Graph data and meta title and description", async ({
     openGraphPage,

--- a/tests/work.spec.ts
+++ b/tests/work.spec.ts
@@ -35,7 +35,6 @@ test.describe("Work page component", async () => {
   /**
    * this test is skipped due to timeouts in github CI actions
    */
-  test.skip();
 
   test("renders Open Graph data and meta title and description", async ({
     openGraphPage,


### PR DESCRIPTION
## What does this do?

This abstracts the embedded viewer as a component and brings it out of the `pages` directory allowing for unit tests to be more easily written toward it. A test has been added checking for rendering of the component for both public and restricted works.

Note: the test mocks the `WorkProvider` and does not check for downstream calls on this provider. Actual calls using this provider will need to be accommodated in Playwright spec test.