### PR TITLE
Remove workgroup title.

### DIFF
--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -111,7 +111,6 @@ const AboutPage: NextPage = () => {
         description={HEAD_META["ABOUT"].description}
       >
         <HeroBasic bgImage="/images/liz__O8A9903_final.jpg">
-          <HeroTitle>Repository and Digital Curation</HeroTitle>
           <Subhead>Digitizing Our Distinctive Collections</Subhead>
         </HeroBasic>
 


### PR DESCRIPTION
## What does this do?

This removes the workgroup title in the banner on https://preview-4439-remove-workgroup-title.dc.rdc-staging.library.northwestern.edu/about.