### PR TITLE
Add app version in footer

### DIFF
--- a/components/Footer/Content.tsx
+++ b/components/Footer/Content.tsx
@@ -8,13 +8,12 @@ import {
   FooterVersion,
   Social,
 } from "./Footer.styled";
-import { version } from "@/package.json";
+import { getBuildInfo } from "@/lib/build-info";
 
 import React from "react";
 
 export const FooterContent: React.FC = () => {
-  const deployEnv = process.env.HONEYBADGER_ENV;
-  const revision = process.env.HONEYBADGER_REVISION;
+  const { version, releaseUrl, commitUrl, shortSha, label } = getBuildInfo();
 
   const currentYear = () => {
     const today = new Date();
@@ -214,31 +213,24 @@ export const FooterContent: React.FC = () => {
           for all audiences.
         </p>
         <FooterVersion
-          as={deployEnv === "production" ? "a" : "span"}
-          {...(deployEnv === "production" && {
-            href: `https://github.com/nulib/dc-nextjs/releases/tag/v${version}`,
-          })}
+          as={releaseUrl ? "a" : "span"}
+          href={releaseUrl ?? undefined}
         >
           v{version}
-          {deployEnv === "staging" && (
+          {label && (
             <>
-              {" (staging"}
-              {revision && (
+              {` (${label}`}
+              {commitUrl && shortSha ? (
                 <>
                   {" "}
-                  <a
-                    href={`https://github.com/nulib/dc-nextjs/commit/${revision}`}
-                  >
-                    {revision.slice(0, 7)}
-                  </a>
+                  <a href={commitUrl}>{shortSha}</a>
                 </>
+              ) : (
+                shortSha && ` ${shortSha}`
               )}
               {")"}
             </>
           )}
-          {deployEnv !== "production" &&
-            deployEnv !== "staging" &&
-            ` (DEV${revision ? ` ${revision.slice(0, 7)}` : ""})`}
         </FooterVersion>
       </FooterCopyright>
     </FooterStyled>

--- a/components/Footer/Content.tsx
+++ b/components/Footer/Content.tsx
@@ -5,12 +5,17 @@ import {
   FooterIcon,
   FooterList,
   FooterStyled,
+  FooterVersion,
   Social,
 } from "./Footer.styled";
+import { version } from "@/package.json";
 
 import React from "react";
 
 export const FooterContent: React.FC = () => {
+  const deployEnv = process.env.HONEYBADGER_ENV;
+  const revision = process.env.HONEYBADGER_REVISION;
+
   const currentYear = () => {
     const today = new Date();
     return today.getFullYear();
@@ -208,6 +213,33 @@ export const FooterContent: React.FC = () => {
           language, or opinions that are offensive and may not be appropriate
           for all audiences.
         </p>
+        <FooterVersion
+          as={deployEnv === "production" ? "a" : "span"}
+          {...(deployEnv === "production" && {
+            href: `https://github.com/nulib/dc-nextjs/releases/tag/v${version}`,
+          })}
+        >
+          v{version}
+          {deployEnv === "staging" && (
+            <>
+              {" (staging"}
+              {revision && (
+                <>
+                  {" "}
+                  <a
+                    href={`https://github.com/nulib/dc-nextjs/commit/${revision}`}
+                  >
+                    {revision.slice(0, 7)}
+                  </a>
+                </>
+              )}
+              {")"}
+            </>
+          )}
+          {deployEnv !== "production" &&
+            deployEnv !== "staging" &&
+            ` (DEV${revision ? ` ${revision.slice(0, 7)}` : ""})`}
+        </FooterVersion>
       </FooterCopyright>
     </FooterStyled>
   );

--- a/components/Footer/Footer.styled.ts
+++ b/components/Footer/Footer.styled.ts
@@ -112,6 +112,18 @@ export const FooterIcon = styled("li", {
   },
 });
 
+export const FooterVersion = styled("span", {
+  color: "$nuPurple10",
+  display: "block",
+  fontSize: "$1",
+  margin: "$2 0 0",
+  opacity: "0.5",
+
+  "&[href]:hover, &[href]:focus": {
+    opacity: "0.8",
+  },
+});
+
 export const FooterList = styled("ul", {
   listStyleType: "none",
   margin: "0",

--- a/lib/build-info.ts
+++ b/lib/build-info.ts
@@ -1,0 +1,39 @@
+import { version } from "@/package.json";
+
+const REPO = "https://github.com/nulib/dc-nextjs";
+
+type DeployEnv = "production" | "staging" | "development";
+
+export interface BuildInfo {
+  version: string;
+  env: DeployEnv;
+  releaseUrl: string | null;
+  commitUrl: string | null;
+  shortSha: string | null;
+  label: string | null;
+}
+
+export function getBuildInfo(): BuildInfo {
+  const rawEnv = process.env.HONEYBADGER_ENV;
+  const revision = process.env.HONEYBADGER_REVISION;
+
+  const env: DeployEnv =
+    rawEnv === "production"
+      ? "production"
+      : rawEnv === "staging"
+        ? "staging"
+        : "development";
+
+  const shortSha = revision ? revision.slice(0, 7) : null;
+
+  return {
+    version,
+    env,
+    releaseUrl:
+      env === "production" ? `${REPO}/releases/tag/v${version}` : null,
+    commitUrl:
+      env === "staging" && revision ? `${REPO}/commit/${revision}` : null,
+    shortSha: env !== "production" ? shortSha : null,
+    label: env === "production" ? null : env === "staging" ? "staging" : "DEV",
+  };
+}


### PR DESCRIPTION
## Summary

Adds a version indicator to the site footer, similar to how Meadow displays its version. The display very unobtrusive and is environment-aware to avoid showing links to releases that don't exist yet.

### Changes

- **Production**: displays the version as a link to the GitHub release tag (e.g. `v3.1.4` -> `github.com/nulib/dc-nextjs/releases/tag/v3.1.4`)
- **Staging**: displays the version as plain text with the short commit SHA linking to the commit on GitHub (e.g. `v3.1.4 (staging abc1234)`)
- **Dev**: displays the version as plain text with the short commit SHA if available (e.g. `v3.1.4 (DEV abc1234)`)
- Version is read from `package.json`; environment is read from the existing `HONEYBADGER_ENV` and `HONEYBADGER_REVISION` env vars already exposed via `next.config.js`

<img width="1305" height="938" alt="Screenshot 2026-06-16 at 9 09 01 AM" src="https://github.com/user-attachments/assets/581935df-9162-4bb4-943c-eb30da610e98" />

