### PR TITLE
Get AI conversations working with Collections scoped

### DIFF
--- a/components/Chat/Chat.tsx
+++ b/components/Chat/Chat.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 
 import { AI_SEARCH_UNSUBMITTED } from "@/lib/constants/common";
 import ChatConversation from "./Conversation";
@@ -27,13 +27,18 @@ const Chat = () => {
             ...conversation.turns,
             {
               question: value,
-              context: conversation.context, // move the chat context to the next turn
+              /**
+               * Move the chat staged context to the new turn
+               */
+              context: conversation.stagedContext,
               answer: "",
               aggregations: [],
-              works: [],
             },
           ],
-          context: undefined, // clear chat context on new question
+          /**
+           * Clear the staged context after submitting a question
+           */
+          stagedContext: undefined, // clear chat context on new question
         },
       });
     }

--- a/components/Chat/Conversation.tsx
+++ b/components/Chat/Conversation.tsx
@@ -41,7 +41,7 @@ const ChatConversation: React.FC<ChatConversationProps> = ({
   }, []);
 
   useEffect(() => {
-    if (conversation?.context?.works?.length && !panel.open) {
+    if (conversation?.stagedContext?.works?.length && !panel.open) {
       const searchWrapper = document.getElementById("search-wrapper");
 
       if (searchWrapper) {
@@ -59,7 +59,7 @@ const ChatConversation: React.FC<ChatConversationProps> = ({
         textareaRef.current.focus();
       }
     }
-  }, [conversation?.context?.works, panel.open]);
+  }, [conversation?.stagedContext?.works, panel.open]);
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -95,7 +95,7 @@ const ChatConversation: React.FC<ChatConversationProps> = ({
       type: "updateConversation",
       conversation: {
         ...conversation,
-        context: undefined,
+        stagedContext: undefined,
       },
     });
   };
