### PR TITLE
Fix work count totals on collection pages

### DIFF
--- a/lib/collection-helpers.test.ts
+++ b/lib/collection-helpers.test.ts
@@ -1,10 +1,12 @@
 import {
   GenericAggsReturn,
   GetTopMetadataAggsReturn,
+  getCollectionWorkCounts,
   isCollectionPage,
   sortAggsByKey,
 } from "@/lib/collection-helpers";
 
+import { apiPostRequest } from "@/lib/dc-api";
 import { getTopMetadataAggs } from "@/lib/collection-helpers";
 
 /* eslint sort-keys: 0 */
@@ -180,5 +182,65 @@ describe("isCollectionPage", () => {
   it("should handle edge cases with extra slashes", () => {
     const pathname = "//collections//123/";
     expect(isCollectionPage(pathname)).toBe(true);
+  });
+});
+
+describe("getCollectionWorkCounts() function", () => {
+  const collectionId = "3c863d97-07c2-4a75-bcb5-5ad3bfb3bcd0";
+
+  const mockWorkCountResponse = {
+    aggregations: {
+      collections: {
+        buckets: [
+          {
+            key: collectionId,
+            doc_count: 100,
+            workTypes: {
+              buckets: [
+                { key: "Image", doc_count: 80 },
+                { key: "Audio", doc_count: 15 },
+                { key: "Video", doc_count: 5 },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  };
+
+  it("returns correct work type counts for a collection", async () => {
+    (apiPostRequest as jest.Mock).mockResolvedValueOnce(mockWorkCountResponse);
+    const result = await getCollectionWorkCounts([collectionId]);
+    expect(result).toEqual({
+      [collectionId]: {
+        totalWorks: 100,
+        totalImage: 80,
+        totalAudio: 15,
+        totalVideo: 5,
+      },
+    });
+  });
+
+  it("uses a must query to filter by collection IDs, not a bare should", async () => {
+    (apiPostRequest as jest.Mock).mockResolvedValueOnce(mockWorkCountResponse);
+    await getCollectionWorkCounts([collectionId]);
+    const { body } = (apiPostRequest as jest.Mock).mock.calls.at(-1)[0];
+    expect(body.query.bool.must).toBeDefined();
+    expect(body.query.bool.should).toBeUndefined();
+  });
+
+  it("returns zero counts for a collection ID not in the aggregation response", async () => {
+    (apiPostRequest as jest.Mock).mockResolvedValueOnce({
+      aggregations: { collections: { buckets: [] } },
+    });
+    const result = await getCollectionWorkCounts(["missing-collection-id"]);
+    expect(result).toEqual({
+      "missing-collection-id": {
+        totalWorks: 0,
+        totalImage: 0,
+        totalAudio: 0,
+        totalVideo: 0,
+      },
+    });
   });
 });

--- a/lib/collection-helpers.ts
+++ b/lib/collection-helpers.ts
@@ -194,11 +194,18 @@ export async function getCollectionWorkCounts(
       collectionIds.length > 0
         ? {
             bool: {
-              should: collectionIds.map((id) => ({
-                match: {
-                  "collection.id": id,
+              must: [
+                {
+                  bool: {
+                    should: collectionIds.map((id) => ({
+                      match: {
+                        "collection.id": id,
+                      },
+                    })),
+                    minimum_should_match: 1,
+                  },
                 },
-              })),
+              ],
             },
           }
         : {


### PR DESCRIPTION
# Summary

fixes https://github.com/nulib/repodev_planning_and_docs/issues/5799

Collection work counts showing 0 Work type counts (Total, Image, Video, Audio) on collection detail pages were always displaying 0. 

**Root cause:** getCollectionWorkCounts used a top-level bool.should query to filter works by collection ID. In OpenSearch, should without a must or filter clause doesn't actually restrict the document set - it only affects relevance scoring. This meant the terms aggregation ran against all works, returning the globally top collection rather than the requested one. Since the requested collection wasn't in the result, the zero-count fallback kicked in. 

**Fix:** Wrap the should clauses inside a must with minimum_should_match: 1, which enforces actual filtering - consistent with how getMetadataAggs already queries by collection.id. 

**Tests added** for getCollectionWorkCounts.


<img width="989" height="903" alt="Screenshot 2026-04-09 at 11 59 24 AM" src="https://github.com/user-attachments/assets/ed90faf5-c0eb-4fb2-9655-4ae5f607ed31" />
