### PR TITLE
Update all search results messages to include filters of facets

### DIFF
--- a/components/Chat/Response/Interstitial.styled.tsx
+++ b/components/Chat/Response/Interstitial.styled.tsx
@@ -1,4 +1,4 @@
-import { keyframes, styled } from "@/stitches.config";
+import { styled } from "@/stitches.config";
 
 const StyledInterstitialIcon = styled("div", {
   display: "flex",
@@ -32,6 +32,7 @@ const StyledInterstitialWrapper = styled("div", {
   display: "flex",
   justifyContent: "space-between",
   alignItems: "center",
+  marginBottom: "$gr1",
 });
 
 const StyledInterstitial = styled("div", {
@@ -41,16 +42,20 @@ const StyledInterstitial = styled("div", {
   display: "inline-flex",
   alignItems: "center",
   gap: "$gr2",
-  marginBottom: "$gr1",
   width: "fit-content",
   color: "$purple60",
   borderRadius: "1em",
-  paddingRight: "$gr2",
   backgroundPosition: "61.8%",
+  flexGrow: "1",
 
   strong: {
     fontFamily: "$northwesternSansBold",
     fontWeight: "400",
+    color: "$purple",
+  },
+
+  em: {
+    fontStyle: "italic",
     color: "$purple",
   },
 });
@@ -58,9 +63,8 @@ const StyledInterstitial = styled("div", {
 const StyledInterstitialAction = styled("button", {
   display: "inline-flex",
   padding: "0 $gr2",
-  height: "38px",
   alignItems: "center",
-  gap: "$gr1",
+  gap: "$gr2",
   color: "$purple",
   background: "transparent",
   fontFamily: "$northwesternSansBold",

--- a/components/Chat/Response/Interstitial.test.tsx
+++ b/components/Chat/Response/Interstitial.test.tsx
@@ -84,7 +84,7 @@ describe("ResponseInterstitial", () => {
     const interstitial = screen.getByTestId("response-interstitial");
     expect(interstitial).toBeInTheDocument();
 
-    expect(interstitial).toHaveTextContent("Searching for Joan Baez");
+    expect(interstitial).toHaveTextContent("Results for “Joan Baez”");
     expect(interstitial.querySelector("strong")).toHaveTextContent("Joan Baez");
 
     const action = screen.getByRole("button");

--- a/components/Chat/Response/Interstitial.tsx
+++ b/components/Chat/Response/Interstitial.tsx
@@ -8,8 +8,10 @@ import {
 } from "@/components/Chat/Response/Interstitial.styled";
 
 import { ChatContext } from "@/types/context/search-context";
+import SearchResultsMessage from "@/components/Search/ResultsMessage";
 import { ToolStartMessage } from "@/types/components/chat";
 import { UrlFacets } from "@/types/context/filter-context";
+import { createResultsMessageFromContext } from "@/lib/chat-helpers";
 import { getFacetIdByField } from "@/lib/queries/facet";
 import { useRouter } from "next/router";
 import { useSearchState } from "@/context/search-context";
@@ -114,8 +116,13 @@ const ResponseInterstitial: React.FC<ResponseInterstitialProps> = ({
       text = `Discovering`;
       break;
     case "search":
-      text = `Searching for <strong>${input.query}</strong>`;
-      action = input.query;
+      text = createResultsMessageFromContext({
+        ...context,
+        query: String(input?.query),
+        works: context?.works ?? [],
+        facets: context?.facets ?? [],
+      });
+      action = input?.query;
       break;
     default:
       console.warn("Unknown tool_start message", message);
@@ -128,10 +135,7 @@ const ResponseInterstitial: React.FC<ResponseInterstitialProps> = ({
   return (
     <StyledInterstitialWrapper id={`interstitial-${id}`}>
       <StyledInterstitial data-testid="response-interstitial" data-tool={tool}>
-        <StyledInterstitialIcon>
-          <IconSparkles />
-        </StyledInterstitialIcon>
-        {text && <label dangerouslySetInnerHTML={{ __html: text }} />}
+        {text && <SearchResultsMessage label={text} icon={<IconSparkles />} />}
       </StyledInterstitial>
       {action && (
         <StyledInterstitialAction onClick={() => handleViewResults(action)}>

--- a/components/Chat/Response/Response.test.tsx
+++ b/components/Chat/Response/Response.test.tsx
@@ -223,8 +223,9 @@ describe("ChatResponse component", () => {
       }
 
       if (tool === "search") {
-        expect(content).toHaveTextContent(`Searching for ${query}`);
-        expect(content.querySelector("strong")).toHaveTextContent(query);
+        const interstitial = content.querySelector("[data-tool='search']");
+        const interstitialLabel = interstitial?.querySelector("label");
+        expect(interstitialLabel).toHaveTextContent("Results for “Joan Baez”");
 
         const action = content.querySelector("button");
         expect(action).toHaveTextContent("View results");

--- a/components/Chat/Stack/Stack.styled.tsx
+++ b/components/Chat/Stack/Stack.styled.tsx
@@ -1,5 +1,3 @@
-import { IconClear } from "@/components/Shared/SVG/Icons";
-import { gr } from "@/styles/sizes";
 import { styled } from "@/stitches.config";
 
 const StyledStack = styled("div", {
@@ -31,11 +29,7 @@ const StyledStackItem = styled("div", {
 });
 
 const StyledStackFillerItem = styled(StyledStackItem, {
-  // radial gradient to fill the stack
-  background: `radial-gradient(circle at 25% 25%, $white, $gray6 100%)`,
   width: "2rem",
-  borderBottom: "1px solid #0003",
-  borderRight: "1px solid #0003",
   borderRadius: "3px",
 });
 
@@ -56,16 +50,22 @@ const StyledStackContent = styled(StyledStack, {
   [`& ${StyledStackItem}`]: {
     width: "2rem",
     height: "2rem",
-    boxShadow: "2px 2px 5px #0002",
+    border: "1px solid $gray6",
+    borderRadius: "3px",
+    boxShadow: "2px 2px 5px #0001",
   },
 
   [`${StyledStackItem}:nth-child(1 of ${StyledStackFillerItem})`]: {
     transform: "translateX(2px) translateY(2px)",
+    borderBottom: "1px solid $black10",
+    borderRight: "1px solid $black10",
     zIndex: 1,
   },
 
   [`${StyledStackItem}:nth-child(2 of ${StyledStackFillerItem})`]: {
     transform: "translateX(4px) translateY(4px)",
+    borderBottom: "1px solid $black10",
+    borderRight: "1px solid $black10",
     zIndex: 0,
   },
 });

--- a/components/Chat/Stack/Stack.test.tsx
+++ b/components/Chat/Stack/Stack.test.tsx
@@ -76,7 +76,7 @@ describe("Stack", () => {
 
     expect(screen.getByTestId("stack")).toHaveAttribute(
       "data-results-message",
-      "Results for 'Dogs' filtered by 'Collection: Spaniels Quarterly'",
+      "Results for <strong>“Dogs”</strong> filtered by <em>collection</em> for <strong>Spaniels Quarterly</strong>",
     );
   });
 });

--- a/components/Chat/Stack/Stack.tsx
+++ b/components/Chat/Stack/Stack.tsx
@@ -18,6 +18,7 @@ import { ApiSearchRequestBody } from "@/types/api/request";
 import { ChatContext } from "@/types/context/search-context";
 import Figure from "@/components/Figure/Figure";
 import { IconClear } from "@/components/Shared/SVG/Icons";
+import SearchResultsMessage from "@/components/Search/ResultsMessage";
 import { buildQuery } from "@/lib/queries/builder";
 import { createResultsMessageFromContext } from "@/lib/chat-helpers";
 import { getQueryRepresentativeThumbnail } from "@/lib/dc-api";
@@ -26,8 +27,8 @@ import { rem } from "@/styles/global";
 
 interface StackProps {
   context: ChatContext;
-  isDismissable: boolean;
   dismissCallback?: () => void;
+  isDismissable: boolean;
 }
 
 /**
@@ -35,13 +36,13 @@ interface StackProps {
  */
 const Stack = ({
   context,
-  isDismissable = true,
   dismissCallback,
+  isDismissable = true,
 }: StackProps) => {
   const [isDismissed, setIsDismissed] = useState(false);
   const [thumbnail, setThumbnail] = useState<string>("");
 
-  const resultsMessage = createResultsMessageFromContext(context);
+  const label = createResultsMessageFromContext(context);
 
   function handleDismiss() {
     setIsDismissed(true);
@@ -88,13 +89,13 @@ const Stack = ({
   /**
    * If there is no results message, we do not render the stack.
    */
-  if (!resultsMessage) return null;
+  if (!label) return null;
 
   return (
     <StyledStack
       data-testid="stack"
       data-isdismissed={isDismissed}
-      data-results-message={resultsMessage}
+      data-results-message={label}
     >
       <StyledStackContent>
         <Tooltip.Provider delayDuration={20}>
@@ -118,7 +119,9 @@ const Stack = ({
                 collisionPadding={19}
               >
                 <TooltipArrow />
-                <TooltipBody>{resultsMessage}</TooltipBody>
+                <TooltipBody>
+                  <SearchResultsMessage label={label} textAlign="center" />
+                </TooltipBody>
               </TooltipContent>
             </Tooltip.Portal>
           </Tooltip.Root>

--- a/components/Search/Panel.styled.tsx
+++ b/components/Search/Panel.styled.tsx
@@ -2,23 +2,43 @@ import { ContainerStyled } from "@/components/Shared/Container";
 import { StyledInterstitial } from "@/components/Chat/Response/Interstitial.styled";
 import { styled } from "@/stitches.config";
 
-const SearchResultsLabel = styled(StyledInterstitial, {
-  marginBottom: "$gr4",
-  alignItems: "baseline",
+const SearchResultsLabel = styled("div", {
+  fontFamily: "$northwesternSansRegular",
+  fontWeight: "400",
+  fontSize: "$gr3",
+  display: "flex",
+  alignItems: "center",
+  color: "$purple60",
+  borderRadius: "1em",
+  backgroundPosition: "61.8%",
+  flexGrow: "1",
+  margin: "0 0 $gr4",
+  paddingRight: 0,
   textAlign: "center",
   justifyContent: "space-between",
   width: "100%",
-
-  "> div": {
-    display: "flex",
-    alignItems: "center",
-    gap: "$gr2",
-  },
+  gap: "$gr4",
 
   "@sm": {
     flexDirection: "column",
     alignItems: "center",
   },
+
+  strong: {
+    fontFamily: "$northwesternSansBold",
+    fontWeight: "400",
+    color: "$purple",
+  },
+
+  em: {
+    fontStyle: "italic",
+    color: "$purple",
+  },
+});
+
+const SearchResultsLabelMessage = styled("div", {
+  lineHeight: "1.35em",
+  flexGrow: "1",
 });
 
 const StyledBackButton = styled("button", {
@@ -26,7 +46,7 @@ const StyledBackButton = styled("button", {
   padding: "0",
   height: "38px",
   alignItems: "center",
-  gap: "$gr1",
+  gap: "$gr2",
   color: "$purple",
   background: "transparent",
   fontFamily: "$northwesternSansBold",
@@ -106,6 +126,7 @@ export {
   StyledSearchPanel,
   StyledSearchPanelContent,
   SearchResultsLabel,
+  SearchResultsLabelMessage,
   StyledBackButton,
   StyledIncludeResults,
 };

--- a/components/Search/Panel.tsx
+++ b/components/Search/Panel.tsx
@@ -2,32 +2,36 @@ import {
   CheckboxIndicator,
   CheckboxRoot as CheckboxRootStyled,
 } from "@/components/Shared/Checkbox.styled";
-import { IconArrowBack, IconSparkles } from "@/components/Shared/SVG/Icons";
 import {
   SearchResultsLabel,
+  SearchResultsLabelMessage,
   StyledBackButton,
   StyledIncludeResults,
   StyledSearchPanel,
   StyledSearchPanelContent,
 } from "./Panel.styled";
+import { getContextFacets, parseUrlFacets } from "@/lib/utils/facet-helpers";
 import { useEffect, useRef, useState } from "react";
 
 import { ApiSearchRequestBody } from "@/types/api/request";
 import { ApiSearchResponse } from "@/types/api/response";
+import Balancer from "react-wrap-balancer";
 import BouncingLoader from "@/components/Shared/BouncingLoader";
 import type { CheckboxProps } from "@radix-ui/react-checkbox";
 import Container from "@/components/Shared/Container";
 import { DC_API_SEARCH_URL } from "@/lib/constants/endpoints";
+import { IconArrowBack } from "@/components/Shared/SVG/Icons";
 import { IconCheck } from "@/components/Shared/SVG/Icons";
 import { SEARCH_RESULTS_PER_PAGE } from "@/lib/constants/common";
 import SearchOptions from "@/components/Search/Options";
 import SearchResults from "@/components/Search/Results";
+import SearchResultsMessage from "./ResultsMessage";
 import { SearchResultsState } from "@/types/components/search";
 import Stack from "../Chat/Stack/Stack";
 import { StyledInterstitialIcon } from "@/components/Chat/Response/Interstitial.styled";
 import { apiPostRequest } from "@/lib/dc-api";
 import { buildQuery } from "@/lib/queries/builder";
-import { parseUrlFacets } from "@/lib/utils/facet-helpers";
+import { createResultsMessageFromContext } from "@/lib/chat-helpers";
 import { useRouter } from "next/router";
 import { useSearchState } from "@/context/search-context";
 
@@ -59,6 +63,12 @@ const SearchPanel = () => {
   const query = router.query.q as string;
   const page = (router.query.page as string) || "1";
   const urlFacets = parseUrlFacets(router.query);
+
+  const label = createResultsMessageFromContext({
+    facets: getContextFacets(urlFacets),
+    query,
+    works: [],
+  });
 
   const requestUrl = new URL(DC_API_SEARCH_URL);
   const body: ApiSearchRequestBody = buildQuery(
@@ -197,31 +207,8 @@ const SearchPanel = () => {
             />
             {query && (
               <SearchResultsLabel>
-                <div>
-                  <div
-                    style={{
-                      display: "flex",
-                      flexDirection: "column",
-                    }}
-                  >
-                    <StyledBackButton onClick={handleBack}>
-                      <IconArrowBack /> Back to conversation
-                    </StyledBackButton>
-                    <StyledIncludeResults>
-                      <CheckboxRootStyled
-                        id="useDocsAsContext"
-                        checked={useDocsAsContext}
-                        onCheckedChange={(e) => handleCheckChange(e)}
-                      >
-                        <CheckboxIndicator>
-                          <IconCheck />
-                        </CheckboxIndicator>
-                      </CheckboxRootStyled>
-                      <label htmlFor="useDocsAsContext">
-                        Chat about results
-                      </label>
-                    </StyledIncludeResults>
-                  </div>
+                <StyledBackButton onClick={handleBack}>
+                  <IconArrowBack /> Back to conversation
                   {conversation.stagedContext?.works &&
                     conversation.stagedContext.works.length > 0 && (
                       <Stack
@@ -229,15 +216,10 @@ const SearchPanel = () => {
                         isDismissable={false}
                       />
                     )}
-                </div>
-                <div>
-                  <StyledInterstitialIcon>
-                    <IconSparkles />
-                  </StyledInterstitialIcon>
-                  <label>
-                    Search results for <strong>{query}</strong>
-                  </label>
-                </div>
+                </StyledBackButton>
+                {label && (
+                  <SearchResultsMessage label={label} textAlign="right" />
+                )}
               </SearchResultsLabel>
             )}
           </Container>

--- a/components/Search/Results.tsx
+++ b/components/Search/Results.tsx
@@ -1,22 +1,28 @@
 import {
   NoResultsMessage,
-  ResultsMessage,
   ResultsWrapper,
   ResultsWrapperHeader,
 } from "@/components/Search/Search.styled";
 
+import { ChatContext } from "@/types/context/search-context";
 import Grid from "@/components/Grid/Grid";
 import IIIFShare from "../Shared/IIIF/Share";
 import PaginationAltCounts from "@/components/Search/PaginationAltCounts";
 import { SEARCH_RESULTS_PER_PAGE } from "@/lib/constants/common";
+import SearchResultsMessage from "./ResultsMessage";
 import { SearchResultsState } from "@/types/components/search";
+import { createResultsMessageFromContext } from "@/lib/chat-helpers";
 import { iiifSearchUri } from "@/lib/dc-api";
-import { pluralize } from "@/lib/utils/count-helpers";
 import useGenerativeAISearchToggle from "@/hooks/useGenerativeAISearchToggle";
 import { useRouter } from "next/router";
 
-const SearchResults: React.FC<SearchResultsState> = ({
+interface SearchResultsStateWithContext extends SearchResultsState {
+  context?: ChatContext;
+}
+
+const SearchResults: React.FC<SearchResultsStateWithContext> = ({
   data,
+  context,
   error,
   loading,
 }) => {
@@ -25,6 +31,7 @@ const SearchResults: React.FC<SearchResultsState> = ({
 
   const iiifCollection = iiifSearchUri(router.query, SEARCH_RESULTS_PER_PAGE);
   const totalResults = data?.pagination?.total_hits;
+  const label = createResultsMessageFromContext(context, totalResults);
 
   return (
     <ResultsWrapper>
@@ -35,10 +42,7 @@ const SearchResults: React.FC<SearchResultsState> = ({
           {!isAI &&
             (totalResults ? (
               <ResultsWrapperHeader>
-                <ResultsMessage data-testid="results-count">
-                  {pluralize("result", totalResults)} for{" "}
-                  <strong>{router.query.q}</strong>
-                </ResultsMessage>
+                {label && <SearchResultsMessage label={label} />}
                 <IIIFShare uri={iiifCollection} />
               </ResultsWrapperHeader>
             ) : (

--- a/components/Search/ResultsMessage.test.tsx
+++ b/components/Search/ResultsMessage.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+
+import SearchResultsMessage from "./ResultsMessage";
+
+describe("SearchResultsMessage", () => {
+  it("renders the correct message", () => {
+    const label = "Results for <strong>“dog”</strong>";
+
+    render(<SearchResultsMessage label={label} />);
+    const message = screen.getByTestId("search-results-message-label");
+    expect(message).toHaveTextContent("Results for “dog”");
+  });
+
+  it("renders with an icon", () => {
+    const label = "Results for <strong>“cat”</strong>";
+    const icon = <span>🔍</span>;
+
+    render(<SearchResultsMessage label={label} icon={icon} />);
+    const message = screen.getByTestId("search-results-message-label");
+    expect(message).toHaveTextContent("Results for “cat”");
+    expect(screen.getByText("🔍")).toBeInTheDocument();
+  });
+
+  it("applies text alignment styles", () => {
+    const label = "Results for <strong>“bird”</strong>";
+
+    render(<SearchResultsMessage label={label} textAlign="center" />);
+    const message = screen.getByTestId("search-results-message");
+    const childElement = message.firstChild as HTMLDivElement;
+    expect(childElement).toHaveStyle("text-align: center");
+  });
+});

--- a/components/Search/ResultsMessage.tsx
+++ b/components/Search/ResultsMessage.tsx
@@ -1,0 +1,42 @@
+import Balancer from "react-wrap-balancer";
+import { CSSProperties } from "react";
+import { StyledInterstitialIcon } from "../Chat/Response/Interstitial.styled";
+import { SearchResultsLabelMessage as StyledLabel } from "./Panel.styled";
+import { styled } from "@/stitches.config";
+
+const SearchResultsMessage = ({
+  label,
+  icon,
+  textAlign = "left",
+}: {
+  label: string;
+  icon?: React.ReactNode;
+  textAlign?: CSSProperties["textAlign"];
+}) => {
+  return (
+    <StyledSearchResultsMessage data-testid="search-results-message">
+      {icon && <StyledInterstitialIcon>{icon}</StyledInterstitialIcon>}
+      <StyledLabel style={{ textAlign }}>
+        {label && (
+          <Balancer
+            as="label"
+            dangerouslySetInnerHTML={{
+              __html: label,
+            }}
+            data-testid="search-results-message-label"
+          />
+        )}
+      </StyledLabel>
+    </StyledSearchResultsMessage>
+  );
+};
+
+export const StyledSearchResultsMessage = styled("div", {
+  display: "flex",
+  alignItems: "center",
+  gap: "$gr2",
+  flexGrow: "1",
+  width: "100%",
+});
+
+export default SearchResultsMessage;

--- a/components/Search/Search.styled.ts
+++ b/components/Search/Search.styled.ts
@@ -1,3 +1,4 @@
+import { StyledSearchResultsMessage } from "./ResultsMessage";
 import { TabsContent } from "@radix-ui/react-tabs";
 import { styled } from "@/stitches.config";
 
@@ -86,21 +87,6 @@ const Button = styled("button", {
   },
 });
 
-const ResultsMessage = styled("span", {
-  color: "$black50",
-  fontSize: "$gr3",
-
-  strong: {
-    color: "$purple",
-    fontFamily: "$northwesternSansBold",
-    fontWeight: "400",
-  },
-
-  "@lg": {
-    padding: "0 0 $gr3",
-  },
-});
-
 const NoResultsMessage = styled("span", {
   display: "flex",
   flexDirection: "column",
@@ -138,6 +124,21 @@ const ResultsWrapperHeader = styled("header", {
   justifyContent: "space-between",
   alignItems: "center",
   padding: "0 $gr4 $gr4",
+
+  [`${StyledSearchResultsMessage}`]: {
+    color: "$black50",
+    fontSize: "$gr3",
+
+    strong: {
+      color: "$purple",
+      fontFamily: "$northwesternSansBold",
+      fontWeight: "400",
+    },
+
+    "@lg": {
+      padding: "0 0 $gr3",
+    },
+  },
 });
 
 const StyledResponseWrapper = styled("div", {
@@ -177,7 +178,6 @@ const StyledTabsContent = styled(TabsContent, {
 export {
   Button,
   NoResultsMessage,
-  ResultsMessage,
   ResultsWrapper,
   ResultsWrapperHeader,
   SearchStyled,

--- a/components/Shared/IIIF/Share.tsx
+++ b/components/Shared/IIIF/Share.tsx
@@ -85,6 +85,7 @@ export const StyledIIIFShare = styled("div", {
   position: "relative",
   zIndex: 1,
   padding: "0 $gr1",
+  whiteSpace: "nowrap",
 
   "&:last-child": {
     paddingRight: "0",

--- a/components/Shared/Tooltip.styled.tsx
+++ b/components/Shared/Tooltip.styled.tsx
@@ -10,18 +10,23 @@ export const TooltipArrow = styled(Tooltip.Arrow, {
 
 export const TooltipBody = styled("div", {
   background: "$white",
-  boxShadow: "5px 5px 19px 0 #0002",
-  maxWidth: "450px",
-  lineHeight: "1.5em",
+  boxShadow: "5px 5px 19px #0002",
+  maxWidth: "350px",
+  lineHeight: "1.47em",
   fontSize: "$gr2 !important",
   fontFamily: "$northwesternSansRegular",
   padding: "$gr3",
   borderRadius: "3px",
+  color: "$black50",
+
+  strong: {
+    fontFamily: "$northwesternSansBold",
+    fontWeight: "400",
+    color: "$black80",
+  },
 
   em: {
-    color: "$black50",
-    marginTop: "$gr1",
-    display: "block",
-    fontSize: "$gr1",
+    fontStyle: "italic",
+    color: "$black80",
   },
 });

--- a/lib/chat-helpers.test.ts
+++ b/lib/chat-helpers.test.ts
@@ -1,0 +1,47 @@
+import { createResultsMessageFromContext } from "@/lib/chat-helpers";
+
+describe("createResultsMessageFromContext", () => {
+  it("should create a results message with facets and query", () => {
+    const context = {
+      query: "test query",
+      facets: [
+        { field: "author", value: "John Doe" },
+        { field: "year", value: "2021" },
+      ],
+      works: [],
+    };
+
+    const result = createResultsMessageFromContext(context);
+    expect(result).toBe(
+      "Results for <strong>“test query”</strong> filtered by <em>author</em> for <strong>John Doe</strong>, <em>year</em> for <strong>2021</strong>",
+    );
+  });
+
+  it("should create a results message without facets", () => {
+    const context = {
+      query: "dogs",
+      facets: [],
+      works: [],
+    };
+
+    const result = createResultsMessageFromContext(context);
+    expect(result).toBe("Results for <strong>“dogs”</strong>");
+  });
+
+  it("should return just the results text if no context is provided", () => {
+    const result = createResultsMessageFromContext(undefined);
+    expect(result).toBe("Results");
+  });
+
+  it("should return just the results text with counts if totalResults is provided", () => {
+    const context = {
+      query: "dogs",
+      facets: [],
+      works: [],
+    };
+    const totalResults = 100;
+
+    const result = createResultsMessageFromContext(context, totalResults);
+    expect(result).toBe("100 results for <strong>“dogs”</strong>");
+  });
+});

--- a/lib/utils/facet-helpers.ts
+++ b/lib/utils/facet-helpers.ts
@@ -1,6 +1,7 @@
 import { ALL_FACETS, FACETS } from "@/lib/constants/facets-model";
 import { FacetsGroup, FacetsInstance } from "@/types/components/facets";
 
+import { Facet } from "@/types/context/search-context";
 import { UrlFacets } from "@/types/context/filter-context";
 
 /**
@@ -29,6 +30,13 @@ export function facetRegex(str?: string) {
 
 export const getAllFacetIds = () => {
   return ALL_FACETS.facets.map((facet) => facet.id);
+};
+
+export const getContextFacets = (urlFacets: UrlFacets): Facet[] => {
+  return Object.entries(urlFacets).map(([key, value]) => ({
+    field: key,
+    value: Array.isArray(value) ? value.join(", ") : value,
+  }));
 };
 
 export const getFacetById = (id: string): FacetsInstance | undefined => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "react-error-boundary": "^4.0.13",
         "react-masonry-css": "^1.0.16",
         "react-share": "^5.0.3",
+        "react-wrap-balancer": "^1.1.1",
         "rehype-raw": "^7.0.0",
         "rehype-stringify": "^10.0.0",
         "remark-parse": "^11.0.0",
@@ -16073,6 +16074,14 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-wrap-balancer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/react-wrap-balancer/-/react-wrap-balancer-1.1.1.tgz",
+      "integrity": "sha512-AB+l7FPRWl6uZ28VcJ8skkwLn2+UC62bjiw8tQUrZPlEWDVnR9MG0lghyn7EyxuJSsFEpht4G+yh2WikEqQ/5Q==",
+      "peerDependencies": {
+        "react": ">=16.8.0 || ^17.0.0 || ^18"
       }
     },
     "node_modules/redent": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "react-error-boundary": "^4.0.13",
     "react-masonry-css": "^1.0.16",
     "react-share": "^5.0.3",
+    "react-wrap-balancer": "^1.1.1",
     "rehype-raw": "^7.0.0",
     "rehype-stringify": "^10.0.0",
     "remark-parse": "^11.0.0",

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -6,6 +6,7 @@ import {
   StyledResponseWrapper,
   StyledTabsContent,
 } from "@/components/Search/Search.styled";
+import { getContextFacets, parseUrlFacets } from "@/lib/utils/facet-helpers";
 
 import { ActiveTab } from "@/types/context/search-context";
 import { ApiSearchRequestBody } from "@/types/api/request";
@@ -31,7 +32,6 @@ import { buildDataLayer } from "@/lib/ga/data-layer";
 import { buildQuery } from "@/lib/queries/builder";
 import { getWork } from "@/lib/work-helpers";
 import { loadDefaultStructuredData } from "@/lib/json-ld";
-import { parseUrlFacets } from "@/lib/utils/facet-helpers";
 import useGenerativeAISearchToggle from "@/hooks/useGenerativeAISearchToggle";
 import { useRouter } from "next/router";
 import { useSearchState } from "@/context/search-context";
@@ -71,6 +71,7 @@ const SearchPage: NextPage = () => {
   });
 
   const showStreamedResponse = Boolean(user?.isLoggedIn && isAI);
+  const urlFacets = parseUrlFacets(router.query);
 
   /**
    * on a query change, we check to see if the user is using the AI and then
@@ -98,7 +99,6 @@ const SearchPage: NextPage = () => {
 
     (async () => {
       try {
-        const urlFacets = parseUrlFacets(router.query);
         const requestUrl = new URL(DC_API_SEARCH_URL);
         const pipeline = process.env.NEXT_PUBLIC_OPENSEARCH_PIPELINE;
 
@@ -256,7 +256,14 @@ const SearchPage: NextPage = () => {
 
             <Tabs.Content value="results">
               <Container containerType="wide">
-                <SearchResults {...searchResults} />
+                <SearchResults
+                  {...searchResults}
+                  context={{
+                    facets: getContextFacets(urlFacets),
+                    query: String(q),
+                    works: [],
+                  }}
+                />
               </Container>
             </Tabs.Content>
           </Tabs.Root>


### PR DESCRIPTION
## What does this do?

This work abstracts out search results message under a single component and a set of helpers. In doing so, we are now appending any applied facets to the message. This can be reviewed at https://preview-5606-unify-results-message.dc.rdc-staging.library.northwestern.edu/search

### Legacy search example

On a legacy search, counts will render. For example, the message for a search on "joan baez" with _genre_ filtered by **black-and-white negatives** will render as:

```
469 results for “joan baez” filtered by genre for black-and-white negatives
```

https://preview-5606-unify-results-message.dc.rdc-staging.library.northwestern.edu/search?q=joan+baez&genre=black-and-white+negatives

<img width="1383" height="1200" alt="image" src="https://github.com/user-attachments/assets/6866e435-2b8e-4f1e-a270-753f02075c86" />

### AI Mode search tool returns

On a AI Mode search tool, the designated `message.input.query` will be the term searched for and render. So if the a question for “joan baez” prompts the LLM searches for "joan baez photographs" the returned message would be:

```
Results for “joan baez photos” filtered by genre for black-and-white negatives
```

Clicking **View Results** would bring the user to a search results screen for those results where they will see the message again.

<img width="1383" height="1263" alt="image" src="https://github.com/user-attachments/assets/b6f055e6-f00b-4120-8cac-f909684ae0f6" />

### AI Mode stack tooltips

On AI Mode, whenever a "Stack" of works with a tooltip is present, a message will display as well.

<img width="1383" height="1263" alt="image" src="https://github.com/user-attachments/assets/b1afef1b-7d67-41dc-80de-95bb1a14eee1" />