### PR TITLE
Keep facets and carry on.

### DIFF
--- a/components/Chat/Chat.test.tsx
+++ b/components/Chat/Chat.test.tsx
@@ -22,7 +22,6 @@ jest.mock("@/context/search-context", () => {
           body: [],
           ref: "",
         },
-        searchFixed: false,
       },
     }),
   };

--- a/components/Chat/Chat.tsx
+++ b/components/Chat/Chat.tsx
@@ -35,10 +35,6 @@ const Chat = () => {
               aggregations: [],
             },
           ],
-          /**
-           * Clear the staged context after submitting a question
-           */
-          stagedContext: undefined, // clear chat context on new question
         },
       });
     }

--- a/components/Chat/Conversation.tsx
+++ b/components/Chat/Conversation.tsx
@@ -1,10 +1,10 @@
 import { IconRefresh, IconReply, IconSparkles } from "../Shared/SVG/Icons";
+import React, { useEffect, useRef } from "react";
 import {
   StyledChatConversation,
   StyledResetButton,
 } from "./Conversation.styled";
 import { defaultState, useSearchState } from "@/context/search-context";
-import { useEffect, useRef } from "react";
 
 import { AI_SYS_PROMPT_MSG } from "@/lib/constants/common";
 import Stack from "./Stack/Stack";
