### PR TITLE
Fix bug causing IIIF image slider view all links to be broken in AI mode

### DIFF
--- a/lib/queries/builder.ts
+++ b/lib/queries/builder.ts
@@ -16,28 +16,12 @@ type BuildQueryProps = {
   urlFacets: UrlFacets;
 };
 
-const searchPipeline = {
-  phase_results_processors: [
-    {
-      "normalization-processor": {
-        combination: {
-          parameters: {
-            weights: [0.25, 0.75],
-          },
-          technique: "arithmetic_mean",
-        },
-        normalization: {
-          technique: "l2",
-        },
-      },
-    },
-  ],
-};
-
 export function buildQuery(obj: BuildQueryProps, isAI: boolean) {
   const { aggs, aggsFilterValue, size, term, urlFacets } = obj;
   const must: QueryDslQueryContainer[] = [];
   let queryValue;
+
+  const facetFilters = buildFacetFilters(urlFacets);
 
   // Build the "must" part of the query
   if (term) must.push(buildSearchPart(term));
@@ -80,6 +64,7 @@ export function buildQuery(obj: BuildQueryProps, isAI: boolean) {
                   },
                 },
               ],
+              ...(!aggs && { filter: facetFilters }),
             },
           },
           {
@@ -88,12 +73,11 @@ export function buildQuery(obj: BuildQueryProps, isAI: boolean) {
                 filter: {
                   bool: !aggs
                     ? {
-                        filter: buildFacetFilters(urlFacets),
+                        filter: facetFilters,
                       }
                     : {},
                 },
                 k: AI_K_VALUE,
-                model_id: process.env.NEXT_PUBLIC_OPENSEARCH_MODEL_ID,
                 query_text: term, // if term has no value, the API returns a 400 error
               },
             },
@@ -108,16 +92,15 @@ export function buildQuery(obj: BuildQueryProps, isAI: boolean) {
     ...(queryValue && {
       query: queryValue,
     }),
-    ...(isAI && {
-      search_pipeline: searchPipeline,
-    }),
     ...(aggs && { aggs: buildAggs(aggs, aggsFilterValue, urlFacets) }),
     ...(typeof size !== "undefined" && { size: size }),
-    post_filter: {
-      bool: {
-        must: buildFacetFilters(urlFacets),
+    ...(!isAI && {
+      post_filter: {
+        bool: {
+          must: facetFilters,
+        },
       },
-    },
+    }),
   } as ApiSearchRequestBody;
 
   return requestBody;


### PR DESCRIPTION
## Summary

When AI mode is enabled, the "View All" links on the IIIF image sliders are linking to a blank page of search results and behind the scenes the search query is returning a 400 error.

### Root cause

The hybrid search request body included an inline `search_pipeline` definition alongside the `?search_pipeline=dc-v2-work-pipeline` URL parameter. The API uses the URL parameter to specify the pipeline, and sending a conflicting inline definition in the body caused the 400.

### Changes

- **Remove inline `search_pipeline` from request body**  as the URL parameter is the correct mechanism for this API and is sufficient on its own
- **Remove `model_id` from neural sub-query** because the API injects the correct model ID server-side if not provided
- **Move facet filters inside hybrid sub-queries** becasue `post_filter` applies after scoring, so filters on `collection` and `subject` weren't constraining the neural query's candidate pool; pushing them into each sub-query ensures the K nearest neighbors are drawn from the correct filtered set
- **Gate `post_filter` on non-AI queries** which keeps existing filter behavior for standard keyword search unchanged