### PR TITLE
Fix similar slider in non AI mode

### DIFF
--- a/lib/chat-helpers.ts
+++ b/lib/chat-helpers.ts
@@ -79,7 +79,9 @@ function createResultsMessageFromContext(
 
     const facetField = getFacetIdByField(facetId);
     // @ts-ignore
-    const facetValue = facet[facetId].replace(/,/g, ", ");
+    const rawValue = facet[facetId];
+    const facetValue =
+      typeof rawValue === "string" ? rawValue.replace(/,/g, ", ") : "";
 
     if (!facetField) return {};
 

--- a/lib/queries/facet.ts
+++ b/lib/queries/facet.ts
@@ -15,6 +15,9 @@ const buildFacetFilters = (urlFacets: UrlFacets) => {
 
   /** Loop through facet keys */
   for (const [key, value] of Object.entries(urlFacets)) {
+    // Skip 'similar' as it's handled separately in the query builder
+    if (key === "similar") continue;
+
     /** Lookup facet field by ID to pass to query */
     const facet = ALL_FACETS.facets.find((item) => item.id === key);
 


### PR DESCRIPTION
### Summary

Fix `404` error in the "View All" link on the "More Like This" slider on work pages (non-AI mode). 

### Changes in this PR

- The `buildFacetFilters` function in `facets.ts` was trying to look up `similar` in the facets list, but similar isn't a facet, it's a special query parameter that's handled separately in the query builder as a `more_like_this` query. Added a check to skip the `similar` parameter in `buildFacetFilters` so it doesn't interfere with the filter building.
- In `chat-helpers.js` added a type check to ensure `facet[facetId]` is a string before calling `.replace()`. If it's not a string, it defaults to an empty string.

<img width="1374" height="973" alt="Screenshot 2025-12-12 at 8 33 03 AM" src="https://github.com/user-attachments/assets/1a719c74-501f-4a27-ba96-1cfba793acf0" />

