### PR TITLE
Bugfix - Work page public items requiring auth on initial load

### DIFF
--- a/components/Work/ActionsDialog/DownloadAndShare/EmbedResources.tsx
+++ b/components/Work/ActionsDialog/DownloadAndShare/EmbedResources.tsx
@@ -46,11 +46,9 @@ const EmbedResources: React.FC<EmbedResourcesProps> = ({
 }) => {
   const router = useRouter();
   const [imageCanvases, setImageCanvases] = React.useState<Canvas[]>([]);
-  const { userCanRead, isAuthLoading } = useWorkAuth(work);
+  const { userCanRead, loginRequired: hookLoginRequired } = useWorkAuth(work);
   const isSharedLinkPage = router.pathname.includes("/shared");
-  const loginRequired =
-    (isAuthLoading && work?.visibility !== "Public") || // Work is not public and auth is loading
-    (work && !userCanRead && !isSharedLinkPage); // User cannot read and it's not a shared link page
+  const loginRequired = hookLoginRequired && !isSharedLinkPage;
 
   React.useEffect(() => {
     if (manifest?.items && Array.isArray(manifest?.items)) {

--- a/components/Work/EmbeddedViewer.test.tsx
+++ b/components/Work/EmbeddedViewer.test.tsx
@@ -34,11 +34,30 @@ describe("EmbeddedViewer", () => {
     expect(screen.getByText("WorkViewerWrapper")).toBeInTheDocument();
   });
 
-  it("renders WorkRestrictedDisplay when userCanRead is false", () => {
+  it("renders WorkRestrictedDisplay when userCanRead is false and loginRequired is true", () => {
     render(
-      <EmbeddedViewer work={mockWork} userCanRead={false} searchParams={{}} />,
+      <EmbeddedViewer
+        work={mockWork}
+        userCanRead={false}
+        loginRequired={true}
+        searchParams={{}}
+      />,
     );
 
     expect(screen.getByText("WorkRestrictedDisplay")).toBeInTheDocument();
+  });
+
+  it("renders neither the viewer nor WorkRestrictedDisplay while auth is still loading for a non-public work", () => {
+    render(
+      <EmbeddedViewer
+        work={mockWork}
+        userCanRead={false}
+        loginRequired={false}
+        searchParams={{}}
+      />,
+    );
+
+    expect(screen.queryByText("WorkViewerWrapper")).not.toBeInTheDocument();
+    expect(screen.queryByText("WorkRestrictedDisplay")).not.toBeInTheDocument();
   });
 });

--- a/components/Work/EmbeddedViewer.tsx
+++ b/components/Work/EmbeddedViewer.tsx
@@ -8,12 +8,12 @@ import WorkViewerWrapper from "@/components/Clover/ViewerWrapper";
 const EmbeddedViewer = ({
   work,
   userCanRead,
-  isAuthLoading,
+  loginRequired,
   searchParams,
 }: {
   work: Work;
   userCanRead?: boolean;
-  isAuthLoading?: boolean;
+  loginRequired?: boolean;
   searchParams: { [key: string]: string };
 }) => {
   const thumbnail = work?.thumbnail || "";
@@ -41,10 +41,6 @@ const EmbeddedViewer = ({
     showIIIFBadge: false,
     showTitle: showTitle === "true" ? true : false,
   };
-
-  const loginRequired =
-    (isAuthLoading && work?.visibility !== "Public") || // Work is not public and auth is loading
-    (work && !userCanRead); // Work is loaded and user cannot read
 
   return (
     <WorkProvider>

--- a/hooks/useWorkAuth.test.tsx
+++ b/hooks/useWorkAuth.test.tsx
@@ -1,0 +1,141 @@
+import { UserContext } from "@/context/user-context";
+import { UserContext as UserContextType } from "@/types/context/user";
+import type { Work } from "@nulib/dcapi-types";
+import React from "react";
+import { renderHook } from "@testing-library/react";
+import useWorkAuth from "./useWorkAuth";
+
+const publicWork = {
+  id: "public-work",
+  published: true,
+  visibility: "Public",
+} as Work;
+
+const unpublishedPublicWork = {
+  id: "unpublished-public-work",
+  published: false,
+  visibility: "Public",
+} as Work;
+
+const institutionWork = {
+  id: "institution-work",
+  published: true,
+  visibility: "Institution",
+} as Work;
+
+const anonymousUser: UserContextType["user"] = {
+  isInstitution: false,
+  isLoggedIn: false,
+  isReadingRoom: false,
+  scopes: ["read:Public", "read:Published"],
+};
+
+const netIdUser: UserContextType["user"] = {
+  isInstitution: false,
+  isLoggedIn: true,
+  isReadingRoom: false,
+  scopes: ["read:Public", "read:Published", "read:Institution"],
+};
+
+const withUserProvider = (
+  work: Work | null | undefined,
+  userContext: Partial<UserContextType>,
+) => {
+  const value: UserContextType = {
+    user: null,
+    isLoading: true,
+    isSignInModalOpen: false,
+    openSignInModal: jest.fn(),
+    closeSignInModal: jest.fn(),
+    ...userContext,
+  };
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <UserContext.Provider value={value}>{children}</UserContext.Provider>
+  );
+
+  return renderHook(() => useWorkAuth(work), { wrapper });
+};
+
+describe("useWorkAuth", () => {
+  it("treats a public, published work as readable while auth is still loading", () => {
+    const { result } = withUserProvider(publicWork, {
+      isLoading: true,
+      user: null,
+    });
+
+    expect(result.current.userCanRead).toBe(true);
+    expect(result.current.loginRequired).toBe(false);
+  });
+
+  it("treats a public, published work as readable when auth resolves without a user (failed whoami)", () => {
+    const { result } = withUserProvider(publicWork, {
+      isLoading: false,
+      user: null,
+    });
+
+    expect(result.current.userCanRead).toBe(true);
+    expect(result.current.loginRequired).toBe(false);
+  });
+
+  it("treats a public, published work as readable for a resolved anonymous user", () => {
+    const { result } = withUserProvider(publicWork, {
+      isLoading: false,
+      user: anonymousUser,
+    });
+
+    expect(result.current.userCanRead).toBe(true);
+    expect(result.current.loginRequired).toBe(false);
+  });
+
+  it("still restricts a public but unpublished work for an anonymous user", () => {
+    const { result } = withUserProvider(unpublishedPublicWork, {
+      isLoading: false,
+      user: anonymousUser,
+    });
+
+    expect(result.current.userCanRead).toBe(false);
+    expect(result.current.loginRequired).toBe(true);
+  });
+
+  it("renders neither viewer nor banner for a non-public work while auth is loading", () => {
+    const { result } = withUserProvider(institutionWork, {
+      isLoading: true,
+      user: null,
+    });
+
+    expect(result.current.userCanRead).toBe(false);
+    expect(result.current.loginRequired).toBe(false);
+  });
+
+  it("requires login for a non-public work once auth resolves without matching scope", () => {
+    const { result } = withUserProvider(institutionWork, {
+      isLoading: false,
+      user: anonymousUser,
+    });
+
+    expect(result.current.userCanRead).toBe(false);
+    expect(result.current.loginRequired).toBe(true);
+  });
+
+  it("allows a non-public work once auth resolves with a matching scope", () => {
+    const { result } = withUserProvider(institutionWork, {
+      isLoading: false,
+      user: netIdUser,
+    });
+
+    expect(result.current.userCanRead).toBe(true);
+    expect(result.current.loginRequired).toBe(false);
+  });
+
+  it("does not throw when the resolved user is missing a scopes array", () => {
+    const { result } = withUserProvider(publicWork, {
+      isLoading: false,
+      // @ts-expect-error - simulating a malformed whoami payload
+      user: { isInstitution: false, isLoggedIn: false, isReadingRoom: false },
+    });
+
+    expect(result.current.userCanRead).toBe(true);
+    expect(result.current.loginRequired).toBe(false);
+  });
+});

--- a/hooks/useWorkAuth.ts
+++ b/hooks/useWorkAuth.ts
@@ -11,9 +11,27 @@ const useWorkAuth = (work: Work | null | undefined) => {
   const isWorkPublic = work?.visibility === "Public";
 
   const publishedStatus = work?.published ? "Published" : "Unpublished";
-  const userCanRead =
-    userAuthContext?.user?.scopes.includes(`read:${work?.visibility}`) &&
-    userAuthContext?.user?.scopes.includes(`read:${publishedStatus}`);
+
+  const hasScope = (scope: string) =>
+    userAuthContext?.user?.scopes?.includes(scope) ?? false;
+
+  // A public, published work is readable by anyone, regardless of whether
+  // auth has resolved yet (or resolved to an anonymous/failed user). This
+  // mirrors the search results' visibility short-circuit and avoids a race
+  // between the work fetch and /auth/whoami that would otherwise flash
+  // "Authentication needed" on public works.
+  const isPubliclyReadable = isWorkPublic && work?.published === true;
+
+  const userCanRead = work
+    ? isPubliclyReadable ||
+      (hasScope(`read:${work.visibility}`) &&
+        hasScope(`read:${publishedStatus}`))
+    : false;
+
+  // Only assert "restricted" once auth has actually resolved, so a
+  // non-public work doesn't briefly show the login banner before swapping
+  // to the viewer for a user who turns out to have access.
+  const loginRequired = Boolean(work) && !userCanRead && !isAuthLoading;
 
   const isWorkReadingRoomOnly =
     userAuthContext?.user?.isReadingRoom &&
@@ -27,6 +45,7 @@ const useWorkAuth = (work: Work | null | undefined) => {
     isWorkPrivate,
     isWorkPublic,
     isWorkReadingRoomOnly,
+    loginRequired,
     userCanRead,
   };
 };

--- a/pages/embedded-viewer/[manifestId].tsx
+++ b/pages/embedded-viewer/[manifestId].tsx
@@ -15,7 +15,7 @@ interface EmbeddedViewerPageProps {
 
 const EmbeddedViewerPage: NextPage<EmbeddedViewerPageProps> = ({ work }) => {
   const router = useRouter();
-  const { userCanRead, isAuthLoading } = useWorkAuth(work);
+  const { userCanRead, loginRequired } = useWorkAuth(work);
 
   const searchParams = getUrlSearchParams(decodeURIComponent(router.asPath));
 
@@ -23,7 +23,7 @@ const EmbeddedViewerPage: NextPage<EmbeddedViewerPageProps> = ({ work }) => {
     <EmbeddedViewer
       work={work}
       userCanRead={userCanRead}
-      isAuthLoading={isAuthLoading}
+      loginRequired={loginRequired}
       searchParams={searchParams}
     />
   );

--- a/pages/items/[...id].tsx
+++ b/pages/items/[...id].tsx
@@ -48,13 +48,10 @@ const WorkPage: NextPage<WorkPageProps> = ({
   const [initialLabel, setInitialLabel] = useState<string | undefined>();
   const [initialSnippet, setInitialSnippet] = useState<string | undefined>();
   const canvasParamProcessed = useRef(false);
-  const { userCanRead, isWorkReadingRoomOnly, isAuthLoading } =
+  const { userCanRead, isWorkReadingRoomOnly, loginRequired } =
     useWorkAuth(work);
   const router = useRouter();
   const { isChecked: isAI } = useGenerativeAISearchToggle();
-  const loginRequired =
-    (isAuthLoading && work?.visibility !== "Public") || // Work is not public and auth is loading
-    (work && !userCanRead); // Work is loaded and user cannot read
   const iiifContent = router?.query["iiif-content"]
     ? (router?.query["iiif-content"] as string)
     : work?.iiif_manifest;


### PR DESCRIPTION
## Summary

Fixes intermittent "Authentication needed" banners on public work pages, embedded viewers, and the download/embed dialog. This was a gap left by #488/#489: those PRs fixed the same race condition for search result thumbnails but never touched the work-detail page, which had its own copy of the login-required logic. Also, that merged work dropped the `!isAuthLoading` guard, so the work page regressed.

Public, published works now render immediately regardless of auth state, matching the guarantee #489 gave search results. Non-public works now render neither the viewer nor the restricted banner until auth has actually resolved, which also fixes a potential reverse flash (a NetID user opening an Institution work could briefly see "Authentication needed" before the viewer swaps in).

fixes https://github.com/nulib/repodev_planning_and_docs/issues/5826

## Changes

- `hooks/useWorkAuth.ts` — added a `isWorkPublic && work.published` short-circuit to `userCanRead`, independent of auth/user state; added a shared `loginRequired` (`work && !userCanRead && !isAuthLoading`) so restricted status is only asserted once auth has resolved; guarded `scopes.includes` with optional chaining so a malformed `whoami` payload can't throw during render
- `pages/items/[...id].tsx` — consume `loginRequired` from the hook instead of a local copy of the expression
- `components/Work/EmbeddedViewer.tsx` — accepts a `loginRequired` prop instead of computing it from `isAuthLoading`
- `pages/embedded-viewer/[manifestId].tsx` — passes `loginRequired` from the hook down to `EmbeddedViewer`
- `components/Work/ActionsDialog/DownloadAndShare/EmbedResources.tsx` — derives its "Download requires NetID" announcement from the hook's `loginRequired`, still exempting shared-link pages
- `hooks/useWorkAuth.test.ts` (new) — covers public+published during auth load, public with a failed/empty `whoami`, public-but-unpublished, non-public during load, non-public with/without matching scope, and a malformed user payload
- `components/Work/EmbeddedViewer.test.tsx` — updated for the prop change; added a case for the non-public/loading render-nothing state

## Testing

- Clear the `dcapi*` cookie for `library.northwestern.edu` (12h TTL) and hard-reload a public work page — viewer should render with no banner (- or use Incognito mode)
- If desired, throttle `/auth/whoami` in DevTools to make the race reproducible; confirm no banner flash on a public work
- Confirm an Institution work while logged out still shows the banner (only after auth resolves, no flash), and the same work logged in with NetID goes straight to the viewer with no flash
- Check `/embedded-viewer/[manifestId]` for a public work, and the Download and Share dialog on a public work and a `/shared/[id]` link
