### PR TITLE
Prevent allow upscaling error for download resources

### DIFF
--- a/components/Work/ActionsDialog/DownloadAndShare/EmbedResources.tsx
+++ b/components/Work/ActionsDialog/DownloadAndShare/EmbedResources.tsx
@@ -120,7 +120,6 @@ interface ItemProps {
 const Item: React.FC<ItemProps> = ({ item, showEmbedWarning }) => {
   const [embedHTMLOpen, setEmbedHTMLOpen] = React.useState(false);
   const [color, setColor] = React.useState("default");
-  const [width, setWidth] = React.useState(3000);
 
   const iiifImageInfo = `${getInfoResponse(item)}/info.json`;
 
@@ -139,24 +138,27 @@ const Item: React.FC<ItemProps> = ({ item, showEmbedWarning }) => {
     },
   ];
 
-  const widths = [
-    {
-      label: "3000px - 100%",
-      value: 3000,
-    },
-    {
-      label: "1800px - 50%",
-      value: 1800,
-    },
-    {
-      label: "900px - 25%",
-      value: 900,
-    },
-    {
-      label: "450px - 12.5%",
-      value: 450,
-    },
-  ];
+  // Cap whichever dimension is longer, so a narrow-but-tall image doesn't
+  // download/embed at its full (potentially huge) height.
+  const isPortrait = !!(item.width && item.height && item.height > item.width);
+  const longestDimension = isPortrait ? item.height : item.width;
+
+  const toSizeParam = (value: number) => {
+    const upscalePrefix = longestDimension ? "" : "^";
+    return isPortrait
+      ? `${upscalePrefix},${value}`
+      : `${upscalePrefix}${value},`;
+  };
+
+  const widths = [3000, 1800, 900, 450]
+    .filter((value) => !longestDimension || value <= longestDimension)
+    .map((value) => ({ label: `${value}px`, value }));
+
+  if (widths.length === 0 && longestDimension) {
+    widths.push({ label: `${longestDimension}px`, value: longestDimension });
+  }
+
+  const [width, setWidth] = React.useState(widths[0]?.value ?? 3000);
 
   const thumbId = item.thumbnail ? item.thumbnail[0].id : "";
   const embedHTMLStringArray = thumbId?.split("/");
@@ -164,7 +166,7 @@ const Item: React.FC<ItemProps> = ({ item, showEmbedWarning }) => {
     embedHTMLStringArray?.length && embedHTMLStringArray.length > 0;
 
   if (isValidStringArray) {
-    embedHTMLStringArray[7] = `${width},`;
+    embedHTMLStringArray[7] = toSizeParam(width);
     embedHTMLStringArray[9] = `${color}.jpg`;
   }
 
@@ -185,7 +187,10 @@ const Item: React.FC<ItemProps> = ({ item, showEmbedWarning }) => {
         : "nul_fileset";
 
     const infoResponse = getInfoResponse(item);
-    const imageUrl = `${infoResponse}/full/3000,/0/default.jpg`;
+    const downloadSize = longestDimension
+      ? Math.min(3000, longestDimension)
+      : 3000;
+    const imageUrl = `${infoResponse}/full/${toSizeParam(downloadSize)}/0/default.jpg`;
     const response = await makeBlob(imageUrl, { credentials: "include" });
 
     if (!response || response.error) {

--- a/tests/work.spec.ts
+++ b/tests/work.spec.ts
@@ -539,7 +539,7 @@ test.describe("Work page component", async () => {
     await expect(embedHtml).toBeVisible();
 
     await expect(
-      downloadEmbedItems.getByText("Copy 3000px - 100%1800px - 50"),
+      downloadEmbedItems.getByText("Copy 3000px1800px900"),
     ).toBeVisible();
 
     await downloadEmbedItems.getByRole("combobox").nth(0).selectOption("900");


### PR DESCRIPTION
## Summary

Fixes "Requested size requires upscaling" errors when clicking Download JPG from the Download and Embed tab on the shared-link and work pages, for images narrower than 3000px. Was also affecting the embed resources code.

fixes https://github.com/nulib/repodev_planning_and_docs/issues/5851

## Changes

- For the download, cap whichever dimension (width or height) is longer at 3000px, instead of always constraining width — a narrow-but-tall image (e.g. 1200×15000) now downloads/embeds at a capped height, not its full native height. Add allow upscaling to the IIIF request as a fallback if dimensions are not known.
- For the embed, dropped the incorrect percentage labels (1800px was mislabeled "50%" when it's actually 60% of 3000, and the percentages were never meaningful relative to the real image size anyway) in favor of plain pixel labels.
- Updated the one Playwright assertion (tests/work.spec.ts:542) that checked the old "...100%...50%" label text; the URL-format assertions didn't need changes since that fixture image is landscape (4032×3024, confirmed via its info.json).

## Testing

- Verify: Download JPG on a narrow <3000px-wide image (the request to the IIIF server should now reflect the image's actual width)
- Verify: Download working as expected for "regular" images
- Verify: Embed options working as expected
