### PR TITLE
Fix public-only toggle URL state

### DIFF
--- a/components/Search/PublicOnlyWorks.test.tsx
+++ b/components/Search/PublicOnlyWorks.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@/test-utils";
+
+import SearchPublicOnlyWorks from "./PublicOnlyWorks";
+import mockRouter from "next-router-mock";
+import userEvent from "@testing-library/user-event";
+
+describe("SearchPublicOnlyWorks", () => {
+  beforeEach(() => {
+    mockRouter.setCurrentUrl("/search?q=northwestern");
+  });
+
+  it("adds the public visibility facet when toggled on", async () => {
+    const user = userEvent.setup();
+    render(<SearchPublicOnlyWorks />);
+
+    await user.click(screen.getByRole("switch", { name: "Public only" }));
+
+    expect(mockRouter).toMatchObject({
+      asPath: "/search?q=northwestern&visibility=Public",
+    });
+  });
+
+  it("removes the public visibility facet with one click when toggled off", async () => {
+    const user = userEvent.setup();
+    mockRouter.setCurrentUrl("/search?q=northwestern&visibility=Public");
+    render(<SearchPublicOnlyWorks />);
+
+    await user.click(screen.getByRole("switch", { name: "Public only" }));
+
+    expect(mockRouter).toMatchObject({
+      asPath: "/search?q=northwestern",
+    });
+  });
+});

--- a/components/Search/PublicOnlyWorks.tsx
+++ b/components/Search/PublicOnlyWorks.tsx
@@ -16,16 +16,25 @@ const SearchPublicOnlyWorks = () => {
   const { query: q } = router;
 
   const switchId = `public-works-toggle`;
-  const checked =
-    urlFacets?.visibility && urlFacets?.visibility[0] === "Public";
+  const checked = Boolean(
+    urlFacets?.visibility && urlFacets?.visibility[0] === "Public",
+  );
 
   const handleCheckedChange = (value: boolean) => {
+    const nextQuery = { ...(q && q) };
     const newObj = { ...urlFacets };
-    newObj["visibility"] = value ? ["Public"] : [];
+
+    delete nextQuery["visibility"];
+
+    if (value) {
+      newObj["visibility"] = ["Public"];
+    } else {
+      delete newObj["visibility"];
+    }
 
     router.push({
       pathname: "/search",
-      query: { ...(q && q), ...newObj },
+      query: { ...nextQuery, ...newObj },
     });
   };
 


### PR DESCRIPTION
## Summary

Fixes the Public only switch requiring two clicks to turn off by removing the `visibility` query param instead of setting it to an empty array. Also keeps the switch controlled with a boolean `checked` value.

## Changes

- Clicking `PublicOnlyWorks` component now removes the query param instead of setting an empty array, toggles with one click.

## Testing

- https://preview-public-only-toggle.dc.rdc-staging.library.northwestern.edu/

