### PR TITLE
Adjust wording on MagicLink form

### DIFF
--- a/components/Shared/AuthDialog.styled.ts
+++ b/components/Shared/AuthDialog.styled.ts
@@ -96,7 +96,7 @@ const AuthDialogColumn = styled("div", {
 
 const MagicLinkInput = styled("input", {
   height: "2.5rem",
-  padding: "$gr2",
+  padding: "$gr2 !important",
   border: "none !important",
   backgroundColor: "$gray6",
   fontSize: "$gr3",

--- a/components/Shared/AuthDialog.test.tsx
+++ b/components/Shared/AuthDialog.test.tsx
@@ -96,6 +96,17 @@ describe("AuthDialog", () => {
       expect(magicLinkSection).toBeInTheDocument();
     });
 
+    it("should display clarifying text that temporary access is for AI search only", async () => {
+      render(withUserProvider(<AuthDialog />));
+
+      await waitFor(() => {
+        expect(mockedAxios.get).toHaveBeenCalled();
+      });
+
+      expect(screen.getByText(/AI search tool only/i)).toBeInTheDocument();
+      expect(screen.getByText(/does not grant/i)).toBeInTheDocument();
+    });
+
     it("should disable magic link button with invalid email", async () => {
       render(withUserProvider(<AuthDialog />));
 

--- a/components/Shared/AuthDialog.tsx
+++ b/components/Shared/AuthDialog.tsx
@@ -146,6 +146,11 @@ export default function AuthDialog() {
                   <AuthDialogDivider>OR</AuthDialogDivider>
                 </AuthDialogColumn>
                 <AuthDialogColumn data-testid="magic-link">
+                  <p>
+                    Temporary access enables use of the{" "}
+                    <strong>AI search tool only</strong>. It does not grant
+                    access to restricted collection items.
+                  </p>
                   <MagicLinkInput
                     data-testid="magic-link-input"
                     type="email"


### PR DESCRIPTION
### Summary

fixes https://github.com/nulib/repodev_planning_and_docs/issues/5794

- Clarify that MagicLink access does not provide access to NU-only collections

<img width="523" height="602" alt="Screenshot 2026-02-23 at 8 18 27 AM" src="https://github.com/user-attachments/assets/41ac764a-85d8-43ff-a59b-2226079daab9" />