@@ -137,10 +137,10 @@ const ChatConversation: React.FC<ChatConversationProps> = ({
             onFocus={handleFocus}
             onBlur={handleFocus}
           ></textarea>
-          {conversation.context?.works &&
-            conversation.context.works.length > 0 && (
+          {conversation.stagedContext?.works &&
+            conversation.stagedContext.works.length > 0 && (
               <Stack
-                context={conversation.context}
+                context={conversation.stagedContext}
                 isDismissable
                 dismissCallback={handleStackDismiss}
               />

--- a/components/Chat/Response/Response.styled.tsx
+++ b/components/Chat/Response/Response.styled.tsx
@@ -88,7 +88,7 @@ const StyledQuestion = styled("header", {
   background: "$purple10",
   display: "flex",
   alignItems: "center",
-  gap: "$gr2",
+  gap: "$gr3",
 });
 
 const StyledResponseMarkdown = styled("div", {

--- a/components/Chat/Stack/Stack.styled.tsx
+++ b/components/Chat/Stack/Stack.styled.tsx
@@ -24,16 +24,19 @@ const StyledStackItem = styled("div", {
   },
 
   img: {
-    borderRadius: gr(2),
+    borderRadius: "2px",
+    marginLeft: "-2px",
     objectFit: "cover",
   },
 });
 
 const StyledStackFillerItem = styled(StyledStackItem, {
-  backgroundColor: "$white",
-  borderBottom: "1px solid #0004",
-  borderRight: "1px solid #0004",
-  borderRadius: `0 0 ${gr(2)}px 0`,
+  // radial gradient to fill the stack
+  background: `radial-gradient(circle at 25% 25%, $white, $gray6 100%)`,
+  width: "2rem",
+  borderBottom: "1px solid #0003",
+  borderRight: "1px solid #0003",
+  borderRadius: "3px",
 });
 
 const StyledStackContent = styled(StyledStack, {
@@ -53,7 +56,7 @@ const StyledStackContent = styled(StyledStack, {
   [`& ${StyledStackItem}`]: {
     width: "2rem",
     height: "2rem",
-    boxShadow: "2px 2px 5px #0001",
+    boxShadow: "2px 2px 5px #0002",
   },
 
   [`${StyledStackItem}:nth-child(1 of ${StyledStackFillerItem})`]: {

--- a/components/Chat/Stack/Stack.test.tsx
+++ b/components/Chat/Stack/Stack.test.tsx
@@ -1,7 +1,7 @@
-import React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
-import Stack from "./Stack";
+import { fireEvent, render, screen } from "@testing-library/react";
 
+import React from "react";
+import Stack from "./Stack";
 import { sampleWork1 } from "@/mocks/sample-work1";
 import { sampleWork2 } from "@/mocks/sample-work2";
 
@@ -9,7 +9,7 @@ describe("Stack", () => {
   it("renders stack with no dismiss button", () => {
     const mockContext = {
       query: "Dogs",
-      facets: { subject: ["Spaniel"] },
+      facets: [{ "collection.title.keyword": "Spaniels Quarterly" }],
       works: [sampleWork1, sampleWork2],
     };
     render(<Stack context={mockContext} isDismissable={false} />);
@@ -20,7 +20,7 @@ describe("Stack", () => {
   it("dismisses the stack when dismiss button is clicked", () => {
     const mockContext = {
       query: "Dogs",
-      facets: { subject: ["Spaniel"] },
+      facets: [{ "collection.title.keyword": "Spaniels Quarterly" }],
       works: [sampleWork1, sampleWork2],
     };
     render(<Stack context={mockContext} isDismissable />);
@@ -40,7 +40,7 @@ describe("Stack", () => {
     const mockDismissCallback = jest.fn();
     const mockContext = {
       query: "Dogs",
-      facets: { subject: ["Spaniel"] },
+      facets: [{ "collection.title.keyword": "Spaniels Quarterly" }],
       works: [sampleWork1, sampleWork2],
     };
 
@@ -56,5 +56,27 @@ describe("Stack", () => {
     fireEvent.click(dismissButton);
 
     expect(mockDismissCallback).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders a results message in a tooltip`", () => {
+    const mockDismissCallback = jest.fn();
+    const mockContext = {
+      query: "Dogs",
+      facets: [{ "collection.title.keyword": "Spaniels Quarterly" }],
+      works: [sampleWork1, sampleWork2],
+    };
+
+    render(
+      <Stack
+        context={mockContext}
+        isDismissable
+        dismissCallback={mockDismissCallback}
+      />,
+    );
+
+    expect(screen.getByTestId("stack")).toHaveAttribute(
+      "data-results-message",
+      "Results for 'Dogs' filtered by 'Collection: Spaniels Quarterly'",
+    );
   });
 });

--- a/components/Figure/Figure.tsx
+++ b/components/Figure/Figure.tsx
@@ -27,12 +27,13 @@ interface Figure {
 interface FigureProps {
   data: Figure;
   orientation?: "horizontal" | "vertical";
+  hideCaption?: boolean;
 }
 
 const Figure: React.FC<FigureProps & FigureVariants> = (props) => {
   const [isLoaded, setIsLoaded] = React.useState<boolean>(false);
 
-  const { data, orientation } = props;
+  const { data, orientation, hideCaption } = props;
   const { aspectRatio, isRestricted, title, supplementalInfo, src } = data;
 
   if (!src) return null;
@@ -73,15 +74,19 @@ const Figure: React.FC<FigureProps & FigureVariants> = (props) => {
           />
         </FigurePlaceholder>
       </FigureImageWrapper>
-      <FigureCaption>
-        <FigureText>
-          <FigureTitle>{title}</FigureTitle>
-          {supplementalInfo && (
-            <FigureSupplementalInfo>{supplementalInfo}</FigureSupplementalInfo>
-          )}
-        </FigureText>
-        {isRestricted && <IconLock aria-hidden="true" />}
-      </FigureCaption>
+      {!hideCaption && (
+        <FigureCaption>
+          <FigureText>
+            <FigureTitle>{title}</FigureTitle>
+            {supplementalInfo && (
+              <FigureSupplementalInfo>
+                {supplementalInfo}
+              </FigureSupplementalInfo>
+            )}
+          </FigureText>
+          {isRestricted && <IconLock aria-hidden="true" />}
+        </FigureCaption>
+      )}
     </FigureStyled>
   );
 };

--- a/components/Search/GenerativeAIToggle.test.tsx
+++ b/components/Search/GenerativeAIToggle.test.tsx
@@ -59,7 +59,7 @@ describe("GenerativeAIToggle", () => {
     const user = userEvent.setup();
     render(withUserProvider(withSearchProvider(<GenerativeAIToggle />)));
 
-    const label = screen.getByLabelText("Use Generative AI");
+    const label = screen.getByLabelText("AI Mode");
     const checkbox = screen.getByRole("checkbox");
 
     expect(label).toBeInTheDocument();

--- a/components/Search/JumpTo.styled.ts
+++ b/components/Search/JumpTo.styled.ts
@@ -4,9 +4,9 @@ import { styled } from "@/stitches.config";
 
 const HelperStyled = styled("div", {
   position: "absolute",
-  top: "10px",
+  top: "11px",
   right: "$gr2",
-  padding: "$gr1 $gr3",
+  padding: "$gr1 $gr2",
   background: "transparent",
   borderRadius: "1rem",
   color: "$black50",
@@ -14,6 +14,7 @@ const HelperStyled = styled("div", {
   alignItems: "center",
   transition: "$dcAll",
   fontFamily: "$northwesternSansRegular",
+  fontSize: "$gr2",
 
   "& > svg": {
     position: "relative",
@@ -40,32 +41,49 @@ const JumpToListStyled = styled("ul", {
   top: "50px",
   borderRadius: "3px",
   boxShadow: "3px 3px 11px #0001",
+  overflow: "hidden",
 });
 
 const JumpItem = styled("li", {
   position: "relative",
   transition: "$dcAll",
 
-  "& a": {
+  label: {
     display: "block",
+    width: "100%",
     padding: "$gr3",
-    borderTopWidth: "1px",
-    borderTopStyle: "solid",
     cursor: "pointer",
+    fontFamily: "$northwesternSansRegular",
+    fontSize: "$gr3",
     color: "$purple120",
+    background: "transparent",
+    borderTop: "1px solid $purple30",
+  },
+
+  input: {
+    position: "absolute",
+    opacity: 0,
+    width: 0,
+    height: 0,
+    pointerEvents: "none",
   },
 
   "&[aria-selected='true']": {
     background: "$purple10",
     fontFamily: "$northwesternSansBold",
 
+    label: {
+      fontFamily: "$northwesternSansBold",
+    },
+
     [`${HelperStyled}`]: {
       color: "$purple10",
-      background: "$purple120",
+      background: "$purple",
       fontFamily: "$northwesternSansRegular",
 
       svg: {
         width: "$gr3",
+        color: "$purple30",
       },
     },
   },

--- a/components/Search/JumpTo.test.tsx
+++ b/components/Search/JumpTo.test.tsx
@@ -4,7 +4,15 @@ import SearchJumpTo from "@/components/Search/JumpTo";
 
 describe("SearchJumpTo component", () => {
   it("conditionally renders the SearchJumpTo component", async () => {
-    render(<SearchJumpTo searchFocus={true} searchValue={"foo"} top={45} />);
+    render(
+      <SearchJumpTo
+        searchFocus={true}
+        searchValue={"foo"}
+        top={45}
+        handleOnClick={jest.fn()}
+        handleScopeValue={jest.fn()}
+      />,
+    );
 
     const listbox = screen.getByRole("listbox");
     expect(listbox).toBeInTheDocument();

--- a/components/Search/JumpTo.tsx
+++ b/components/Search/JumpTo.tsx
@@ -1,75 +1,36 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useState } from "react";
 
 import SearchJumpToList from "@/components/Search/JumpToList";
-import Swiper from "swiper";
 
 interface SearchProps {
+  handleOnClick: () => void;
+  handleScopeValue: (value: string) => void;
   searchFocus: boolean;
   searchValue: string;
   top: number;
 }
 
 const SearchJumpTo: React.FC<SearchProps> = ({
+  handleOnClick,
+  handleScopeValue,
   searchFocus,
   searchValue,
   top,
 }) => {
-  const formRef = useRef<HTMLFormElement>(null);
   const [showJumpTo, setShowJumpTo] = useState<boolean>(false);
 
   useEffect(() => {
     if (searchFocus) setShowJumpTo(Boolean(searchValue));
   }, [searchFocus, searchValue]);
 
-  useEffect(() => {
-    const handleMouseDown = (e: MouseEvent) => {
-      if (
-        showJumpTo &&
-        formRef.current &&
-        !formRef.current.contains(e.target as Node)
-      ) {
-        setShowJumpTo(false);
-      }
-    };
-
-    const handleSwiperTouch = () => {
-      if (showJumpTo) {
-        setShowJumpTo(false);
-      }
-    };
-
-    window.addEventListener("mousedown", handleMouseDown);
-
-    /**
-     * SwiperJS swallows mouse/touch events on window, so if a Swiper
-     * is on the same page as this component, grab an instance of Swiper
-     * and specifically listen for touch events. This seems to be the only
-     * way to grab mousedown events on the Swiper hero.
-     */
-    interface SwiperEl extends Element {
-      swiper?: Swiper;
-    }
-    const swiperEl: SwiperEl | null = document?.querySelector(".swiper");
-    const swiper = swiperEl ? swiperEl.swiper : undefined;
-
-    if (swiper) {
-      swiper.on("touchStart", handleSwiperTouch);
-    }
-
-    return () => {
-      window.removeEventListener("mousedown", handleMouseDown);
-      if (swiper) {
-        swiper?.off("touchStart", handleSwiperTouch);
-      }
-    };
-  }, [showJumpTo]);
-
   if (!showJumpTo) return null;
 
   return (
     <SearchJumpToList
+      handleOnClick={handleOnClick}
       searchValue={searchValue}
       setShowJumpTo={setShowJumpTo}
+      setScopeValue={handleScopeValue}
       top={top}
     />
   );

--- a/components/Search/JumpToList.test.tsx
+++ b/components/Search/JumpToList.test.tsx
@@ -24,18 +24,22 @@ describe("SearchJumpToList component", () => {
         searchValue="Dylan"
         setShowJumpTo={mockSetShowJumpTo}
         top={0}
+        handleOnClick={jest.fn()}
+        setScopeValue={jest.fn()}
       />,
     );
     expect(screen.getByTestId("jump-to-wrapper"));
     expect(screen.getAllByText("Dylan")).toHaveLength(2);
   });
 
-  it("renders Helper components in each JumpTo item", () => {
+  it("renders helper text for collection and all collections", () => {
     render(
       <SearchJumpToList
         searchValue="foo"
         setShowJumpTo={mockSetShowJumpTo}
         top={0}
+        handleOnClick={jest.fn()}
+        setScopeValue={jest.fn()}
       />,
     );
     const helpers = screen.getAllByTestId("helper");
@@ -49,6 +53,8 @@ describe("SearchJumpToList component", () => {
         searchValue="foo"
         setShowJumpTo={mockSetShowJumpTo}
         top={0}
+        handleOnClick={jest.fn()}
+        setScopeValue={jest.fn()}
       />,
     );
 
@@ -61,11 +67,11 @@ describe("SearchJumpToList component", () => {
 
     expect(
       await screen.findByTestId("helper-anchor-collection"),
-    ).toHaveAttribute("href", `/search?collection=Best+Collection+Ever&q=foo`);
+    ).toHaveAttribute("data-value", "collection");
 
     expect(screen.getByTestId("helper-anchor-all")).toHaveAttribute(
-      "href",
-      "/search?q=foo",
+      "data-value",
+      "all",
     );
   });
 
@@ -76,6 +82,8 @@ describe("SearchJumpToList component", () => {
         searchValue="foo"
         setShowJumpTo={mockSetShowJumpTo}
         top={0}
+        handleOnClick={jest.fn()}
+        setScopeValue={jest.fn()}
       />,
     );
     const listItems = await screen.findAllByRole("option");
@@ -106,6 +114,8 @@ describe("SearchJumpToList component", () => {
         searchValue="foo"
         setShowJumpTo={mockSetShowJumpTo}
         top={0}
+        handleOnClick={jest.fn()}
+        setScopeValue={jest.fn()}
       />,
     );
 

--- a/components/Search/JumpToList.tsx
+++ b/components/Search/JumpToList.tsx
@@ -6,69 +6,59 @@ import {
 } from "@/components/Search/JumpTo.styled";
 
 import { IconReturnDownBack } from "@/components/Shared/SVG/Icons";
-import Link from "next/link";
-import { getCollection } from "@/lib/collection-helpers";
 import useEventListener from "@/hooks/useEventListener";
-import { useRouter } from "next/router";
 
 interface SearchJumpToListProps {
+  handleOnClick: () => void;
   searchValue: string;
   setShowJumpTo: Dispatch<React.SetStateAction<boolean>>;
+  setScopeValue: (value: string) => void;
   top: number;
 }
 
 const SearchJumpToList: React.FC<SearchJumpToListProps> = ({
+  handleOnClick,
   searchValue,
   setShowJumpTo,
+  setScopeValue,
   top,
 }) => {
-  const router = useRouter();
-  const [collectionTitle, setCollectionTitle] = useState<string>("");
   const [activeIndex, setActiveIndex] = useState<number>(0);
 
   const jumpToItems = [
     {
       dataTestId: "helper-anchor-collection",
       helperLabel: "In this Collection",
-      pathName: "/search",
-      query: {
-        collection: collectionTitle,
-        q: searchValue,
-      },
+      value: "collection",
     },
     {
       dataTestId: "helper-anchor-all",
       helperLabel: "All Digital Collections",
-      pathName: "/search",
-      query: {
-        q: searchValue,
-      },
+      value: "all",
     },
   ];
 
-  const handleItemHover = (index: number): void => {
-    setActiveIndex(index);
-  };
+  const defaultScopeValue = jumpToItems[0].value;
 
   const handleKeyEvent = (e: KeyboardEvent) => {
     switch (e.key) {
       case "ArrowUp":
         if (activeIndex > 0) {
-          setActiveIndex(activeIndex - 1);
+          const targetIndex = activeIndex - 1;
+          const value = jumpToItems[targetIndex].value;
+          handleValue(value);
         }
         break;
       case "ArrowDown":
         if (activeIndex < jumpToItems.length - 1) {
-          setActiveIndex(activeIndex + 1);
+          const targetIndex = activeIndex + 1;
+          const value = jumpToItems[targetIndex].value;
+          handleValue(value);
         }
         break;
       case "Enter":
         e.preventDefault();
-        const activeItem = jumpToItems[activeIndex];
-        router.push({
-          pathname: activeItem.pathName,
-          query: activeItem.query,
-        });
+        setShowJumpTo(false);
         break;
       case "Escape":
         setShowJumpTo(false);
@@ -81,22 +71,22 @@ const SearchJumpToList: React.FC<SearchJumpToListProps> = ({
   // @ts-ignore
   useEventListener("keydown", handleKeyEvent);
 
-  useEffect(() => {
-    if (!router?.query?.id) return;
+  useEffect(() => setScopeValue(defaultScopeValue), []);
 
-    async function getCollectionTitle() {
-      try {
-        const data = await getCollection(router.query.id as string);
-        setCollectionTitle(data?.title || "");
-      } catch (err) {
-        console.error(
-          "Error getting Collection title in JumpTo component",
-          err,
-        );
-      }
-    }
-    getCollectionTitle();
-  }, [router.query.id]);
+  const handleValue = (value: string) => {
+    setActiveIndex(jumpToItems.findIndex((item) => item.value === value));
+    setScopeValue(value);
+  };
+
+  const handleItemHover = (e: React.MouseEvent<HTMLLIElement>) => {
+    const value = e.currentTarget.getAttribute("data-value");
+    if (value) handleValue(value);
+  };
+
+  const handleOnChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+    if (value) if (value) handleValue(value);
+  };
 
   return (
     <JumpToListStyled
@@ -109,18 +99,22 @@ const SearchJumpToList: React.FC<SearchJumpToListProps> = ({
           key={item.dataTestId}
           role="option"
           aria-selected={index === activeIndex}
-          onMouseEnter={() => handleItemHover(index)}
+          data-value={item.value}
+          onClick={handleOnClick}
+          onMouseEnter={handleItemHover}
+          data-testid={item.dataTestId}
         >
-          <Link
-            href={{
-              pathname: item.pathName,
-              query: item.query,
-            }}
-            tabIndex={0}
-            data-testid={item.dataTestId}
-          >
+          <label htmlFor={`dc-search-scope-${item.value}`}>
+            <input
+              type="radio"
+              id={`dc-search-scope-${item.value}`}
+              name="dc-search-scope"
+              value={item.value}
+              checked={activeIndex === index}
+              onChange={handleOnChange}
+            />
             {searchValue} <Helper label={item.helperLabel} />
-          </Link>
+          </label>
         </JumpItem>
       ))}
     </JumpToListStyled>

--- a/components/Search/Options.styled.tsx
+++ b/components/Search/Options.styled.tsx
@@ -1,15 +1,10 @@
 import { IconStyled } from "../Shared/Icon";
 import { Wrapper as WorkTypeWrapper } from "@/components/Facets/WorkType/WorkType.styled";
+import { keyframes } from "@stitches/react";
 import { styled } from "@/stitches.config";
 import { timingFunction } from "@/styles/transitions";
-import { keyframes } from "@stitches/react";
 
 /* eslint sort-keys: 0 */
-
-const slideInFromRight = keyframes({
-  "0%": { transform: "translateX(100vw)" },
-  "100%": { transform: "translateX0)" },
-});
 
 const StyledOptionsBar = styled("div", {
   display: "flex",
@@ -17,7 +12,6 @@ const StyledOptionsBar = styled("div", {
   gap: "$gr3",
   flexWrap: "wrap",
   alignItems: "center",
-  animation: `${slideInFromRight} 1s ${timingFunction};`,
 
   "@md": {
     gap: "$gr2",

--- a/components/Search/Panel.styled.tsx
+++ b/components/Search/Panel.styled.tsx
@@ -60,7 +60,7 @@ const StyledBackButton = styled("button", {
 const StyledSearchPanel = styled("aside", {
   width: "100%",
   height: "100%",
-  transition: "all 382ms ease-in-out",
+  transition: "opacity 382ms ease-in-out",
   opacity: "0",
   variants: {
     isOpen: {

--- a/lib/constants/common.tsx
+++ b/lib/constants/common.tsx
@@ -1,7 +1,7 @@
 export const AI_DISCLAIMER = `This is a preview of Digital Collection's semantic search tool. It uses generative AI to answer questions about the results of your natural-language search. The goal is to deliver results and rich context not possible with traditional search technologies. Occasionally search results may not be complete. Please use this as a starting point on your research journey.`;
 export const AI_LOGIN_ALERT = `You must be logged in with a Northwestern NetID to use the Generative AI search feature.`;
 export const AI_SEARCH_UNSUBMITTED = `What can I help you find? Try searching for "john cage scrapbooks" or "who played at the Berkeley Folk Music Festival in 1965?"`;
-export const AI_TOGGLE_LABEL = "Use Generative AI";
+export const AI_TOGGLE_LABEL = "AI Mode";
 export const AI_SYS_PROMPT_MSG = () => (
   <span className="ai-sys-prompt-msg">
     Curious how this works? Click{" "}

--- a/lib/dc-api.ts
+++ b/lib/dc-api.ts
@@ -6,8 +6,10 @@ import axios, {
 } from "axios";
 
 import type { ApiSearchRequestBody } from "@/types/api/request";
+import { ApiSearchResponse } from "@/types/api/response";
 import { NextRouter } from "next/router";
 import { getFacetById } from "@/lib/utils/facet-helpers";
+import { isSanitizedWork } from "./work-helpers";
 
 interface ApiGetRequestParams {
   url: string;
@@ -91,6 +93,32 @@ async function getIIIFResource<R>(
   }
 }
 
+async function getQueryRepresentativeThumbnail(
+  body: ApiSearchRequestBody,
+  size: number,
+): Promise<string | undefined> {
+  const results = await apiPostRequest<ApiSearchResponse>({
+    url: DC_API_SEARCH_URL,
+    body,
+  });
+
+  /**
+   * Find the first work with a thumbnail and
+   * return its URL with the specified size.
+   */
+  const item = results?.data?.find(
+    (result) => isSanitizedWork(result) && result.thumbnail,
+  );
+
+  if (!item || !item.thumbnail) return;
+
+  const thumbnail = new URL(item.thumbnail);
+  thumbnail.searchParams.set("size", size.toString());
+  thumbnail.searchParams.set("aspect", "square");
+
+  return thumbnail.toString() || "";
+}
+
 function iiifSearchUri(query: NextRouter["query"], size?: number): string {
   const url = new URL(DC_API_SEARCH_URL);
 
@@ -158,6 +186,7 @@ export {
   apiGetStatus,
   apiPostRequest,
   getIIIFResource,
+  getQueryRepresentativeThumbnail,
   handleError,
   iiifCollectionUri,
   iiifSearchUri,

--- a/lib/queries/facet.test.ts
+++ b/lib/queries/facet.test.ts
@@ -62,3 +62,25 @@ describe("buildFacetFilters fn()", () => {
     ]);
   });
 });
+
+describe("getFacetIdByField fn()", () => {
+  it("returns null if no facet is found", () => {
+    const result = facetFns.getFacetIdByField("foo");
+    expect(result).toBeNull();
+  });
+
+  it("returns the correct facet ID for subject.label", () => {
+    const result = facetFns.getFacetIdByField("subject.label");
+    expect(result).toEqual("subject");
+  });
+
+  it("returns the correct facet ID for creator.label", () => {
+    const result = facetFns.getFacetIdByField("creator.label");
+    expect(result).toEqual("creator");
+  });
+
+  it("returns the correct facet ID for collection.title.keyword", () => {
+    const result = facetFns.getFacetIdByField("collection.title.keyword");
+    expect(result).toEqual("collection");
+  });
+});

--- a/lib/queries/facet.ts
+++ b/lib/queries/facet.ts
@@ -30,4 +30,9 @@ const buildFacetFilters = (urlFacets: UrlFacets) => {
   return filter;
 };
 
-export { buildFacetFilters };
+const getFacetIdByField = (field: string) => {
+  const facet = ALL_FACETS.facets.find((item) => item.field === field);
+  return facet ? facet.id : null;
+};
+
+export { buildFacetFilters, getFacetIdByField };

--- a/lib/work-helpers.ts
+++ b/lib/work-helpers.ts
@@ -4,10 +4,15 @@ import {
   DC_URL,
 } from "@/lib/constants/endpoints";
 
+import { SanitizedWork } from "@/types/context/work-context";
 import type { Work } from "@nulib/dcapi-types";
 import { apiGetRequest } from "@/lib/dc-api";
 import { appendHybridSearchParams } from "./chat-helpers";
 import { shuffle } from "@/lib/utils/array-helpers";
+
+export function isSanitizedWork(work: Partial<Work>): work is SanitizedWork {
+  return work.title && work.thumbnail ? true : false;
+}
 
 export async function getWork(id: string) {
   try {

--- a/types/context/search-context.ts
+++ b/types/context/search-context.ts
@@ -1,5 +1,5 @@
-import { Work } from "@nulib/dcapi-types";
 import type { AggregationResultMessage } from "types/components/chat";
+import { Work } from "@nulib/dcapi-types";
 
 export type ActiveTab = "stream" | "results";
 
@@ -11,13 +11,16 @@ export interface Article {
 export interface ChatContext {
   works: Work[];
   query: string;
-  facets: UserFacets;
+  facets: Facet[];
+}
+
+// a facet looks { "subject.label": "Nigeria" } or { "collection.title.keyword": "E. H. Duckworth Photograph Collection" }
+export interface Facet {
+  [key: string]: string;
 }
 
 export interface Turn extends Article {
   aggregations: Omit<AggregationResultMessage, "type">["message"][];
-  works: Work[][];
-  /** Docs users can send along in addition to a question */
   context?: ChatContext;
   renderedContent?: React.JSX.Element;
 }
@@ -25,9 +28,8 @@ export interface Turn extends Article {
 export interface SearchContextStore {
   conversation: {
     ref?: string;
-    /** the question that kickstarts a conversation */
     initialQuestion: string;
-    context?: ChatContext;
+    stagedContext?: ChatContext;
     turns: Turn[];
   };
   panel: {

--- a/types/context/work-context.ts
+++ b/types/context/work-context.ts
@@ -10,3 +10,8 @@ export interface WorkContextStore {
   manifest: Manifest | undefined;
   work: Work | undefined;
 }
+
+export interface SanitizedWork extends Work {
+  title: NonNullable<Work["title"]>;
+  thumbnail: NonNullable<Work["thumbnail"]>;
+}


### PR DESCRIPTION
## What does this do?

This allows a user to initiate an AI conversation from a named collection, like Africa Embracing Obama, and for the ensuing conversation turn to be scoped to the facet of that collection.At this point, this can only be completed from a `/collections/[id]` route. Other functionality such as add docs for followup in a conversation remains.   This approach to initiating a conversation from a Collection crosses a lot of files and required the creation of a few helpers. This can previewed in https://preview-5596-collections-ai-scope.dc.rdc-staging.library.northwestern.edu/

### What changed?

 - Update of label `Use Generative AI` to `AI Mode`
 - Refactoring of the JumpTo and JumpToList components to accommodate updating of chat conversation in the search context
 - Refactoring of the Stack (thumbnail) component to issue a `1` result preview search to generate a representative thumbnail of the search context. In this case
 - Addition of `searchScope` property in Search, JumpTo, and JumpToList to make Search form aware of staged search scope of `all` or `collection`
 - Abstraction of `createResultsMessageFromContext()`, `getQueryRepresentativeThumbnail()`, and `getFacetIdByField()` helpers

Example 1: _shirt_  in **Africa Embracing Obama**

<img width="1844" height="1225" alt="image" src="https://github.com/user-attachments/assets/0a2de835-d311-4d4d-9abd-677f7303d3c4" />

<img width="1844" height="1225" alt="image" src="https://github.com/user-attachments/assets/7f9a7d74-2c61-455f-92f6-6c40b55e1931" />

Example 2: _apache_  in **Curtis...**

<img width="1844" height="1225" alt="image" src="https://github.com/user-attachments/assets/fe4aff33-ad2e-47a8-af1c-f689048e3e3a" />

<img width="1844" height="1225" alt="image" src="https://github.com/user-attachments/assets/07fee333-fa3d-4fcc-8c11-db4539237be5" />

Example 3: _shirt_ (all collections)

<img width="1844" height="1225" alt="image" src="https://github.com/user-attachments/assets/1d237861-c120-4655-ae8a-1a2561e1bc38" />


## How to review

- Go to https://preview-5596-collections-ai-scope.dc.rdc-staging.library.northwestern.edu/
- Turn on AI Mode
- Go to a named collection, preferably one with many items
- Search for a generic term like "shirts" where you know results will be across many collections
- With the "In this Collection" selected, submit your search
- Search screen should be routed to with a your query in the light purple _question_
- A representative thumbnail should generate for your query
- Your response should be scoped to the relative collection


