### PR TITLE
Update EmbedResources component for ImageService3

### DIFF
--- a/components/Work/ActionsDialog/DownloadAndShare/EmbedResources.tsx
+++ b/components/Work/ActionsDialog/DownloadAndShare/EmbedResources.tsx
@@ -181,10 +181,9 @@ const Item: React.FC<ItemProps> = ({ item, showEmbedWarning }) => {
         ? item.label.none[0].replace(/\.[^/.]+$/, "")
         : "nul_fileset";
 
-    const response = await makeBlob(
-      `${getInfoResponse(item)}/full/3000,/0/default.jpg`,
-      { credentials: "include" },
-    );
+    const infoResponse = getInfoResponse(item);
+    const imageUrl = `${infoResponse}/full/3000,/0/default.jpg`;
+    const response = await makeBlob(imageUrl, { credentials: "include" });
 
     if (!response || response.error) {
       alert("Error fetching the image");

--- a/lib/iiif/manifest-helpers.ts
+++ b/lib/iiif/manifest-helpers.ts
@@ -34,8 +34,10 @@ export const getInfoResponse = (canvas: Canvas) => {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const body = annotation.body as AnnotationBody as any;
-    if (body && body.service && body.service[0])
-      infoResponse = body.service[0]["@id"] as string;
+    if (body && body.service && body.service[0]) {
+      const service = body.service[0];
+      infoResponse = service?.id ?? service?.["@id"] ?? "";
+    }
   }
 
   return infoResponse;

--- a/mocks/private-unpublished-work.ts
+++ b/mocks/private-unpublished-work.ts
@@ -307,9 +307,8 @@ export const mockPrivateUnpublishedWorkManifest: Manifest = {
           service: [
             // @ts-ignore
             {
-              "@id":
-                "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/62adb94b-36d9-4f6f-bd18-ae4e7f3e7ba0",
-              "@type": "ImageService2",
+              id: "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/62adb94b-36d9-4f6f-bd18-ae4e7f3e7ba0",
+              type: "ImageService3",
               profile: "http://iiif.io/api/image/2/level2.json",
             },
           ],
@@ -335,9 +334,8 @@ export const mockPrivateUnpublishedWorkManifest: Manifest = {
                 width: 2400,
                 service: [
                   {
-                    "@id":
-                      "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/62adb94b-36d9-4f6f-bd18-ae4e7f3e7ba0",
-                    "@type": "ImageService2",
+                    id: "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/62adb94b-36d9-4f6f-bd18-ae4e7f3e7ba0",
+                    type: "ImageService3",
                     profile: "http://iiif.io/api/image/2/level2.json",
                   },
                 ],
@@ -366,9 +364,8 @@ export const mockPrivateUnpublishedWorkManifest: Manifest = {
           service: [
             // @ts-ignore
             {
-              "@id":
-                "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/592022f6-3dc1-4f17-a412-42c025ceae93",
-              "@type": "ImageService2",
+              id: "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/592022f6-3dc1-4f17-a412-42c025ceae93",
+              type: "ImageService3",
               profile: "http://iiif.io/api/image/2/level2.json",
             },
           ],
@@ -394,9 +391,8 @@ export const mockPrivateUnpublishedWorkManifest: Manifest = {
                 width: 1538,
                 service: [
                   {
-                    "@id":
-                      "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/592022f6-3dc1-4f17-a412-42c025ceae93",
-                    "@type": "ImageService2",
+                    id: "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/592022f6-3dc1-4f17-a412-42c025ceae93",
+                    type: "ImageService3",
                     profile: "http://iiif.io/api/image/2/level2.json",
                   },
                 ],

--- a/mocks/sample-public-work.ts
+++ b/mocks/sample-public-work.ts
@@ -163,9 +163,8 @@ export const samplePublicWorkManifest = {
                 id: "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/1d2c2e79-8a6a-4b55-b06a-627cbf82ddd0/full/600,/0/default.jpg",
                 service: [
                   {
-                    "@id":
-                      "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/1d2c2e79-8a6a-4b55-b06a-627cbf82ddd0",
-                    "@type": "ImageService2",
+                    id: "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/1d2c2e79-8a6a-4b55-b06a-627cbf82ddd0",
+                    type: "ImageService3",
                     profile: "http://iiif.io/api/image/2/level2.json",
                   },
                 ],
@@ -199,9 +198,8 @@ export const samplePublicWorkManifest = {
                   id: "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/1d2c2e79-8a6a-4b55-b06a-627cbf82ddd0/full/!640,689/0/default.jpg",
                   service: [
                     {
-                      "@id":
-                        "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/1d2c2e79-8a6a-4b55-b06a-627cbf82ddd0",
-                      "@type": "ImageService2",
+                      id: "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/1d2c2e79-8a6a-4b55-b06a-627cbf82ddd0",
+                      type: "ImageService3",
                       profile: "http://iiif.io/api/image/2/level2.json",
                     },
                   ],
@@ -228,9 +226,8 @@ export const samplePublicWorkManifest = {
           id: "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/1d2c2e79-8a6a-4b55-b06a-627cbf82ddd0/full/!300,300/0/default.jpg",
           service: [
             {
-              "@id":
-                "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/1d2c2e79-8a6a-4b55-b06a-627cbf82ddd0",
-              "@type": "ImageService2",
+              id: "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/1d2c2e79-8a6a-4b55-b06a-627cbf82ddd0",
+              type: "ImageService3",
               profile: "http://iiif.io/api/image/2/level2.json",
             },
           ],
@@ -255,9 +252,8 @@ export const samplePublicWorkManifest = {
                 id: "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/3a1562c9-e9d7-4311-a572-28e9ddf39745/full/600,/0/default.jpg",
                 service: [
                   {
-                    "@id":
-                      "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/3a1562c9-e9d7-4311-a572-28e9ddf39745",
-                    "@type": "ImageService2",
+                    id: "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/3a1562c9-e9d7-4311-a572-28e9ddf39745",
+                    type: "ImageService3",
                     profile: "http://iiif.io/api/image/2/level2.json",
                   },
                 ],
@@ -291,9 +287,8 @@ export const samplePublicWorkManifest = {
                   id: "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/3a1562c9-e9d7-4311-a572-28e9ddf39745/full/!640,683/0/default.jpg",
                   service: [
                     {
-                      "@id":
-                        "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/3a1562c9-e9d7-4311-a572-28e9ddf39745",
-                      "@type": "ImageService2",
+                      id: "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/3a1562c9-e9d7-4311-a572-28e9ddf39745",
+                      type: "ImageService3",
                       profile: "http://iiif.io/api/image/2/level2.json",
                     },
                   ],
@@ -320,9 +315,8 @@ export const samplePublicWorkManifest = {
           id: "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/3a1562c9-e9d7-4311-a572-28e9ddf39745/full/!300,300/0/default.jpg",
           service: [
             {
-              "@id":
-                "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/3a1562c9-e9d7-4311-a572-28e9ddf39745",
-              "@type": "ImageService2",
+              id: "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/3a1562c9-e9d7-4311-a572-28e9ddf39745",
+              type: "ImageService3",
               profile: "http://iiif.io/api/image/2/level2.json",
             },
           ],

--- a/mocks/sample-work-image.ts
+++ b/mocks/sample-work-image.ts
@@ -373,9 +373,8 @@ const manifest = {
           width: 300,
           service: [
             {
-              "@id":
-                "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/d164b89c-10ca-42d3-b201-d584e7175604",
-              "@type": "ImageService2",
+              id: "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/d164b89c-10ca-42d3-b201-d584e7175604",
+              type: "ImageService3",
               profile: "http://iiif.io/api/image/2/level2.json",
             },
           ],
@@ -400,9 +399,8 @@ const manifest = {
                 width: 4148,
                 service: [
                   {
-                    "@id":
-                      "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/d164b89c-10ca-42d3-b201-d584e7175604",
-                    "@type": "ImageService2",
+                    id: "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/d164b89c-10ca-42d3-b201-d584e7175604",
+                    type: "ImageService3",
                     profile: "http://iiif.io/api/image/2/level2.json",
                   },
                 ],


### PR DESCRIPTION
Update `EmbedResources` component to account for `ImageService3` (`id` vs `@id`)
Update mock manifests to include `ImageService3` services

Fixes #478