### PR TITLE
Bugfix - public items appearing as institution

### DIFF
--- a/components/Chat/Feedback/OptIn.test.tsx
+++ b/components/Chat/Feedback/OptIn.test.tsx
@@ -9,9 +9,15 @@ const mockUserContextValue = {
     email: "foo@bar.com",
     isLoggedIn: true,
     isReadingRoom: false,
+    isInstitution: false,
     name: "foo",
+    scopes: [],
     sub: "123",
   },
+  isLoading: false,
+  isSignInModalOpen: false,
+  openSignInModal: jest.fn(),
+  closeSignInModal: jest.fn(),
 };
 
 describe("ChatFeedbackOptIn", () => {

--- a/components/Clover/ViewerWrapper.test.tsx
+++ b/components/Clover/ViewerWrapper.test.tsx
@@ -15,6 +15,10 @@ const userContextValue = {
     primaryAffiliation: "staff",
     provider: "nusso",
   },
+  isLoading: false,
+  isSignInModalOpen: false,
+  openSignInModal: jest.fn(),
+  closeSignInModal: jest.fn(),
 };
 const readingRoomMessage =
   /You have access to this Work because you are in the reading room/i;

--- a/components/Grid/Item.tsx
+++ b/components/Grid/Item.tsx
@@ -16,6 +16,7 @@ const GridItem: React.FC<GridItemProps> = ({ item, isFeatured }) => {
   const userContext = useContext(UserContext);
 
   const isRestricted = (item: SearchShape): boolean => {
+    if (userContext?.isLoading) return false;
     return !(
       userContext?.user?.scopes?.includes(`read:${item?.visibility}`) ?? false
     );

--- a/components/Grid/Item.tsx
+++ b/components/Grid/Item.tsx
@@ -16,7 +16,7 @@ const GridItem: React.FC<GridItemProps> = ({ item, isFeatured }) => {
   const userContext = useContext(UserContext);
 
   const isRestricted = (item: SearchShape): boolean => {
-    if (userContext?.isLoading) return false;
+    if (userContext?.isLoading) return item?.visibility !== "Public";
     return !(
       userContext?.user?.scopes?.includes(`read:${item?.visibility}`) ?? false
     );

--- a/components/Search/GenerativeAIToggle.test.tsx
+++ b/components/Search/GenerativeAIToggle.test.tsx
@@ -17,9 +17,12 @@ const defaultUserContext: UserContextType = {
     primaryAffiliation: "student",
     isLoggedIn: true,
     isReadingRoom: false,
+    isInstitution: false,
     name: "Ace Frehley",
+    scopes: [],
     sub: "xyz123",
   },
+  isLoading: false,
   isSignInModalOpen: false,
   openSignInModal: jest.fn(() => {
     defaultUserContext.isSignInModalOpen = true;

--- a/components/Search/Search.test.tsx
+++ b/components/Search/Search.test.tsx
@@ -15,9 +15,15 @@ const defaultUser = {
     email: "ace@northewestern.edu",
     isLoggedIn: true,
     isReadingRoom: false,
+    isInstitution: false,
     name: "Ace Frehley",
+    scopes: [],
     sub: "xyz123",
   },
+  isLoading: false,
+  isSignInModalOpen: false,
+  openSignInModal: jest.fn(),
+  closeSignInModal: jest.fn(),
 };
 
 const withUserProvider = (

--- a/components/Search/TranscriptionResults.tsx
+++ b/components/Search/TranscriptionResults.tsx
@@ -81,7 +81,7 @@ const TranscriptionResults: React.FC<TranscriptionResultsProps> = ({
   const groups = groupByWork(results);
   const { user, isLoading } = useContext(UserContext);
   const isRestricted = (visibility: string) => {
-    if (isLoading) return false;
+    if (isLoading) return visibility !== "Public";
     return !(user?.scopes?.includes(`read:${visibility}`) ?? false);
   };
 

--- a/components/Search/TranscriptionResults.tsx
+++ b/components/Search/TranscriptionResults.tsx
@@ -79,9 +79,11 @@ const TranscriptionResults: React.FC<TranscriptionResultsProps> = ({
   onPageChange,
 }) => {
   const groups = groupByWork(results);
-  const { user } = useContext(UserContext);
-  const isRestricted = (visibility: string) =>
-    !(user?.scopes?.includes(`read:${visibility}`) ?? false);
+  const { user, isLoading } = useContext(UserContext);
+  const isRestricted = (visibility: string) => {
+    if (isLoading) return false;
+    return !(user?.scopes?.includes(`read:${visibility}`) ?? false);
+  };
 
   return (
     <Wrapper>

--- a/components/Shared/AuthDialog.test.tsx
+++ b/components/Shared/AuthDialog.test.tsx
@@ -15,6 +15,7 @@ jest.mock("@/lib/dc-api", () => ({
 
 const defaultUserContext: UserContextType = {
   user: null,
+  isLoading: false,
   isSignInModalOpen: true,
   openSignInModal: jest.fn(() => {
     defaultUserContext.isSignInModalOpen = true;

--- a/components/Work/ActionsDialog/DownloadAndShare/EmbedResources.test.tsx
+++ b/components/Work/ActionsDialog/DownloadAndShare/EmbedResources.test.tsx
@@ -14,6 +14,10 @@ const userContextValue = {
     isReadingRoom: false,
     isInstitution: false,
   },
+  isLoading: false,
+  isSignInModalOpen: false,
+  openSignInModal: jest.fn(),
+  closeSignInModal: jest.fn(),
 };
 
 const alternateFormatItems = manifest.rendering ? [...manifest.rendering] : [];

--- a/components/Work/ActionsDialog/DownloadAndShare/EmbedResources.tsx
+++ b/components/Work/ActionsDialog/DownloadAndShare/EmbedResources.tsx
@@ -48,6 +48,9 @@ const EmbedResources: React.FC<EmbedResourcesProps> = ({
   const [imageCanvases, setImageCanvases] = React.useState<Canvas[]>([]);
   const { userCanRead, isAuthLoading } = useWorkAuth(work);
   const isSharedLinkPage = router.pathname.includes("/shared");
+  const loginRequired =
+    (isAuthLoading && work?.visibility !== "Public") || // Work is not public and auth is loading
+    (work && !userCanRead && !isSharedLinkPage); // User cannot read and it's not a shared link page
 
   React.useEffect(() => {
     if (manifest?.items && Array.isArray(manifest?.items)) {
@@ -62,7 +65,7 @@ const EmbedResources: React.FC<EmbedResourcesProps> = ({
     <EmbedResourcesWrapper>
       <Heading as="h3">Download and Embed</Heading>
 
-      {!userCanRead && !isAuthLoading && !isSharedLinkPage && (
+      {loginRequired && (
         <Announcement>
           Download requires Northwestern University NetID authentication{" "}
         </Announcement>

--- a/components/Work/ActionsDialog/DownloadAndShare/EmbedResources.tsx
+++ b/components/Work/ActionsDialog/DownloadAndShare/EmbedResources.tsx
@@ -46,7 +46,7 @@ const EmbedResources: React.FC<EmbedResourcesProps> = ({
 }) => {
   const router = useRouter();
   const [imageCanvases, setImageCanvases] = React.useState<Canvas[]>([]);
-  const { userCanRead } = useWorkAuth(work);
+  const { userCanRead, isAuthLoading } = useWorkAuth(work);
   const isSharedLinkPage = router.pathname.includes("/shared");
 
   React.useEffect(() => {
@@ -62,7 +62,7 @@ const EmbedResources: React.FC<EmbedResourcesProps> = ({
     <EmbedResourcesWrapper>
       <Heading as="h3">Download and Embed</Heading>
 
-      {!userCanRead && !isSharedLinkPage && (
+      {!userCanRead && !isAuthLoading && !isSharedLinkPage && (
         <Announcement>
           Download requires Northwestern University NetID authentication{" "}
         </Announcement>

--- a/components/Work/EmbeddedViewer.tsx
+++ b/components/Work/EmbeddedViewer.tsx
@@ -8,10 +8,12 @@ import WorkViewerWrapper from "@/components/Clover/ViewerWrapper";
 const EmbeddedViewer = ({
   work,
   userCanRead,
+  isAuthLoading,
   searchParams,
 }: {
   work: Work;
   userCanRead?: boolean;
+  isAuthLoading?: boolean;
   searchParams: { [key: string]: string };
 }) => {
   const thumbnail = work?.thumbnail || "";
@@ -48,7 +50,7 @@ const EmbeddedViewer = ({
           viewerOptions={viewerOptions}
         />
       ) : (
-        <WorkRestrictedDisplay thumbnail={thumbnail} />
+        !isAuthLoading && <WorkRestrictedDisplay thumbnail={thumbnail} />
       )}
     </WorkProvider>
   );

--- a/components/Work/EmbeddedViewer.tsx
+++ b/components/Work/EmbeddedViewer.tsx
@@ -42,6 +42,10 @@ const EmbeddedViewer = ({
     showTitle: showTitle === "true" ? true : false,
   };
 
+  const loginRequired =
+    (isAuthLoading && work?.visibility !== "Public") || // Work is not public and auth is loading
+    (work && !userCanRead); // Work is loaded and user cannot read
+
   return (
     <WorkProvider>
       {userCanRead ? (
@@ -50,7 +54,7 @@ const EmbeddedViewer = ({
           viewerOptions={viewerOptions}
         />
       ) : (
-        !isAuthLoading && <WorkRestrictedDisplay thumbnail={thumbnail} />
+        loginRequired && <WorkRestrictedDisplay thumbnail={thumbnail} />
       )}
     </WorkProvider>
   );

--- a/context/user-context.tsx
+++ b/context/user-context.tsx
@@ -8,6 +8,7 @@ import { getUser } from "@/lib/user-helpers";
 
 const UserContext = createContext<UserContextType>({
   user: null,
+  isLoading: true,
   isSignInModalOpen: false,
   openSignInModal: () => {},
   closeSignInModal: () => {},
@@ -15,35 +16,38 @@ const UserContext = createContext<UserContextType>({
 
 const UserProvider = ({ children }: { children: ReactNode }) => {
   const [user, setUser] = useState<User | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
   const [isSignInModalOpen, setIsSignInModalOpen] = useState(false);
   const router = useRouter();
 
   useEffect(() => {
     /* Determine if user is authenticated via cookie */
     getUser().then((result) => {
-      if (!result) return;
-      const {
-        email,
-        isInstitution = false,
-        isLoggedIn = false,
-        isReadingRoom = false,
-        name,
-        primaryAffiliation,
-        provider,
-        scopes,
-        sub,
-      } = result;
-      setUser({
-        email,
-        isInstitution,
-        isLoggedIn,
-        isReadingRoom,
-        name,
-        primaryAffiliation,
-        provider,
-        scopes,
-        sub,
-      });
+      if (result) {
+        const {
+          email,
+          isInstitution = false,
+          isLoggedIn = false,
+          isReadingRoom = false,
+          name,
+          primaryAffiliation,
+          provider,
+          scopes,
+          sub,
+        } = result;
+        setUser({
+          email,
+          isInstitution,
+          isLoggedIn,
+          isReadingRoom,
+          name,
+          primaryAffiliation,
+          provider,
+          scopes,
+          sub,
+        });
+      }
+      setIsLoading(false);
     });
   }, []);
 
@@ -86,6 +90,7 @@ const UserProvider = ({ children }: { children: ReactNode }) => {
     <UserContext.Provider
       value={{
         user,
+        isLoading,
         isSignInModalOpen,
         openSignInModal,
         closeSignInModal,

--- a/hooks/useWorkAuth.ts
+++ b/hooks/useWorkAuth.ts
@@ -4,6 +4,7 @@ import { useContext } from "react";
 
 const useWorkAuth = (work: Work | null | undefined) => {
   const userAuthContext = useContext(UserContext);
+  const isAuthLoading = userAuthContext?.isLoading ?? true;
   const isUserLoggedIn = userAuthContext?.user?.isLoggedIn;
   const isWorkInstitution = work?.visibility === "Institution";
   const isWorkPrivate = work?.visibility === "Private";
@@ -20,6 +21,7 @@ const useWorkAuth = (work: Work | null | undefined) => {
       (isWorkInstitution && !userAuthContext?.user?.isInstitution));
 
   return {
+    isAuthLoading,
     isUserLoggedIn,
     isWorkInstitution,
     isWorkPrivate,

--- a/pages/embedded-viewer/[manifestId].tsx
+++ b/pages/embedded-viewer/[manifestId].tsx
@@ -15,7 +15,7 @@ interface EmbeddedViewerPageProps {
 
 const EmbeddedViewerPage: NextPage<EmbeddedViewerPageProps> = ({ work }) => {
   const router = useRouter();
-  const { userCanRead } = useWorkAuth(work);
+  const { userCanRead, isAuthLoading } = useWorkAuth(work);
 
   const searchParams = getUrlSearchParams(decodeURIComponent(router.asPath));
 
@@ -23,6 +23,7 @@ const EmbeddedViewerPage: NextPage<EmbeddedViewerPageProps> = ({ work }) => {
     <EmbeddedViewer
       work={work}
       userCanRead={userCanRead}
+      isAuthLoading={isAuthLoading}
       searchParams={searchParams}
     />
   );

--- a/pages/items/[...id].tsx
+++ b/pages/items/[...id].tsx
@@ -48,7 +48,8 @@ const WorkPage: NextPage<WorkPageProps> = ({
   const [initialLabel, setInitialLabel] = useState<string | undefined>();
   const [initialSnippet, setInitialSnippet] = useState<string | undefined>();
   const canvasParamProcessed = useRef(false);
-  const { userCanRead, isWorkReadingRoomOnly } = useWorkAuth(work);
+  const { userCanRead, isWorkReadingRoomOnly, isAuthLoading } =
+    useWorkAuth(work);
   const router = useRouter();
   const { isChecked: isAI } = useGenerativeAISearchToggle();
 
@@ -144,7 +145,7 @@ const WorkPage: NextPage<WorkPageProps> = ({
                   searchQuery={searchQuery}
                 />
               )}
-              {work && !userCanRead && (
+              {work && !userCanRead && !isAuthLoading && (
                 <WorkRestrictedDisplay
                   thumbnail={work.thumbnail}
                   workId={work.id}

--- a/pages/items/[...id].tsx
+++ b/pages/items/[...id].tsx
@@ -52,7 +52,9 @@ const WorkPage: NextPage<WorkPageProps> = ({
     useWorkAuth(work);
   const router = useRouter();
   const { isChecked: isAI } = useGenerativeAISearchToggle();
-
+  const loginRequired =
+    (isAuthLoading && work?.visibility !== "Public") || // Work is not public and auth is loading
+    (work && !userCanRead); // Work is loaded and user cannot read
   const iiifContent = router?.query["iiif-content"]
     ? (router?.query["iiif-content"] as string)
     : work?.iiif_manifest;
@@ -145,7 +147,7 @@ const WorkPage: NextPage<WorkPageProps> = ({
                   searchQuery={searchQuery}
                 />
               )}
-              {work && !userCanRead && !isAuthLoading && (
+              {loginRequired && (
                 <WorkRestrictedDisplay
                   thumbnail={work.thumbnail}
                   workId={work.id}

--- a/types/context/user.ts
+++ b/types/context/user.ts
@@ -15,6 +15,7 @@ export type User = {
 
 export type UserContext = {
   user: User | null;
+  isLoading: boolean;
   isSignInModalOpen: boolean;
   openSignInModal: () => void;
   closeSignInModal: () => void;


### PR DESCRIPTION
## Summary

Users reported that sometimes 'Public' assets are shown as restricted (thumbnails have the lock icon and the "Authentication Needed..." banner is displayed). A page refresh fixes the error. 

The root cause is a race condition: `UserContext` has no loading state. `user` starts as `null` and `getUser()` is async. Every component that checks `user?.scopes?.includes('read:Public')` sees `null` before the request completes and evaluates to `false` → restricted. Once the auth call resolves and user scopes are populated, re-renders fix it. That's why a refresh "helps"  timing varies. The race window is very short - just the time it takes for `/auth/whoami` to respond. By the time you type a URL and the page visually settles in front of you, the auth call has almost certainly already completed and the UI has already self-corrected. You'd have to be watching the exact millisecond of first paint to catch it.

The users who see it are likely experiencing it as a visible flash or a stuck state — depending on how fast their network resolves that auth endpoint. There's a range of possibilities:
- Fast connection: brief flicker of lock icons that self-corrects quickly — easy to miss
- Slower connection or higher latency to `/auth/whoami`: the restricted state persists long enough to notice, take a screenshot, or share the link while the page is still in that state
- If they shared the link while the page was already rendered in the restricted state in their browser, your loading that same URL in a fresh context would start the race fresh — and again resolve before you see it

The fix: add `isLoading` to `UserContext`, start it `true`, and set it `false` only after `getUser()` settles. Then guard all "show as restricted" conditions behind `!isLoading`.

fixes https://github.com/nulib/repodev_planning_and_docs/issues/5826

## Changes

**Core fix (5 files):**
- `types/context/user.ts` — added `isLoading: boolean` to the `UserContext` type
- `context/user-context.tsx` — added `isLoading` state starting at `true`; moved `setIsLoading(false)` to fire after `getUser()` settles whether or not a user was found
- `hooks/useWorkAuth.ts` — reads and returns `isAuthLoading` from the context
- `components/Grid/Item.tsx` — `isRestricted` returns `false` while loading
- `components/Search/TranscriptionResults.tsx` — same guard on `isRestricted`

**Work display (4 files):**
- `pages/items/[...id].tsx` — `WorkRestrictedDisplay` now requires `!isAuthLoading` in addition to `!userCanRead`
- `pages/embedded-viewer/[manifestId].tsx` — passes `isAuthLoading` down to `EmbeddedViewer`
- `components/Work/EmbeddedViewer.tsx` — accepts `isAuthLoading` prop; suppresses `WorkRestrictedDisplay` while loading
- `components/Work/ActionsDialog/DownloadAndShare/EmbedResources.tsx` — suppresses the "Download requires NetID" announcement while loading

**Test mocks (5 files):** Added the now-required `isLoading: false` (plus pre-existing missing `scopes`, `isInstitution`, and modal stubs that were already type errors).

## Testing

- Not sure how to test, I think this might be a deploy and see if the issue re-occurs situation. 
- But we should  check it didn't introduce unintended regressions