@@ -31,17 +31,8 @@ const ChatConversation: React.FC<ChatConversationProps> = ({
 
   const textareaPlaceholder = "Ask a followup question";
 
-  const handleScroll = () => {
-    // handle scrolling
-  };
-
   useEffect(() => {
-    window.addEventListener("scroll", handleScroll);
-    return () => window.removeEventListener("scroll", handleScroll);
-  }, []);
-
-  useEffect(() => {
-    if (conversation?.stagedContext?.works?.length && !panel.open) {
+    if (conversation?.stagedContext?.facets && !panel.open) {
       const searchWrapper = document.getElementById("search-wrapper");
 
       if (searchWrapper) {
@@ -59,7 +50,7 @@ const ChatConversation: React.FC<ChatConversationProps> = ({
         textareaRef.current.focus();
       }
     }
-  }, [conversation?.stagedContext?.works, panel.open]);
+  }, [conversation?.stagedContext?.facets, panel.open]);
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -137,14 +128,13 @@ const ChatConversation: React.FC<ChatConversationProps> = ({
             onFocus={handleFocus}
             onBlur={handleFocus}
           ></textarea>
-          {conversation.stagedContext?.works &&
-            conversation.stagedContext.works.length > 0 && (
-              <Stack
-                context={conversation.stagedContext}
-                isDismissable
-                dismissCallback={handleStackDismiss}
-              />
-            )}
+          {conversation.stagedContext && (
+            <Stack
+              context={conversation.stagedContext}
+              isDismissable
+              dismissCallback={handleStackDismiss}
+            />
+          )}
           <button type="submit" disabled={isStreaming}>
             {isStreaming ? (
               <>
@@ -180,4 +170,4 @@ export const StyledSystemPrompt = styled("p", {
   },
 });
 
-export default ChatConversation;
+export default React.memo(ChatConversation);

--- a/components/Chat/Response/Interstitial.tsx
+++ b/components/Chat/Response/Interstitial.tsx
@@ -39,6 +39,8 @@ const ResponseInterstitial: React.FC<ResponseInterstitialProps> = ({
 
   const handleViewResults = (action: string) => {
     const facets = context?.facets.map((facet) => {
+      if (facet.field) return facet;
+
       const [key, value] = Object.entries(facet)[0];
       const field = getFacetIdByField(key);
       return { field, value };

--- a/components/Facets/Filter/Clear.tsx
+++ b/components/Facets/Filter/Clear.tsx
@@ -1,18 +1,18 @@
 import { FilterClearStyled } from "@/components/Facets/Filter/Clear.styled";
 import React from "react";
 import { useFilterState } from "@/context/filter-context";
+import { useLayoutState } from "@/context/layout-context";
 import { useRouter } from "next/router";
-import { useSearchState } from "@/context/search-context";
 
 interface FilterClearProps {
   isModal?: boolean;
 }
 
 const FilterClear: React.FC<FilterClearProps> = ({ isModal = false }) => {
-  const {
-    searchState: { searchFixed },
-  } = useSearchState();
   const { filterDispatch } = useFilterState();
+  const {
+    layoutState: { searchFixed },
+  } = useLayoutState();
 
   const router = useRouter();
   const {

--- a/components/Facets/UserFacets/UserFacets.test.tsx
+++ b/components/Facets/UserFacets/UserFacets.test.tsx
@@ -7,6 +7,18 @@ import { SearchContextStore } from "@/types/context/search-context";
 import { SearchProvider } from "@/context/search-context";
 import UserFacets from "./UserFacets";
 
+jest.mock("@/context/layout-context", () => ({
+  __esModule: true,
+  useLayoutState: jest.fn(() => {
+    return {
+      layoutDispatch: jest.fn(),
+      layoutState: {
+        searchFixed: false,
+      },
+    };
+  }),
+}));
+
 const searchStateDefault: SearchContextStore = {
   aggregations: {},
   chat: {
@@ -14,7 +26,6 @@ const searchStateDefault: SearchContextStore = {
     documents: [],
     question: "",
   },
-  searchFixed: false,
 };
 
 const searchState: SearchContextStore = {
@@ -24,7 +35,6 @@ const searchState: SearchContextStore = {
     documents: [],
     question: "",
   },
-  searchFixed: false,
 };
 
 const filterStateDefault = {

--- a/components/Facets/UserFacets/UserFacets.tsx
+++ b/components/Facets/UserFacets/UserFacets.tsx
@@ -13,8 +13,8 @@ import { IconChevronDown } from "@/components/Shared/SVG/Icons";
 import { UrlFacets } from "@/types/context/filter-context";
 import { getFacetById } from "@/lib/utils/facet-helpers";
 import { useFilterState } from "@/context/filter-context";
+import { useLayoutState } from "@/context/layout-context";
 import { useRouter } from "next/router";
-import { useSearchState } from "@/context/search-context";
 
 interface FacetsCurrentUserProps {
   screen: "modal" | "search";
@@ -35,8 +35,8 @@ const FacetsCurrentUser: React.FC<FacetsCurrentUserProps> = ({
 
   const { filterDispatch, filterState } = useFilterState();
   const {
-    searchState: { searchFixed },
-  } = useSearchState();
+    layoutState: { searchFixed },
+  } = useLayoutState();
 
   const [currentOptions, setCurrentOptions] = useState<CurrentFacet[]>([]);
   const [isOpen, setIsOpen] = useState(false);

--- a/components/Figure/Figure.tsx
+++ b/components/Figure/Figure.tsx
@@ -47,7 +47,7 @@ const Figure: React.FC<FigureProps & FigureVariants> = (props) => {
   const srcSetSizes = `(max-width: ${width.xxs}px) 100vw`;
 
   return (
-    <FigureStyled data-orientation={orientation} {...props}>
+    <FigureStyled data-orientation={orientation}>
       <FigureImageWrapper>
         <FigurePlaceholder ratio={aspectRatio ? aspectRatio : 1}>
           {!data.priority && (

--- a/components/Header/Primary.tsx
+++ b/components/Header/Primary.tsx
@@ -6,26 +6,26 @@ import Link from "next/link";
 import Nav from "@/components/Nav/Nav";
 import Search from "@/components/Search/Search";
 import useElementPosition from "@/hooks/useElementPosition";
-import { useSearchState } from "@/context/search-context";
+import { useLayoutState } from "@/context/layout-context";
 
 const HeaderPrimary: React.FC = () => {
   const [searchActive, setSearchActive] = useState<boolean>(false);
 
   const {
-    searchDispatch,
-    searchState: { searchFixed },
-  } = useSearchState();
+    layoutDispatch,
+    layoutState: { searchFixed },
+  } = useLayoutState();
 
   const primaryRef = useRef<HTMLDivElement>(null);
   const scrollPosition = useElementPosition(primaryRef);
 
   useEffect(
     () =>
-      searchDispatch({
+      layoutDispatch({
         searchFixed: scrollPosition > 0,
         type: "updateSearchFixed",
       }),
-    [searchDispatch, scrollPosition],
+    [layoutDispatch, scrollPosition],
   );
 
   const handleIsSearchActive = (status: boolean) => {

--- a/components/Search/Options.tsx
+++ b/components/Search/Options.tsx
@@ -11,23 +11,21 @@ import Container from "@/components/Shared/Container";
 import Facets from "@/components/Facets";
 import FacetsWorkType from "@/components/Facets/WorkType/WorkType";
 import SearchPublicOnlyWorks from "@/components/Search/PublicOnlyWorks";
-import { useSearchState } from "@/context/search-context";
 import { createPortal } from "react-dom";
+import { useLayoutState } from "@/context/layout-context";
+import { useSearchState } from "@/context/search-context";
 
 interface SearchOptionsProps {
-  tabs: React.ReactNode;
   activeTab?: string;
-  renderTabList?: boolean;
 }
 
-const SearchOptions: React.FC<SearchOptionsProps> = ({
-  tabs,
-  activeTab,
-  renderTabList,
-}) => {
+const SearchOptions: React.FC<SearchOptionsProps> = ({ activeTab }) => {
   const {
-    searchState: { searchFixed, panel },
+    searchState: { panel },
   } = useSearchState();
+  const {
+    layoutState: { searchFixed },
+  } = useLayoutState();
 
   const optionsRef = useRef<HTMLDivElement>(null);
 

--- a/components/Search/Panel.test.tsx
+++ b/components/Search/Panel.test.tsx
@@ -19,6 +19,18 @@ jest.mock("@/context/search-context", () => ({
   }),
 }));
 
+jest.mock("@/context/layout-context", () => ({
+  __esModule: true,
+  useLayoutState: jest.fn(() => {
+    return {
+      layoutDispatch: jest.fn(),
+      layoutState: {
+        searchFixed: false,
+      },
+    };
+  }),
+}));
+
 describe("SearchPanel", () => {
   it("renders the search panel in closed state", async () => {
     render(<SearchPanel />);

--- a/components/Search/Search.tsx
+++ b/components/Search/Search.tsx
@@ -62,26 +62,30 @@ const Search: React.FC<SearchProps> = ({ isSearchActive }) => {
     const updatedFacets: UrlFacets = {};
     const allFacetsIds = getAllFacetIds();
 
+    const isScopedCollection = searchScope === "collection" && collectionLabel;
+
+    const context = {
+      query: searchValue,
+      facets: isScopedCollection
+        ? [
+            {
+              "collection.title.keyword": collectionLabel,
+            },
+          ]
+        : [],
+      works: [],
+    };
+
     const conversation = {
       ref: uuidv4(),
       initialQuestion: searchValue,
+      stagedContext: isScopedCollection ? context : undefined,
       turns: [
         {
           question: searchValue,
           answer: "",
           aggregations: [],
-          context: {
-            query: searchValue,
-            facets:
-              searchScope === "collection" && collectionLabel
-                ? [
-                    {
-                      "collection.title.keyword": collectionLabel,
-                    },
-                  ]
-                : [],
-            works: [],
-          },
+          context,
         },
       ],
     };

--- a/components/Shared/AuthDialog.styled.ts
+++ b/components/Shared/AuthDialog.styled.ts
@@ -88,7 +88,7 @@ const AuthDialogColumn = styled("div", {
     margin: 0,
   },
 
-  a: {
+  "a[role=button]": {
     color: "$white",
     width: "100%",
   },

--- a/components/Shared/AuthDialog.tsx
+++ b/components/Shared/AuthDialog.tsx
@@ -134,6 +134,7 @@ export default function AuthDialog() {
                 isLowercase
                 //@ts-ignore - by setting as="a" we lose the type but href is set
                 href={ssoUrl}
+                role="button"
               >
                 Northwestern NetID
               </Button>

--- a/context/layout-context.tsx
+++ b/context/layout-context.tsx
@@ -1,0 +1,63 @@
+// create layout-context to update layout state
+
+import React from "react";
+
+interface LayoutContextStore {
+  searchFixed: boolean;
+}
+
+type Action = {
+  type: "updateSearchFixed";
+  searchFixed: boolean;
+};
+type Dispatch = (action: Action) => void;
+type State = LayoutContextStore;
+type LayoutProviderProps = {
+  children: React.ReactNode;
+  initialState?: LayoutContextStore;
+};
+
+const defaultState: LayoutContextStore = {
+  searchFixed: false,
+};
+
+const LayoutStateContext = React.createContext<
+  { layoutState: State; layoutDispatch: Dispatch } | undefined
+>(undefined);
+
+function layoutReducer(state: State, action: Action) {
+  switch (action.type) {
+    case "updateSearchFixed": {
+      return {
+        ...state,
+        searchFixed: action.searchFixed,
+      };
+    }
+    default: {
+      throw new Error(`Unhandled action type`);
+    }
+  }
+}
+
+function LayoutProvider({
+  initialState = defaultState,
+  children,
+}: LayoutProviderProps) {
+  const [state, dispatch] = React.useReducer(layoutReducer, initialState);
+  const value = { layoutDispatch: dispatch, layoutState: state };
+  return (
+    <LayoutStateContext.Provider value={value}>
+      {children}
+    </LayoutStateContext.Provider>
+  );
+}
+
+function useLayoutState() {
+  const context = React.useContext(LayoutStateContext);
+  if (context === undefined) {
+    throw new Error("useLayoutState must be used within a LayoutProvider");
+  }
+  return context;
+}
+
+export { LayoutProvider, useLayoutState };

--- a/context/search-context.tsx
+++ b/context/search-context.tsx
@@ -14,8 +14,7 @@ type Action =
         query?: string;
       };
     }
-  | { type: "updateSearch"; q: string }
-  | { type: "updateSearchFixed"; searchFixed: boolean };
+  | { type: "updateSearch"; q: string };
 
 type Dispatch = (action: Action) => void;
 type State = SearchContextStore;
@@ -35,7 +34,6 @@ const defaultState: SearchContextStore = {
     open: false,
     query: undefined,
   },
-  searchFixed: false,
 };
 
 const SearchStateContext = React.createContext<
@@ -54,12 +52,6 @@ function searchReducer(state: State, action: Action) {
       return {
         ...state,
         q: action.q,
-      };
-    }
-    case "updateSearchFixed": {
-      return {
-        ...state,
-        searchFixed: action.searchFixed,
       };
     }
     case "updatePanel": {

--- a/hooks/useChatSocket.ts
+++ b/hooks/useChatSocket.ts
@@ -37,12 +37,12 @@ const useChatSocket = () => {
     socketRef.current = new WebSocket(url);
 
     socketRef.current.onopen = () => {
-      console.log("WebSocket connected");
+      // console.log("WebSocket connected");
       setIsConnected(true);
     };
 
     socketRef.current.onclose = () => {
-      console.log("WebSocket disconnected");
+      // console.log("WebSocket disconnected");
       setIsConnected(false);
     };
 
@@ -62,7 +62,7 @@ const useChatSocket = () => {
 
   const sendMessage = useCallback((data: object) => {
     if (socketRef.current && socketRef.current.readyState === WebSocket.OPEN) {
-      console.log("Sending message", data);
+      // console.log("Sending message", data);
       socketRef.current.send(JSON.stringify(data));
     }
   }, []);

--- a/lib/chat-helpers.ts
+++ b/lib/chat-helpers.ts
@@ -71,13 +71,14 @@ function createResultsMessageFromContext(
     ? pluralize("result", totalResults, "s")
     : "Results";
 
-  if (!context || !context.query) return resultsText;
+  if (!context) return resultsText;
 
   const facets = context.facets.map((facet) => {
     const facetId = Object.keys(facet)[0];
     if (facetId === "field") return facet;
 
     const facetField = getFacetIdByField(facetId);
+    // @ts-ignore
     const facetValue = facet[facetId].replace(/,/g, ", ");
 
     if (!facetField) return {};
@@ -98,7 +99,11 @@ function createResultsMessageFromContext(
     appendFilteredBy = ` filtered by ${facetMessages.join(", ")}`;
   }
 
-  return `${resultsText} for <strong>“${context.query}”</strong>${appendFilteredBy}`;
+  const queryLabel = context.query
+    ? ` for <strong>“${context.query}”</strong>`
+    : "";
+
+  return `${resultsText}${queryLabel}${appendFilteredBy}`;
 }
 
 export {

--- a/lib/dc-api.ts
+++ b/lib/dc-api.ts
@@ -167,9 +167,9 @@ function handleError(err: unknown) {
   if (error.response) {
     // The request was made and the server responded with a status code
     // that falls out of the range of 2xx
-    console.log(error.response.data);
-    console.log(error.response.status);
-    console.log(error.response.headers);
+    // console.log(error.response.data);
+    // console.log(error.response.status);
+    // console.log(error.response.headers);
   } else if (error.request) {
     // The request was made but no response was received
     // `error.request` is an instance of XMLHttpRequest in the browser and an instance of

--- a/lib/utils/facet-helpers.ts
+++ b/lib/utils/facet-helpers.ts
@@ -32,11 +32,36 @@ export const getAllFacetIds = () => {
   return ALL_FACETS.facets.map((facet) => facet.id);
 };
 
-export const getContextFacets = (urlFacets: UrlFacets): Facet[] => {
-  return Object.entries(urlFacets).map(([key, value]) => ({
-    field: key,
-    value: Array.isArray(value) ? value.join(", ") : value,
-  }));
+export const convertUrlFacetsToContextFacets = (
+  urlFacets: UrlFacets,
+): Facet[] => {
+  // url facets may look like [{ "collection": [ "Aldridge Collection" ] }]
+  // we need to lookup the field by its and return field
+  return Object.entries(urlFacets).map(([key, value]) => {
+    const facet = getFacetById(key);
+    if (!facet) return {};
+
+    return { [facet?.field]: Array.isArray(value) ? value.join(", ") : value };
+  });
+};
+
+export const convertContextFacetsToUrlFacets = (
+  contextFacets: Facet[],
+): UrlFacets => {
+  return contextFacets.reduce((acc: UrlFacets, facet) => {
+    const field = getFacetByField(Object.keys(facet)[0]);
+    if (!field) return acc;
+
+    const value = facet[field?.field];
+    if (!value) return acc;
+
+    acc[field.id] = Array.isArray(value) ? value : [value];
+    return acc;
+  }, {});
+};
+
+export const getFacetByField = (field: string): FacetsInstance | undefined => {
+  return ALL_FACETS.facets.find((facet) => facet.field === field);
 };
 
 export const getFacetById = (id: string): FacetsInstance | undefined => {

--- a/next.config.js
+++ b/next.config.js
@@ -52,9 +52,14 @@ module.exports = withBundleAnalyzer({
       "dcapi.rdc.library.northwestern.edu",
       "dcapi.rdc-staging.library.northwestern.edu",
       "iiif.dc.library.northwestern.edu",
-      "iiif.dc.library.northwestern.edu",
       "iiif.stack.rdc-staging.library.northwestern.edu",
       "api.dc.library.northwestern.edu",
+    ],
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "**",
+      },
     ],
   },
   reactStrictMode: false,

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,7 +1,9 @@
 import { GoogleTagManager, sendGTMEvent } from "@next/third-parties/google";
 
 import type { AppProps } from "next/app";
+import AuthDialog from "@/components/Shared/AuthDialog";
 import Head from "next/head";
+import { LayoutProvider } from "@/context/layout-context";
 import { ObjectLiteral } from "@/types";
 import React from "react";
 import { SearchProvider } from "@/context/search-context";
@@ -13,7 +15,7 @@ import { getUser } from "@/lib/user-helpers";
 import globalStyles from "@/styles/global";
 import setupHoneyBadger from "@/lib/honeybadger/config";
 import useLocalStorage from "@/hooks/useLocalStorage";
-import AuthDialog from "@/components/Shared/AuthDialog";
+
 // Init Honeybadger
 setupHoneyBadger();
 
@@ -74,13 +76,15 @@ function MyApp({ Component, pageProps }: MyAppProps) {
 
       <UserProvider>
         <SearchProvider>
-          <style jsx global>{`
-            :root {
-            }
-          `}</style>
-          {mounted && <Component {...pageProps} />}
-          <AuthDialog />
-          <GoogleTagManager gtmId="GTM-NDJXLQW" />
+          <LayoutProvider>
+            <style jsx global>{`
+              :root {
+              }
+            `}</style>
+            {mounted && <Component {...pageProps} />}
+            <AuthDialog />
+            <GoogleTagManager gtmId="GTM-NDJXLQW" />
+          </LayoutProvider>
         </SearchProvider>
       </UserProvider>
     </>

--- a/pages/search.tsx
+++ b/pages/search.tsx
@@ -6,7 +6,10 @@ import {
   StyledResponseWrapper,
   StyledTabsContent,
 } from "@/components/Search/Search.styled";
-import { getContextFacets, parseUrlFacets } from "@/lib/utils/facet-helpers";
+import {
+  convertUrlFacetsToContextFacets,
+  parseUrlFacets,
+} from "@/lib/utils/facet-helpers";
 
 import { ActiveTab } from "@/types/context/search-context";
 import { ApiSearchRequestBody } from "@/types/api/request";
@@ -233,13 +236,7 @@ const SearchPage: NextPage = () => {
             className="tabs-wrapper"
             onValueChange={(value) => setActiveTab(value as ActiveTab)}
           >
-            {activeTab === "results" && (
-              <SearchOptions
-                tabs={<></>} // placeholder for back tab
-                activeTab={activeTab}
-                renderTabList={showStreamedResponse}
-              />
-            )}
+            {activeTab === "results" && <SearchOptions activeTab={activeTab} />}
 
             <StyledTabsContent value="stream">
               <div
@@ -251,7 +248,7 @@ const SearchPage: NextPage = () => {
               >
                 <Chat key={conversation.ref} />
               </div>
-              <SearchPanel />
+              {panel.open && <SearchPanel />}
             </StyledTabsContent>
 
             <Tabs.Content value="results">
@@ -259,8 +256,8 @@ const SearchPage: NextPage = () => {
                 <SearchResults
                   {...searchResults}
                   context={{
-                    facets: getContextFacets(urlFacets),
-                    query: String(q),
+                    facets: convertUrlFacetsToContextFacets(urlFacets),
+                    query: q ? (q as string) : "",
                     works: [],
                   }}
                 />

--- a/test-utils.tsx
+++ b/test-utils.tsx
@@ -1,6 +1,8 @@
 import React, { FC, ReactElement, ReactNode } from "react";
 import { RenderOptions, render } from "@testing-library/react";
+
 import { FilterProvider } from "@/context/filter-context";
+import { LayoutProvider } from "./context/layout-context";
 import { SearchProvider } from "@/context/search-context";
 import { WorkProvider } from "./context/work-context";
 
@@ -12,7 +14,9 @@ const AllTheProviders: FC<AllTheProvidersProps> = ({ children }) => {
   return (
     <SearchProvider>
       <FilterProvider>
-        <WorkProvider>{children}</WorkProvider>
+        <LayoutProvider>
+          <WorkProvider>{children}</WorkProvider>
+        </LayoutProvider>
       </FilterProvider>
     </SearchProvider>
   );

--- a/types/context/search-context.ts
+++ b/types/context/search-context.ts
@@ -1,3 +1,4 @@
+import { ALL_FACETS } from "@/lib/constants/facets-model";
 import type { AggregationResultMessage } from "types/components/chat";
 import { Work } from "@nulib/dcapi-types";
 
@@ -14,10 +15,12 @@ export interface ChatContext {
   facets: Facet[];
 }
 
-// a facet looks { "subject.label": "Nigeria" } or { "collection.title.keyword": "E. H. Duckworth Photograph Collection" }
-export interface Facet {
-  [key: string]: string;
-}
+/**
+ * { "subject.label": "Nigeria" } or
+ * { "collection.title.keyword": "E. H. Duckworth Photograph Collection" }
+ */
+export type FacetKey = (typeof ALL_FACETS.facets)[number]["field"];
+export type Facet = Partial<Record<FacetKey, string>>;
 
 export interface Turn extends Article {
   aggregations: Omit<AggregationResultMessage, "type">["message"][];
@@ -37,7 +40,6 @@ export interface SearchContextStore {
     open: boolean;
     query?: string;
   };
-  searchFixed: boolean;
 }
 
 export interface UserFacets {


### PR DESCRIPTION
## What does this do?

This work will keep the the filtered context of a conversation going if it exists and carry it over to the followup textarea until dismissed or replaced by and new filter. Much of the work included here is part of the process to clean up the passing of context between an initial search, rendered interstitials, the results panel where filters can be refined, and the conversations followup textarea. Many files are touched with all of these moving parts.

### Summary

- Filters will carry through to conversation followup textarea if Collection is searched within
- Filters will carry over from the results panel when use clicks back
- Filters will be dismissed if user manually dismisses 

### Notes

- To avoid rerenders of search results, a new layout-context has been created to separate search logic watching if the search bar is fixed.

## How should we review?

https://preview-5597-keep-facets-and-carry-on.dc.rdc-staging.library.northwestern.edu/

- Go the preview branch.
- Start a search from a collection.
- See that facets carry over.
- Click on a View results -> interstitial and refine
- See that the refined facets carry over
- Ask a followup (note you may need to be explicit to the LLM about the changes in your refinement as it may still be thinking you care more about the original context)
- Dismiss context