### PR TITLE
Update dcapi types to include annotation references.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@next/bundle-analyzer": "^14.0.3",
         "@next/font": "^14.0.3",
         "@next/third-parties": "^14.2.3",
-        "@nulib/dcapi-types": "^2.8.0",
+        "@nulib/dcapi-types": "^2.9.1",
         "@nulib/design-system": "^1.6.2",
         "@nulib/use-markdown": "^0.2.1",
         "@radix-ui/colors": "^3.0.0",
@@ -2287,9 +2287,9 @@
       }
     },
     "node_modules/@nulib/dcapi-types": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@nulib/dcapi-types/-/dcapi-types-2.8.0.tgz",
-      "integrity": "sha512-1N/CfNVDwkl7/tD6KCLZhV0TSvDP5Frk1rwBu+qDBGzqhY6T1xrngkYaxvbqCkWeVSzmkhB7gNTQKkLob1741g=="
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@nulib/dcapi-types/-/dcapi-types-2.9.1.tgz",
+      "integrity": "sha512-XBM+a24rdi1D2jVZS/8c99dilfS4am620zq2CWDMYoqftPvCf/+tsw47gTF/XjgRz44ZGihSz6rC73HB0SYFug=="
     },
     "node_modules/@nulib/design-system": {
       "version": "1.6.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@next/bundle-analyzer": "^14.0.3",
     "@next/font": "^14.0.3",
     "@next/third-parties": "^14.2.3",
-    "@nulib/dcapi-types": "^2.8.0",
+    "@nulib/dcapi-types": "^2.9.1",
     "@nulib/design-system": "^1.6.2",
     "@nulib/use-markdown": "^0.2.1",
     "@radix-ui/colors": "^3.0.0",


### PR DESCRIPTION
Update `@nulib/dcapi-types` package to v2.9.1.

Note: that there was human error made by me during the publishing of v2.9.0. v2.9.0 has been unpublished but NPM history disallows this version to be used again so after fixing my error, I have published the update as v2.9.1. See https://www.npmjs.com/package/@nulib/dcapi-types/v/2.9.1?activeTab=versions