### PR TITLE
Show user rate limit errors and warnings

### DIFF
--- a/components/Chat/Response/Response.tsx
+++ b/components/Chat/Response/Response.tsx
@@ -16,6 +16,7 @@ import { prepareQuestion } from "@/lib/chat-helpers";
 import useChatSocket from "@/hooks/useChatSocket";
 import { useSearchState } from "@/context/search-context";
 import { v4 as uuidv4 } from "uuid";
+import { Notification } from "@nulib/design-system";
 
 interface ChatResponseProps {
   conversationIndex: number;
@@ -82,6 +83,32 @@ const ChatResponse: React.FC<ChatResponseProps> = ({
       setTurnAnswer(turnAnswer + message.message);
     }
 
+    if (type === "rate_limit") {
+      const { remaining, until } = message;
+
+      if (remaining <= 5) {
+        const formattedDate = new Date(until).toLocaleString(undefined, {
+          dateStyle: "medium",
+          timeStyle: "short",
+        });
+        setRenderedMessage((prev) => (
+          <>
+            {prev}
+            <Notification isWarning>
+              <p>
+                <strong>Rate Limit Warning</strong>
+              </p>
+              <p>
+                You have {remaining} chat{" "}
+                {remaining === 1 ? "message" : "messages"} remaining until{" "}
+                {formattedDate}
+              </p>
+            </Notification>
+          </>
+        ));
+      }
+    }
+
     if (type === "tool_start") {
       setRenderedMessage((prev) => (
         <>
@@ -121,12 +148,26 @@ const ChatResponse: React.FC<ChatResponseProps> = ({
       setTurnAggregations([...turnAggregations, message.message]);
     }
 
+    if (type === "error") {
+      setRenderedMessage((prev) => (
+        <>
+          {prev}
+          <Notification isDanger>
+            <p>
+              <strong>Error</strong>
+            </p>
+            <p>{message.message}</p>
+          </Notification>
+        </>
+      ));
+    }
+
     /**
      * Final message is the last message in the response
      * and is used to trigger the responseCallback
      * and store this response to the conversation.
      */
-    if (type === "final_message") {
+    if (type === "final_message" || type === "error") {
       setIsStreamingComplete(true);
 
       // update the corresponding turn with the response

--- a/types/components/chat.ts
+++ b/types/components/chat.ts
@@ -53,6 +53,17 @@ export type StartMessage = {
   };
 };
 
+export type RateLimitMessage = {
+  type: "rate_limit";
+  remaining: number;
+  until: string;
+};
+
+export type ErrorMessage = {
+  type: "error";
+  message: string;
+};
+
 export type ToolStartMessage = {
   type: "tool_start";
   message:
@@ -80,10 +91,12 @@ export type StreamingMessage = Ref &
   (
     | AggregationResultMessage
     | AgentFinalMessage
+    | ErrorMessage
     | LLMAnswerMessage
     | LLMFinalMessage
     | LLMTokenMessage
     | LLMStopMessage
+    | RateLimitMessage
     | SearchResultMessage
     | StartMessage
     | ToolStartMessage


### PR DESCRIPTION
## Summary

fixes https://github.com/nulib/repodev_planning_and_docs/issues/5618

Surface rate limit warnings + ultimately the error to user

## Changes In This PR

- If user is at 5 or less messages remaining, show warning
- If an error occurs (including a rate limit error), show to the user and stop the loader

## How to Test

- You can do a `make deploy` of your local API (including chat) - first adjust the `max_requests` to be lower: https://github.com/nulib/dc-api-v2/blob/deploy/staging/chat/src/core/rate_limiter.py#L12
- Then run DC Next against it
```
export NEXT_PUBLIC_DC_URL=https://<your-dev-env-url>:3000 && export NEXT_PUBLIC_DCAPI_ENDPOINT=https://<your-api-env-url>/api/v2  && npm run dev
```
- * My API is currently deployed so you can use that if you want (it's set to 7 messages)




<img width="1249" height="800" alt="Screenshot 2025-12-17 at 12 43 37 PM" src="https://github.com/user-attachments/assets/783722b7-61c2-4e0f-8655-d7337a9c2518" />


<img width="1193" height="651" alt="Screenshot 2025-12-17 at 12 57 51 PM" src="https://github.com/user-attachments/assets/41833b40-fc2c-478d-ba16-2eb7ecbd5799" />

