### PR TITLE
Automatically create tag, bump version and open deploy PR on merge to main

### DIFF
--- a/.github/workflows/next_version.yml
+++ b/.github/workflows/next_version.yml
@@ -1,0 +1,69 @@
+name: Tag Release & Open Next Production PR
+on:
+  push:
+    branches: [main]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+permissions:
+  contents: write # create/push tag + push bump commit to deploy/staging
+  pull-requests: write # open the next release PR
+jobs:
+  version:
+    # allow an escape hatch for non-release pushes to main
+    if: ${{ !contains(github.event.head_commit.message, '[skip-release]') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history + tags, and ability to push deploy/staging
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+
+      - name: Read release version
+        id: ver
+        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Configure git
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+      - name: Tag the release
+        # idempotent: only tag when this version is new; emit tagged=false for
+        # non-release pushes to main so the bump/PR step is skipped entirely
+        id: tag
+        env:
+          V: v${{ steps.ver.outputs.version }}
+        run: |
+          if git rev-parse "$V" >/dev/null 2>&1; then
+            echo "Tag $V already exists — not a new release, skipping all release steps."
+            echo "tagged=false" >> "$GITHUB_OUTPUT"
+          else
+            git tag -a "$V" -m "Release $V"
+            git push origin "$V"
+            echo "tagged=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Bump patch on deploy/staging & open next PR
+        # only runs when a brand-new release tag was just created; any non-release
+        # push to main (version unchanged → tag already exists) is a complete no-op
+        if: ${{ steps.tag.outputs.tagged == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git fetch origin deploy/staging
+          git checkout deploy/staging
+          # bumps package.json + package-lock.json without creating its own git tag
+          npm version patch --no-git-tag-version
+          NEXT=$(node -p "require('./package.json').version")
+          git commit -am "Bump version to v${NEXT}"
+          git push origin deploy/staging
+          # open the next release PR only if one isn't already open
+          if [ -z "$(gh pr list --base main --head deploy/staging --state open --json number -q '.[].number')" ]; then
+            gh pr create --base main --head deploy/staging --draft \
+              --title "Deploy vX.X.X to production" \
+              --body "Automated production release PR. Update the version in \`package.json\` (patch/minor/major) and the title before merging."
+          fi

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -7,8 +7,14 @@ on:
   workflow_dispatch:
 jobs:
   test:
-    timeout-minutes: 10
+    timeout-minutes: 20
     runs-on: ubuntu-latest
+    container:
+      # Image version must match @playwright/test in package.json.
+      # Mismatch produces: "Executable doesn't exist at /ms-playwright/chromium-XXXX/..."
+      # To upgrade: bump both this tag and the package.json version together.
+      image: mcr.microsoft.com/playwright:v1.46.1-noble
+      options: --user 1001
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -16,9 +22,6 @@ jobs:
           node-version: lts/*
       - name: Install dependencies
         run: npm ci --force
-
-      - name: Install Playwright Browsers
-        run: npx playwright install --with-deps
 
       - name: Build app
         run: npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,12 @@
 {
   "name": "dc-nextjs",
+  "version": "3.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dc-nextjs",
+      "version": "3.1.2",
       "dependencies": {
         "@honeybadger-io/js": "^5.1.1",
         "@honeybadger-io/webpack": "^5.1.0",
@@ -54,7 +56,7 @@
       "devDependencies": {
         "@elastic/elasticsearch": "7.17",
         "@iiif/presentation-3": "^1.1.3",
-        "@playwright/test": "^1.45.2",
+        "@playwright/test": "1.46.1",
         "@testing-library/jest-dom": "^6.1.2",
         "@testing-library/react": "^16.0.0",
         "@testing-library/user-event": "^14.0.4",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "dc-nextjs",
+  "version": "3.1.2",
   "private": true,
   "scripts": {
     "analyze": "ANALYZE=true npm run build",
@@ -67,7 +68,7 @@
   "devDependencies": {
     "@elastic/elasticsearch": "7.17",
     "@iiif/presentation-3": "^1.1.3",
-    "@playwright/test": "^1.45.2",
+    "@playwright/test": "1.46.1",
     "@testing-library/jest-dom": "^6.1.2",
     "@testing-library/react": "^16.0.0",
     "@testing-library/user-event": "^14.0.4",

--- a/server.js
+++ b/server.js
@@ -4,8 +4,8 @@ const next = require("next");
 const fs = require("fs");
 const port = 3000;
 const dev = process.env.NODE_ENV !== "production";
-const hostname = "localhost"; // use in AWS dev environment
-// const hostname = "local.dev.rdc.library.northwestern.edu"; // use for local development
+// const hostname = "localhost"; // use in AWS dev environment
+const hostname = "local.dev.rdc.library.northwestern.edu"; // use for local development
 const app = next({ dev, hostname, port });
 const handle = app.getRequestHandler();
 


### PR DESCRIPTION
## Summary

- Adds Github action that tags release, increments version in staging branch's `package.json` and opens the next deployment PR (workflow similar to Meadow). 
- Establishes initial version in `package.json`
- Refactors `.github/workflows/playwright.yml` to use the official Playwright Docker image which will increase test reliability and speed.

Note: 
- Actual deployment is handled in Amplify 
- Playwright tests will not run on the deployment PR unless manually triggered 
- Release notes generation to come in subsequent PR, but this sets the stage

## Notes for first deployment

  1. Merge `auto-version-pr` → `deploy/staging`
  2. Manually open the first `Deploy vX.X.X to production` PR (`deploy/staging` → `main`)
  3. Merge it → Amplify deploys, workflow fires, tags `v3.1.2`, bumps staging to `3.1.3`, opens the next PR automatically

